### PR TITLE
Check override signatures

### DIFF
--- a/source/rock/middle/FunctionCall.ooc
+++ b/source/rock/middle/FunctionCall.ooc
@@ -435,7 +435,7 @@ FunctionCall: class extends Expression {
                     }
                     if(args size != refActualArguments && 
                         args size != ref getArguments() size) {
-                        res throwError(ArgumentUnmatch new(token, this, ref))
+                        res throwError(ArgumentMismatch new(token, this, ref))
                     }
                     expr = VariableAccess new(superTypeDecl getThisDecl(), token)
                     if(args empty?() && !ref getArguments() empty?()) {
@@ -1756,7 +1756,7 @@ UseOfVoidExpression: class extends Error {
     init: super func ~tokenMessage
 }
 
-ArgumentUnmatch: class extends Warning {
+ArgumentMismatch: class extends Warning {
     init: func ~withToken (.token, call: FunctionCall, cand: FunctionDecl) {
         super(token, "Different number of arguments between the super call in %s and function %s" format(call toString(), cand toString()))
     }

--- a/source/rock/middle/FunctionCall.ooc
+++ b/source/rock/middle/FunctionCall.ooc
@@ -429,6 +429,14 @@ FunctionCall: class extends Expression {
                 }
                 if(ref != null) {
                     refScore = 1
+                    refActualArguments := 0
+                    for(arg in ref getArguments()){
+                        if(!arg expr) { refActualArguments += 1 }
+                    }
+                    if(args size != refActualArguments && 
+                        args size != ref getArguments() size) {
+                        res throwError(ArgumentUnmatch new(token, this, ref))
+                    }
                     expr = VariableAccess new(superTypeDecl getThisDecl(), token)
                     if(args empty?() && !ref getArguments() empty?()) {
                         for(declArg in fDecl getArguments()) {
@@ -1748,3 +1756,8 @@ UseOfVoidExpression: class extends Error {
     init: super func ~tokenMessage
 }
 
+ArgumentUnmatch: class extends Warning {
+    init: func ~withToken (.token, call: FunctionCall, cand: FunctionDecl) {
+        super(token, "Different number of arguments between the super call in %s and function %s" format(call toString(), cand toString()))
+    }
+}

--- a/source/rock/middle/TypeDecl.ooc
+++ b/source/rock/middle/TypeDecl.ooc
@@ -1022,9 +1022,14 @@ TypeDecl: abstract class extends Declaration {
                                             if(type2 getRef() && type2 getRef() instanceOf?(TypeDecl))
                                                 type2 = type2 getRef() as TypeDecl getNonMeta() ? type2 getRef() as TypeDecl getNonMeta() : type2
                                          }
+                                         score := type1 getScore(type2)
+                                         if(score == -1) {
+                                           res wholeAgain(this, "something is un-resolved")
+                                           return false
+                                         }
                                          if(fdecl getArguments() size == 
                                              other getArguments() size && 
-                                             (type1 isGeneric() || type2 isGeneric() || type1 getScore(type2) > 0)) {
+                                             (type1 isGeneric() || type2 isGeneric() || score >= 0)) {
                                                  preciseMatch = true
                                                  break
                                          }

--- a/source/rock/middle/TypeDecl.ooc
+++ b/source/rock/middle/TypeDecl.ooc
@@ -1539,6 +1539,6 @@ TypeArgSizeMismatch: class extends Error {
 
 ArgumentMismatch: class extends Warning {
     init: func ~withToken (.token, call: FunctionDecl, cand: FunctionDecl) {
-        super(token, "Different number of arguments between derived definitoin %s and base definition %s" format(call toString(), cand toString()))
+        super(token, "Mismatch definition between %s (derived) and %s (base)" format(call toString(), cand toString()))
     }
 }

--- a/source/rock/middle/TypeDecl.ooc
+++ b/source/rock/middle/TypeDecl.ooc
@@ -1042,9 +1042,11 @@ TypeDecl: abstract class extends Declaration {
                                              other getArguments() size && 
                                              (type1 isGeneric() || type2 isGeneric() || score > 0)) {
                                                 argumentTypeIsOk := true 
-                                                for(arg in fdecl getArguments()) {
-                                                     type1 := unwrapType(fdecl getReturnType())
-                                                     type2 := unwrapType(other getReturnType())
+                                                thisArgs := fdecl getArguments()
+                                                otherArgs := other getArguments()
+                                                for(i in 0 .. fdecl getArguments() size) {
+                                                     type1 := unwrapType(thisArgs[i] getType())
+                                                     type2 := unwrapType(otherArgs[i] getType())
                                                      score := type1 getScore(type2)
                                                      if(score == -1) {
                                                        res wholeAgain(this, "something is un-resolved")

--- a/source/rock/middle/TypeDecl.ooc
+++ b/source/rock/middle/TypeDecl.ooc
@@ -1047,6 +1047,10 @@ TypeDecl: abstract class extends Declaration {
                                                 for(i in 0 .. fdecl getArguments() size) {
                                                      type1 := unwrapType(thisArgs[i] getType())
                                                      type2 := unwrapType(otherArgs[i] getType())
+                                                     if(!type1 || !type2) {
+                                                       res wholeAgain(this, "argument type needs to be resolved")
+                                                       return false
+                                                     }
                                                      score := type1 getScore(type2)
                                                      if(score == -1) {
                                                        res wholeAgain(this, "something is un-resolved")

--- a/source/rock/middle/TypeDecl.ooc
+++ b/source/rock/middle/TypeDecl.ooc
@@ -1022,14 +1022,25 @@ TypeDecl: abstract class extends Declaration {
                                             if(type2 getRef() && type2 getRef() instanceOf?(TypeDecl))
                                                 type2 = type2 getRef() as TypeDecl getNonMeta() ? type2 getRef() as TypeDecl getNonMeta() : type2
                                          }
+
+
                                          score := type1 getScore(type2)
                                          if(score == -1) {
                                            res wholeAgain(this, "something is un-resolved")
                                            return false
                                          }
+
+                                         lhsInt := type1 getIntegerState()
+                                         rhsInt := type2 getIntegerState()
+                                         lhsFp := type1 getFloatingPointState()
+                                         rhsFp := type2 getFloatingPointState()
+                                         lhsNum := (lhsInt == NumericState YES || lhsFp == NumericState YES)
+                                         rhsNum := (rhsInt == NumericState YES || rhsFp == NumericState YES)
+                                         if(lhsNum && rhsNum && type1 getName() != type2 getName()) { score = -100000 }
+
                                          if(fdecl getArguments() size == 
                                              other getArguments() size && 
-                                             (type1 isGeneric() || type2 isGeneric() || score >= 0)) {
+                                             (type1 isGeneric() || type2 isGeneric() || score > 0)) {
                                                  preciseMatch = true
                                                  break
                                          }

--- a/source/rock/middle/TypeDecl.ooc
+++ b/source/rock/middle/TypeDecl.ooc
@@ -981,8 +981,9 @@ TypeDecl: abstract class extends Declaration {
         }
         unwrapType := func(type: Type) -> Type {
              if (type getName() == "This") {
-                if(type getRef() && type getRef() instanceOf?(TypeDecl))
-                    return type getRef() as TypeDecl getNonMeta() ? type getRef() as TypeDecl getNonMeta() getType() : type
+                if(type getRef() && type getRef() instanceOf?(TypeDecl) && 
+                    type getRef() as TypeDecl getNonMeta() && type getRef() as TypeDecl getNonMeta() getType())
+                    return type getRef() as TypeDecl getNonMeta() getType()
              }
              type
         }


### PR DESCRIPTION
### Summary

This pull request allow rock check if there exists any incompatible definition between derived and base classes (covers). If there are any incompatible definitons, a warning is generated.
The rules for checking is summarized as follows:

1. `super` function call vs definition

* Number of the arguments provided in `super` should match the best matched definitoin.

2. derived function vs base function

* Number of the arguments provided should match.
* Return type should match (i.e. the match score is larger than 0)
* Type of each argument should match (i.e. the match score is larger than 0)
* NumberTypes only match when they are definitely the same..

### Implementation Details

* `super` call is unwrapped in `middle/FunctionCall.ooc`. When resolving a function call, rock checks if its name equals to `super`. Once a super call is found, rock will perform a search the best definition in the `meta class` (which contains all the functions). The auto-fordwarding of arguments also happens here. A extra check on the number of arguments is added after the definition is got.
* In `magic-lang/rock`, every function derived from the base class should have  the `override` property. Override functions are guaranteed to only derived from abstract/virtual function by `TypeDecl.ooc:checkOverrideFuncs`. Checking of compatiblity is also performed in `checkOverrideFuncs`. One thing should be point out is that it is necessary to unwrap `This` before checking because `getScore` can not match `This` agaist its actural definition.