### PR TITLE
methods-on-tuple

### DIFF
--- a/source/rock/backend/cnaughty/CGenerator.ooc
+++ b/source/rock/backend/cnaughty/CGenerator.ooc
@@ -21,7 +21,7 @@ import rock/middle/[Module, FunctionDecl, FunctionCall, Expression, Type,
     Cast, Comparison, Ternary, BoolLiteral, Argument, Statement,
     AddressOf, Dereference, CommaSequence, UnaryOp, ArrayAccess, Match,
     FlowControl, InterfaceDecl, Version, Block, EnumDecl, ArrayLiteral,
-    ArrayCreation, StructLiteral, FuncType]
+    ArrayCreation, StructLiteral, FuncType, Tuple]
 
 // backend
 import Skeleton, FunctionDeclWriter, ControlStatementWriter,
@@ -494,5 +494,13 @@ CGenerator: class extends Skeleton {
         }
         VersionWriter writeEnd(this, node getSpec())
     }
+
+    // write a stand alone tuple
+    visitTuple: func (node: Tuple) {
+        for(e in node getElements()) {
+            writeLine(e)
+        }
+    }
+
 
 }

--- a/source/rock/middle/FunctionCall.ooc
+++ b/source/rock/middle/FunctionCall.ooc
@@ -1778,9 +1778,3 @@ ArgumentMismatch: class extends Warning {
         super(token, "Different number of arguments between the super call in %s and function %s" format(call toString(), cand toString()))
     }
 }
-
-/*
-IncompatibleTupleMethedCall: class extends Error {
-    init: usper func ~tokenMessage
-}
-*/

--- a/source/rock/middle/Tuple.ooc
+++ b/source/rock/middle/Tuple.ooc
@@ -31,8 +31,7 @@ Tuple: class extends Expression {
     operator [] (i: Int) -> Expression { get(i) }
 
     accept: func (visitor: Visitor) {
-        token formatMessage("Visiting a Tuple! We're on the good track.", "INFO") println()
-        NullLiteral new(token) accept(visitor)
+        visitor visitTuple(this)
     }
 
     getType: func -> Type {

--- a/source/rock/middle/Visitor.ooc
+++ b/source/rock/middle/Visitor.ooc
@@ -7,7 +7,7 @@ import Return, ClassDecl, CoverDecl, FunctionDecl, VariableDecl, Type,
         Cast, Comparison, Ternary, Argument, AddressOf, Dereference,
         CommaSequence, UnaryOp, ArrayAccess, Match, FlowControl,
         InterfaceDecl, Version, Block, Scope, EnumDecl, ArrayLiteral,
-        ArrayCreation, StructLiteral
+        ArrayCreation, StructLiteral, Tuple
 
 Visitor: abstract class {
 
@@ -70,5 +70,7 @@ Visitor: abstract class {
     visitVersionBlock:      func (node: VersionBlock) {}
 
     visitScope:             func (node: Scope) {}
+
+    visitTuple:             func (node: Tuple) {}
 
 }


### PR DESCRIPTION
### Description

This pull request add the ability of caling functions/accessing variable/accessing property on Tuples.
For example, the following expression:

```ooc
(c,d,e) := (a, b, c) memberVariable
(a, b, c) free()
```

will be unwrapped to:

```ooc
(c, d, e) := (a memberVariable, b memberVariable, c memberVariabel)
a free()
b free()
c free()
```

### Implementation Details

The unwrap process only happes in two module: `VariableAccess` and `FunctionCall`. 

* `VariableAccess`

VariableAccess handles the member variable/property access.  If the `expr` is a Tuple, it is necessary to do the unwrap. In current rock, tuple-tuple assignment is already able to be unwrapped. Thus, the only work is to turn `Tuple method` to `(TupleElements method(), ...)`.

* `FunctionCall`

FunctionCall handlse the member function call access. Similar with `VariableAccess`, we just "move" the method call into the tuple. One thing needed to be noticed is that because `Tuple` is an expression, so to make the following codes work, modification is also done in the return type check.
```ooc
free: func {}
(a, b, c) free()
```

* Standalone Tuple

Current rock do not write standalone tuple to the c sources but just put a `null`. Such as the example given in `FunctionCall`, if the unwrapped tuple is just replaced with a `NULL`, the memory of `a, b,c` leaks.  Thus, a `visitTuple` method is added into the `Visitor` to allow backend write each element of tuples. 