### PR TITLE
Started on a primitive obfuscator

### DIFF
--- a/source/rock/RockVersion.ooc
+++ b/source/rock/RockVersion.ooc
@@ -4,9 +4,9 @@ RockVersion: class {
 
     getMajor:    static func -> Int    { 1 }
     getMinor:    static func -> Int    { 0 }
-    getPatch:    static func -> Int    { 16 }
+    getPatch:    static func -> Int    { 17 }
     getRevision: static func -> String { "head" }
-    getCodename: static func -> String { "Serious" }
+    getCodename: static func -> String { "Freppasaurus" }
 
     getName: static func -> String { "%d.%d.%d%s codename %s" format(
         getMajor(), getMinor(), getPatch(), (getRevision() ? "-" + getRevision() : ""),

--- a/source/rock/frontend/BuildParams.ooc
+++ b/source/rock/frontend/BuildParams.ooc
@@ -9,7 +9,7 @@ import PathList, CommandLine, Target
 import drivers/CCompiler
 import rock/middle/[Module, UseDef]
 import rock/middle/tinker/Errors
-import rock/frontend/drivers/[Driver, SequenceDriver]
+import rock/frontend/drivers/[Driver, SequenceDriver, Obfuscator]
 
 /**
  * All the parameters for a build are stored there.
@@ -255,6 +255,9 @@ BuildParams: class {
 
     // compilation driver
     driver := SequenceDriver new(this)
+
+    obfuscate := false
+    obfuscator: Obfuscator
 
     validBinaryName?: func (name: String) -> Bool {
         if (File new(name) dir?()) {

--- a/source/rock/frontend/CommandLine.ooc
+++ b/source/rock/frontend/CommandLine.ooc
@@ -389,6 +389,7 @@ CommandLine: class {
                 } else if (option startsWith?("obfuscate=")) {
                     params obfuscate = true
                     params obfuscator = Obfuscator new(params, option substring("obfuscate=" length()))
+					params lineDirectives = false
                 } else if (option startsWith?("blowup=")) {
 
                     if(!longOption) warnUseLong("blowup")

--- a/source/rock/frontend/CommandLine.ooc
+++ b/source/rock/frontend/CommandLine.ooc
@@ -6,7 +6,7 @@ import text/StringTokenizer
 
 // our stuff
 import Help, Token, BuildParams, AstBuilder, PathList, Target
-import rock/frontend/drivers/[Driver, SequenceDriver, MakeDriver, DummyDriver, CCompiler, AndroidDriver, CMakeDriver]
+import rock/frontend/drivers/[Driver, SequenceDriver, MakeDriver, DummyDriver, CCompiler, AndroidDriver, CMakeDriver, Obfuscator]
 import rock/backend/json/JSONGenerator
 import rock/backend/lua/LuaGenerator
 import rock/middle/[Module, Import, UseDef, Use]
@@ -220,8 +220,8 @@ CommandLine: class {
 
                 } else if (option == "static") {
 
-		    params staticLib = true
-		} else if (option startsWith?("gc=")) {
+                    params staticLib = true
+                } else if (option startsWith?("gc=")) {
 
                     suboption := option substring(3)
                     match suboption {
@@ -386,6 +386,9 @@ CommandLine: class {
                             null
                     }
 
+                } else if (option startsWith?("obfuscate=")) {
+                    params obfuscate = true
+                    params obfuscator = Obfuscator new(params, option substring("obfuscate=" length()))
                 } else if (option startsWith?("blowup=")) {
 
                     if(!longOption) warnUseLong("blowup")
@@ -704,7 +707,7 @@ CommandLine: class {
             if(params driver != null) {
                 code := 0
                 compileMs := Time measure(||
-                    code = params driver compile(module)
+                    code = params obfuscate ? params obfuscator compile(module) : params driver compile(module)
                 )
                 if(code == 0) {
                     if (params timing) {

--- a/source/rock/frontend/CommandLine.ooc
+++ b/source/rock/frontend/CommandLine.ooc
@@ -389,7 +389,7 @@ CommandLine: class {
                 } else if (option startsWith?("obfuscate=")) {
                     params obfuscate = true
                     params obfuscator = Obfuscator new(params, option substring("obfuscate=" length()))
-					params lineDirectives = false
+                    params lineDirectives = false
                 } else if (option startsWith?("blowup=")) {
 
                     if(!longOption) warnUseLong("blowup")

--- a/source/rock/frontend/Help.ooc
+++ b/source/rock/frontend/Help.ooc
@@ -193,8 +193,12 @@ ADVANCED OPTIONS
 
 -t, --timing
     Print how much time the compilation took.
+
+--obfuscate=TRANSLATION FILE
+    Translates types specified in the translation file (EXPERIMENTAL).
+    Example: The entry \"Foobar\":\"Moobar\" will rename each occurance of
+             Foobar with Moobar.
 "
         )
     }
-
 }

--- a/source/rock/frontend/drivers/Obfuscator.ooc
+++ b/source/rock/frontend/drivers/Obfuscator.ooc
@@ -1,0 +1,60 @@
+import io/[FileReader]
+import text/[StringTokenizer]
+import structs/[ArrayList, HashMap]
+
+import Driver
+import rock/frontend/[BuildParams]
+import rock/middle/[Module, TypeDecl, FunctionDecl]
+
+ObfuscationTargetType: enum {
+    Unknown,
+    Type,
+    Function
+}
+ObfuscationTarget: class {
+    oldName: String
+    newName: String
+    type := ObfuscationTargetType Unknown
+    init: func (=oldName, =newName, =type)
+}
+Obfuscator: class extends Driver {
+    targets: HashMap<String, ObfuscationTarget>
+    init: func(.params, mappingFile: String) {
+        super(params)
+        targets = parseMappingFile(mappingFile)
+    }
+    compile: func (module: Module) -> Int {
+        for (currentModule in module collectDeps()) {
+            if (targets contains?(currentModule simpleName)) {
+                target := targets get(currentModule simpleName)
+                currentModule simpleName = target newName
+                currentModule underName = currentModule underName substring(0, currentModule underName indexOf(target oldName)) append(target newName)
+            }
+            for (type in currentModule types) {
+                if (targets contains?(type name)) {
+                    type name = targets get(type name) newName
+                    if (type isMeta) {
+                        "meta: #{type meta toString()}" printfln()
+                    }
+                    "name: #{type getName()}" printfln()
+                }
+            }
+        }
+        params driver compile(module)
+    }
+    parseMappingFile: func (mappingFile: String) -> HashMap<String, ObfuscationTarget> {
+        result := HashMap<String, ObfuscationTarget> new(15)
+        reader := FileReader new(mappingFile)
+        content := ""
+        while (reader hasNext?())
+            content = content append(reader read())
+        reader close()
+        targets := content split('\n')
+        for (target in targets) {
+            temp := target split(':')
+            if (temp size > 1)
+                result put(temp[0], ObfuscationTarget new(temp[0], temp[1], ObfuscationTargetType Type))
+        }
+        result
+    }
+}

--- a/source/rock/frontend/drivers/Obfuscator.ooc
+++ b/source/rock/frontend/drivers/Obfuscator.ooc
@@ -54,8 +54,17 @@ Obfuscator: class extends Driver {
         // For now, this must live outside the above if-statement, since obfuscation targets may
         // be present in non-target modules.
         for (type in module types) {
-            if (targets contains?(type name))
-                type name = targets get(type name) newName
+            if (targets contains?(type name)) {
+                target := targets get(type name)
+                type name = target newName
+                for (function in type functions) {
+                    // trim(String) is buggy, so use substring and indexOf instead.
+                    // TODO: What happens if a type actually has the word "Class" in its name?
+                    functionCandidate := target oldName substring(0, target oldName indexOf("Class")) + "." + function name
+                    if (targets contains?(functionCandidate))
+                        function name = targets get(functionCandidate) newName
+                }
+            }
         }
     }
     parseMappingFile: func (mappingFile: String) -> HashMap<String, ObfuscationTarget> {
@@ -70,7 +79,8 @@ Obfuscator: class extends Driver {
             temp := target split(':')
             if (temp size > 1) {
                 result put(temp[0], ObfuscationTarget new(temp[0], temp[1], ObfuscationTargetType Type))
-                result put(temp[0] + "Class", ObfuscationTarget new(temp[0] + "Class", temp[1] + "Class", ObfuscationTargetType Type))
+                if (!temp[0] contains?('.'))
+                    result put(temp[0] + "Class", ObfuscationTarget new(temp[0] + "Class", temp[1] + "Class", ObfuscationTargetType Type))
             }
         }
         result

--- a/source/rock/frontend/drivers/Obfuscator.ooc
+++ b/source/rock/frontend/drivers/Obfuscator.ooc
@@ -4,7 +4,7 @@ import structs/[ArrayList, HashMap]
 
 import Driver
 import rock/frontend/[BuildParams, CommandLine]
-import rock/middle/[Module, TypeDecl, FunctionDecl, VariableDecl, StructLiteral, FunctionCall]
+import rock/middle/[Module, TypeDecl, FunctionDecl, VariableDecl, StructLiteral, FunctionCall, PropertyDecl]
 
 ObfuscationTargetType: enum {
     Unknown,
@@ -32,7 +32,8 @@ Obfuscator: class extends Driver {
         for (currentModule in module collectDeps())
             processModule(currentModule)
         processModule(module)
-        "Obfuscation done, compiling..." printfln()
+        CommandLine success(params)
+        "Compiling..." printfln()
         params driver compile(module)
     }
     processModule: func (module: Module) {
@@ -57,16 +58,17 @@ Obfuscator: class extends Driver {
             if (targets contains?(type name)) {
                 target := targets get(type name)
                 type name = target newName
+                searchKeyPrefix := target oldName substring(0, target oldName indexOf("Class")) + "."
                 for (function in type functions) {
                     // trim(String) is buggy, so use substring and indexOf instead.
                     // TODO: What happens if a type actually has the word "Class" in its name?
-                    functionCandidate := target oldName substring(0, target oldName indexOf("Class")) + "." + function name
-                    if (targets contains?(functionCandidate)) {
+                    functionSearchKey := searchKeyPrefix + function name
+                    if (targets contains?(functionSearchKey)) {
                         if (function isAbstract || function isVirtual) {
                             CommandLine warn("Obfuscator: abstract and virtual functions are not yet supported.")
                             continue
                         }
-                        function name = targets get(functionCandidate) newName
+                        function name = targets get(functionSearchKey) newName
                     }
                 }
             }

--- a/source/rock/frontend/drivers/Obfuscator.ooc
+++ b/source/rock/frontend/drivers/Obfuscator.ooc
@@ -4,7 +4,7 @@ import structs/[ArrayList, HashMap]
 
 import Driver
 import rock/frontend/[BuildParams]
-import rock/middle/[Module, TypeDecl, FunctionDecl]
+import rock/middle/[Module, TypeDecl, FunctionDecl, VariableDecl]
 
 ObfuscationTargetType: enum {
     Unknown,
@@ -17,6 +17,10 @@ ObfuscationTarget: class {
     type := ObfuscationTargetType Unknown
     init: func (=oldName, =newName, =type)
 }
+//
+// At this point, this is more like a hack than anything else. We should probably
+// defer the obfuscation to a AST walk just before the C-generation pass.
+//
 Obfuscator: class extends Driver {
     targets: HashMap<String, ObfuscationTarget>
     init: func(.params, mappingFile: String) {
@@ -24,23 +28,30 @@ Obfuscator: class extends Driver {
         targets = parseMappingFile(mappingFile)
     }
     compile: func (module: Module) -> Int {
+        "Obfuscating..." printfln()
         for (currentModule in module collectDeps()) {
-            if (targets contains?(currentModule simpleName)) {
-                target := targets get(currentModule simpleName)
-                currentModule simpleName = target newName
-                currentModule underName = currentModule underName substring(0, currentModule underName indexOf(target oldName)) append(target newName)
-            }
-            for (type in currentModule types) {
-                if (targets contains?(type name)) {
-                    type name = targets get(type name) newName
-                    if (type isMeta) {
-                        "meta: #{type meta toString()}" printfln()
-                    }
-                    "name: #{type getName()}" printfln()
-                }
+            processModule(currentModule)
+        }
+        processModule(module)
+        "Obfuscation done, compiling..." printfln()
+        params driver compile(module)
+    }
+    processModule: func (module: Module) {
+        if (targets contains?(module simpleName)) {
+            target := targets get(module simpleName)
+            "  Module: #{target oldName} -> #{target newName}" printfln()
+            module simpleName = target newName
+            module underName = module underName substring(0, module underName indexOf(target oldName)) append(target newName)
+        }
+        // For now, this must live outside the above if-statement, since obfuscation targets may
+        // be present in non-target modules. 
+        for (type in module types) {
+            if (targets contains?(type name)) {
+                target := targets get(type name)
+                "  Type:   #{target oldName} -> #{target newName}" printfln()
+                type name = target newName
             }
         }
-        params driver compile(module)
     }
     parseMappingFile: func (mappingFile: String) -> HashMap<String, ObfuscationTarget> {
         result := HashMap<String, ObfuscationTarget> new(15)
@@ -52,8 +63,10 @@ Obfuscator: class extends Driver {
         targets := content split('\n')
         for (target in targets) {
             temp := target split(':')
-            if (temp size > 1)
+            if (temp size > 1) {
                 result put(temp[0], ObfuscationTarget new(temp[0], temp[1], ObfuscationTargetType Type))
+                result put(temp[0] + "Class", ObfuscationTarget new(temp[0] + "Class", temp[1] + "Class", ObfuscationTargetType Type))
+            }
         }
         result
     }

--- a/source/rock/frontend/drivers/Obfuscator.ooc
+++ b/source/rock/frontend/drivers/Obfuscator.ooc
@@ -3,7 +3,7 @@ import text/[StringTokenizer]
 import structs/[ArrayList, HashMap]
 
 import Driver
-import rock/frontend/[BuildParams]
+import rock/frontend/[BuildParams, CommandLine]
 import rock/middle/[Module, TypeDecl, FunctionDecl, VariableDecl, StructLiteral, FunctionCall]
 
 ObfuscationTargetType: enum {
@@ -61,8 +61,13 @@ Obfuscator: class extends Driver {
                     // trim(String) is buggy, so use substring and indexOf instead.
                     // TODO: What happens if a type actually has the word "Class" in its name?
                     functionCandidate := target oldName substring(0, target oldName indexOf("Class")) + "." + function name
-                    if (targets contains?(functionCandidate))
+                    if (targets contains?(functionCandidate)) {
+                        if (function isAbstract || function isVirtual) {
+                            CommandLine warn("Obfuscator: abstract and virtual functions are not yet supported.")
+                            continue
+                        }
                         function name = targets get(functionCandidate) newName
+                    }
                 }
             }
         }

--- a/source/rock/middle/Module.ooc
+++ b/source/rock/middle/Module.ooc
@@ -49,6 +49,7 @@ Module: class extends Node {
     lastModified : Long
 
     params: BuildParams { get set }
+    isObfuscated := false
 
     init: func ~module (.fullName, =pathElement, =params, .token) {
         super(token)
@@ -94,6 +95,9 @@ Module: class extends Node {
     }
 
     getPath: func (suffix := "") -> String {
+        // TODO: This is highly ineffecient
+        if (isObfuscated)
+            path = path contains?(File separator) ? path substring(0, path lastIndexOf(File separator) + 1) + simpleName : simpleName
         base := getSourceFolderName()
         File new(base, path) path + suffix
     }


### PR DESCRIPTION
This is really only to get the ball rolling and for experimentation (and also to get to know rock a little better), there will probably be a major redesign further down the road. The additions in this PR supports arbitrary obfuscation of:
* class names
* regular functions (no abstract, virtual etc yet)
* filenames

**Usage**
`rock --obfuscate=MAP FILE`

**Map file format**
Each target on its own line, the old and new name are separated by a colon `:`. Class name and a function of said class is separated by a dot `.`.

Class example: `OriginalClassName:NewClassName`
Function example: `OriginalClassName.oldFunction:newFunction`

The map file **must** end with an empty line.

**Map file example** *obfuscate.map*
```
SuperSecretClass:SuperObfuscatedClass
SuperSecretClass.superSecretFunction:nothingToSeeHere
AnotherSuperSecretClass:AnotherObfuscatedClass

```

