### PR TITLE
Fixed safe navigation into properties

### DIFF
--- a/source/rock/middle/VariableAccess.ooc
+++ b/source/rock/middle/VariableAccess.ooc
@@ -15,6 +15,7 @@ VariableAccess: class extends Expression {
 
     _warned := false
     _staticFunc : FunctionDecl = null
+    _replacedByProperty := false
 
     expr: Expression {
         get
@@ -170,7 +171,7 @@ VariableAccess: class extends Expression {
             return false
         }
 
-        true
+        !_replacedByProperty
     }
 
     resolve: func (trail: Trail, res: Resolver) -> Response {
@@ -234,6 +235,8 @@ VariableAccess: class extends Expression {
                 }
 
                 if(shouldReplace) {
+                    _replacedByProperty = true
+
                     property := ref as PropertyDecl
                     fCall := FunctionCall new(expr, property getGetterName(), token)
                     if (!trail peek() replace(this, fCall)) {
@@ -244,6 +247,7 @@ VariableAccess: class extends Expression {
                         res wholeAgain(this, "couldn't replace with getter call")
                         return Response OK
                     }
+
                     res wholeAgain(this, "replaced with getter call")
                     return Response OK
                 }


### PR DESCRIPTION
... after a lot of debugging :)  

This is one of those fixes that appear trivial but are really insidious.  

Here is an overview of the bug:  

SafeNavigation creates a chain of ternary operations containing VariableAccesses compared to null and null literals.  
Each step is obviously constructed from the previous one, as accesses get deeper and deeper.  

The most obvious (as well as optimal) solution to do so is to reuse VariableAccesses as the expr field of the next VariableAccess.  
However, it turns out that VariableAccess (correctly) tries to skip resolving if it has already been done.  
This means that since every subsequent VariableAccess points to the current VariableAccess in the ternary chain, each unique property VariableAccess was only replaced with a function call once (leading to 1 property call per level as I pointed out on the issue).  

The fix proposed is to let a VariableAccess resolve again if it was replaced by a property.  
This makes sense since the only way to get resolved again is when we are lead through another Node and need to be replaced once more.  
This could also stop other bugs from showing up under similar circumstances (many Nodes pointing to a VariableAccess -> fails when it is a property).  

Another fix would be to clone the VariableAccesses in SafeNavigation when constructing the ternary chain but I believe this is the optimal solution.  


I will be adding tests if you require them and probably bringing this to ooc-lang/rock (with tests).