### PR TITLE
generic-arrays

### DIFF
--- a/source/rock/middle/FunctionCall.ooc
+++ b/source/rock/middle/FunctionCall.ooc
@@ -346,7 +346,7 @@ FunctionCall: class extends Expression {
         }
 
         // handle generic-class(cover) array
-        if(expr instanceOf?(TypeAccess)){
+        if(expr && expr instanceOf?(TypeAccess)){
             if(expr as TypeAccess inner instanceOf?(ArrayType)){
                 // unwrap array creation
                 if(getName() == "new"){

--- a/source/rock/middle/FunctionCall.ooc
+++ b/source/rock/middle/FunctionCall.ooc
@@ -6,7 +6,7 @@ import Visitor, Expression, FunctionDecl, Argument, Type,
        InterfaceDecl, Cast, NamespaceDecl, BaseType, FuncType, Return,
        TypeList, Scope, Block, StructLiteral, NullLiteral,
        IntLiteral, Ternary, ClassDecl, CoverDecl, ArrayLiteral, Module,
-       StringLiteral, Tuple
+       StringLiteral, Tuple, ArrayCreation
 import algo/typeAnalysis
 import text/EscapeSequence
 import tinker/[Response, Resolver, Trail, Errors]
@@ -343,6 +343,20 @@ FunctionCall: class extends Expression {
             }
 
             trail pop(this)
+        }
+
+        // handle generic-class(cover) array
+        if(expr instanceOf?(TypeAccess)){
+            if(expr as TypeAccess inner instanceOf?(ArrayType)){
+                // unwrap array creation
+                if(getName() == "new"){
+                    arrayType := expr as TypeAccess inner as ArrayType
+                    arrayCreation := ArrayCreation new(arrayType, token)
+                    trail peek() replace(this, arrayCreation)
+                    res wholeAgain(this, "just unwrapped array creation of generic classes")
+                    return Response OK
+                }
+            }
         }
 
         // resolve our expr. e.g. in


### PR DESCRIPTION
### Description

This pull request allow the following code work:
```ooc
array := GenericClass<Int>[10] new()
```
In detail, the above code will be unwrapped to:
```ooc
array := Array new(GenericClass*, 10)
```

### Implementation Details

In current rock, only `ArrayAccess` is automatically unwrapped to creation. However, `GenericClass<TypeArg>[Expression]` will be parsed as a `TypeAccess` of `ArrayType`. It is clearly that calling methods on `ArrayType` can not get anything. Thus, before `FunctionCall` starts resolve, `TypeAccess` should be turned into an array creation.

Here the unwrap process happens before resolving expr. This is because that we only need to know the type of `expr` and `inner`, which can be judged by `instanceOf?`.