### PR TITLE
Rock can now extend generic classes

### DIFF
--- a/source/rock/middle/Addon.ooc
+++ b/source/rock/middle/Addon.ooc
@@ -363,7 +363,11 @@ Addon: class extends Node {
         }
 
         if (typeArgMapping && typeArgMapping contains?(type name)) {
-            if (type suggest(typeArgMapping[type name])) {
+            vDecl := typeArgMapping[type name]
+            if (type suggest(vDecl)) {
+                // We replace our name so that rock's generic inference can do its thing.
+                // This is very much a hack, all of rock's typeArg systems very much need a rewrite
+                type name = vDecl name
                 return 0
             }
         }

--- a/source/rock/middle/Addon.ooc
+++ b/source/rock/middle/Addon.ooc
@@ -1,6 +1,7 @@
-import structs/[ArrayList, HashMap, MultiMap]
-import Node, Type, TypeDecl, FunctionDecl, FunctionCall, Visitor, VariableAccess, PropertyDecl, ClassDecl, CoverDecl
+import structs/[List, ArrayList, HashMap, MultiMap]
+import Node, Type, TypeDecl, FunctionDecl, FunctionCall, Visitor, VariableAccess, PropertyDecl, ClassDecl, CoverDecl, BaseType, VariableDecl
 import tinker/[Trail, Resolver, Response, Errors]
+import ../frontend/Token
 
 /**
  * An addon is a collection of methods added to a type via the 'extend'
@@ -24,9 +25,21 @@ Addon: class extends Node {
 
     base: TypeDecl { get set }
 
+    // Map of name -> VariableDecl of our typeArgs to our classe's
+    // For example, if we 'extend Foo <K>' and Foo was defined as a class <T>
+    // we will have a "K" -> T: Class mapping
+    typeArgMapping: HashMap<String, VariableDecl>
+
+    // Illegal generics are the symbols that appear in the generics of our ref
+    // AND do not appear in the generics of our baseType.
+    illegalGenerics: ArrayList<String>
+
     functions := MultiMap<String, FunctionDecl> new()
 
     properties := HashMap<String, PropertyDecl> new()
+
+    _stoppedAt := -1
+    dummy: VariableDecl
 
     init: func (=baseType, .token) {
         super(token)
@@ -91,15 +104,123 @@ Addon: class extends Node {
     }
 
     resolve: func (trail: Trail, res: Resolver) -> Response {
+        retry? := _stoppedAt != -1
+        if(base == null || retry?) {
+            // So, if we have typeArgs, we need to make sure that the generic ones are not actual types
+            // because we cannot extend a realized generic type but we must rather extend the whole type.
+            typeArgs? := baseType getTypeArgs() != null && !baseType getTypeArgs() empty?()
 
-        if(base == null) {
+            // To get our base type's ref while using undefined typeArg types, we will point those to a
+            // dummy declaration.
+            // At the moment, we let the rest, that have a ref be, until we can get our base ref and do some checking.
+            if (!dummy) dummy = VariableDecl new(null, "dummy", token)
+
+            if (typeArgs? && !retry?) {
+                for (typeArg in baseType getTypeArgs()) {
+                    typeArg resolve(trail, res)
+
+                    if (!typeArg getRef()) {
+                        typeArg setRef(dummy)
+                    }
+                }
+            }
+
             baseType resolve(trail, res)
-            if(baseType isResolved()) {
-                base = baseType getRef() as TypeDecl
-                checkRedefinitions(trail, res)
-                base addons add(this)
 
-                for(fDecl in functions) {
+            if (baseType isResolved()) {
+                base = baseType getRef() as TypeDecl
+
+                if (!retry?) {
+                    checkRedefinitions(trail, res)
+                    base addons add(this)
+                }
+
+                if (typeArgs?) {
+                    // We will now check that all our generic typeArgs point to the dummy.
+                    // In addition to that, we build the typeArg mapping as described on its decl.
+
+                    // Only go through generics, not templates
+                    genSize := base typeArgs size
+
+                    if (!retry?) {
+                        typeArgMapping = HashMap<String, VariableDecl> new()
+
+                        // Start off by making all the ref generics illegal, remove as we go
+                        illegalGenerics = base typeArgs map(|ta|
+                            ta name
+                        )
+                    }
+
+                    for ((i, typeArg) in baseType getTypeArgs()) {
+                        if (i >= genSize) {
+                            break
+                        }
+
+                        if (i < _stoppedAt) {
+                            continue
+                        }
+
+                        // Matched against a declaration, not good
+                        if (typeArg getRef() != dummy) {
+                            res throwError(ExtendRealizedGeneric new(baseType, typeArg, token))
+                            return Response OK
+                        }
+
+                        // We "link" the type ourselves, to our base's generics.
+                        // Here, we go up the base class's hierarchy and fidn where the generic declaration originally came from.
+
+                        superRef := base
+                        genDecl := base typeArgs get(i)
+
+                        while (superRef) {
+                            superType := superRef getSuperType()
+                            superRef = superRef getSuperRef()
+                            if (superRef && superRef isMeta) {
+                                superRef = superRef getNonMeta()
+                            }
+
+                            if (!superType || !superType isResolved() || !superRef) {
+                                _stoppedAt = i
+                                res wholeAgain(this, "Need all super refs and super types of addon base")
+                                return Response OK
+                            }
+
+                            if (superRef isObjectClass()) {
+                                break
+                            }
+
+                            // Extract the next index from the supertype
+                            found? := false
+
+                            if (superType) {
+                                targs := superType getTypeArgs()
+                                if (targs) for ((j, ta) in targs) {
+                                    if (ta getName() == genDecl name) {
+                                        found? = true
+                                        genDecl = superRef typeArgs get(j)
+                                    }
+                                }
+                            }
+
+                            if (!found?) {
+                                break
+                            }
+                        }
+
+
+                        _stoppedAt = i + 1
+                        typeArg setRef(genDecl)
+                        typeArgMapping put(typeArg getName(), genDecl)
+
+                        index := illegalGenerics indexOf(typeArg getName())
+                        if (index != -1) {
+                            illegalGenerics removeAt(index)
+                        }
+
+                    }
+                }
+
+                for (fDecl in functions) {
                     if(fDecl name == "init" && (base instanceOf?(ClassDecl) || base instanceOf?(CoverDecl))) {
                         if(base instanceOf?(ClassDecl)) base as ClassDecl addInit(fDecl)
                         else base getMeta() addInit(fDecl)
@@ -107,7 +228,7 @@ Addon: class extends Node {
                     fDecl setOwner(base)
                 }
 
-                for(prop in properties) {
+                for (prop in properties) {
                     old := base getVariable(prop name)
                     if(old) token module params errorHandler onError(DuplicateField new(old, prop))
                     prop owner = base
@@ -123,29 +244,34 @@ Addon: class extends Node {
         }
 
         finalResponse := Response OK
-        trail push(base getMeta())
-        for(f in functions) {
+
+        trail push(this)
+
+        for (f in functions) {
             response := f resolve(trail, res)
             if(!response ok()) {
                 finalResponse = response
             }
         }
-        for(p in properties) {
+
+        for (p in properties) {
             response := p resolve(trail, res)
             if(!response ok()) {
                 finalResponse = response
             } else {
                 // all functions of an addon are final, because we *definitely* don't have a 'class' field
-                if(p getter) p getter isFinal = true
-                if(p setter) p setter isFinal = true
+                if (p getter) p getter isFinal = true
+                if (p setter) p setter isFinal = true
             }
         }
-        trail pop(base getMeta())
+
+        trail pop(this)
 
         return finalResponse
     }
 
-    resolveCall: func (call : FunctionCall, res: Resolver, trail: Trail) -> Int {
+    // These resolve methods are called back from TypeDecl.
+    resolveCallFromClass: func (call : FunctionCall, res: Resolver, trail: Trail) -> Int {
         if(base == null) return 0
 
         functions getEach(call name, |fDecl|
@@ -165,7 +291,7 @@ Addon: class extends Node {
         return 0
     }
 
-    resolveAccess: func (access: VariableAccess, res: Resolver, trail: Trail) -> Int {
+    resolveAccessFromClass: func (access: VariableAccess, res: Resolver, trail: Trail) -> Int {
         if(base == null) return 0
 
         vDecl := properties[access name]
@@ -182,6 +308,81 @@ Addon: class extends Node {
         0
     }
 
+    _checkInIllegal: func (name: String, tok: Token, res: Resolver) -> Bool {
+        if (illegalGenerics && illegalGenerics contains?(name)) {
+            // If we got up the trail so match, we didn't get any match sooner, so we error out immediately.
+            ours: String = "<unknown>"
+            typeArgMapping each(|src, dist|
+                if (dist name == name) {
+                    ours = src
+                }
+            )
+
+            res throwError(IllegalGenericAccess new(name, ours, tok))
+            return true
+        }
+
+        false
+    }
+
+    // These resolve functions are here to intercept attempts to use illegal generics or
+    // generics we have a mapping for.
+    // Then, they give up and let the base do its thing.
+
+    resolveAccess: func (access: VariableAccess, res: Resolver, trail: Trail) -> Int {
+        // This is true if we are accessing a field, false otherwise
+        thisAccess? := access expr == null || match (access expr) {
+            case va: VariableAccess =>
+                va name == "this" || va name == "This"
+            case =>
+                false
+        }
+
+        if (thisAccess? && _checkInIllegal(access name, access token, res)) {
+            return -1
+        }
+
+        if (thisAccess? && typeArgMapping && typeArgMapping contains?(access name)) {
+            if (access suggest(typeArgMapping[access name])) {
+                // This is a pretty bad hack but by setting the expr to 'this' we force it to be seen as a member
+                access expr = VariableAccess new("this", access token)
+                return 0
+            }
+        }
+
+        if (base) {
+            return base resolveAccess(access, res, trail)
+        }
+
+        0
+    }
+
+    resolveType: func (type: BaseType, res: Resolver, trail: Trail) -> Int {
+        if (_checkInIllegal(type name, type token, res)) {
+            return -1
+        }
+
+        if (typeArgMapping && typeArgMapping contains?(type name)) {
+            if (type suggest(typeArgMapping[type name])) {
+                return 0
+            }
+        }
+
+        if (base) {
+            return base resolveType(type, res, trail)
+        }
+
+        0
+    }
+
+    resolveCall: func (call: FunctionCall, res: Resolver, trail: Trail) -> Int {
+        if (base) {
+            return base getMeta() resolveCall(call, res, trail)
+        }
+
+        0
+    }
+
     toString: func -> String {
         "Addon of %s in module %s" format(baseType toString(), token module getFullName())
     }
@@ -190,4 +391,20 @@ Addon: class extends Node {
 
 ExtendFieldDefinition: class extends Error {
     init: super func ~tokenMessage
+}
+
+ExtendRealizedGeneric: class extends Error {
+    baseType, realizedType: Type
+
+    init: func (=baseType, =realizedType, .token) {
+        super(token, "Trying to extend type #{baseType} with realized generic #{realizedType}, which is unsupported.")
+    }
+}
+
+IllegalGenericAccess: class extends Error {
+    illegalGeneric, ourGeneric: String
+
+    init: func (=illegalGeneric, =ourGeneric, .token) {
+        super(token, "Trying to use generic argument '#{illegalGeneric}', which is defined in base declaration but not the addon. You should use '#{ourGeneric}' instead.")
+    }
 }

--- a/source/rock/middle/PropertyDecl.ooc
+++ b/source/rock/middle/PropertyDecl.ooc
@@ -67,7 +67,7 @@ PropertyDecl: class extends VariableDecl {
                     res wholeAgain(this, "need addon's base type")
                     return Response OK
                 }
-                node = ad base
+                node = ad base getMeta()
             case td: TypeDecl =>
                 // Everything ok
             case =>

--- a/source/rock/middle/TypeDecl.ooc
+++ b/source/rock/middle/TypeDecl.ooc
@@ -1416,7 +1416,7 @@ TypeDecl: abstract class extends Declaration {
         }
 
         if (has) {
-            if (addon resolveCall(call, res, trail) == -1) return -1
+            if (addon resolveCallFromClass(call, res, trail) == -1) return -1
         }
 
         0
@@ -1436,7 +1436,7 @@ TypeDecl: abstract class extends Declaration {
         }
 
         if (has) {
-            if (addon resolveAccess(access, res, trail) == -1) return -1
+            if (addon resolveAccessFromClass(access, res, trail) == -1) return -1
         }
 
         0

--- a/source/rock/middle/VariableAccess.ooc
+++ b/source/rock/middle/VariableAccess.ooc
@@ -3,7 +3,7 @@ import BinaryOp, Visitor, Expression, VariableDecl, FunctionDecl,
        TypeDecl, Declaration, Type, Node, ClassDecl, NamespaceDecl,
        EnumDecl, PropertyDecl, FunctionCall, Module, Import, FuncType,
        NullLiteral, AddressOf, BaseType, StructLiteral, Return,
-       Argument, Scope, CoverDecl, StringLiteral, Cast, Tuple
+       Argument, Scope, CoverDecl, StringLiteral, Cast, Tuple, Addon
 
 import tinker/[Resolver, Response, Trail, Errors]
 import structs/ArrayList
@@ -396,6 +396,29 @@ VariableAccess: class extends Expression {
                 return BranchResult BREAK
             }
 
+            // If we still don't have a ref, we're going to try to go up the trail and find an Addon.
+            if (!ref) {
+                depth := trail getSize() - 1
+                while (depth >= 0) {
+                    node := trail get(depth)
+
+                    match node {
+                        case addon: Addon =>
+                            status := node resolveAccess(this, res, trail)
+
+                            if (status == -1) {
+                                res wholeAgain(this, "asked to wait while resolving access")
+                                return BranchResult BREAK
+                            }
+
+                            if (ref) {
+                                break
+                            }
+                    }
+
+                    depth -= 1
+                }
+            }
         } else {
             /*
              * Try resolving as a builtin, e.g. __BUILD_DATE__, etc.

--- a/source/rock/middle/VariableDecl.ooc
+++ b/source/rock/middle/VariableDecl.ooc
@@ -233,7 +233,7 @@ VariableDecl: class extends Declaration {
 
         parent := trail peek()
         {
-            if(!parent isScope() && !parent instanceOf?(TypeDecl) && !parent instanceOf?(FuncType)) {
+            if(!parent isScope() && !parent instanceOf?(TypeDecl) && !parent instanceOf?(Addon) && !parent instanceOf?(FuncType)) {
                 if(debugCondition()) "Parent isn't scope nor typedecl, unwrapping." println()
                 varAcc := VariableAccess new(this, token)
 
@@ -258,16 +258,28 @@ VariableDecl: class extends Declaration {
                     // Didn't find a scope, but maybe we can find something else?
                     mDeclIdx := trail find(VariableDecl)
                     cDeclIdx := trail find(ClassDecl)
+                    addonIdx := trail find(Addon)
+
                     if (cDeclIdx != -1 && mDeclIdx != -1 && (mDeclIdx - cDeclIdx) == 1) {
                         cDecl := trail get(cDeclIdx, ClassDecl)
                         mDecl := trail get(mDeclIdx, VariableDecl)
 
-                        fDecl: FunctionDecl
-                        if(mDecl isStatic()) {
-                            fDecl = cDecl getLoadFunc()
-                        } else {
-                            fDecl = cDecl getDefaultsFunc()
+                        fDecl := match (mDecl isStatic()) {
+                            case true => cDecl getLoadFunc()
+                            case      => cDecl getDefaultsFunc()
                         }
+
+                        fDecl getBody() add(this)
+                        result = true
+                    } else if (addonIdx != -1 && mDeclIdx != -1 && (mDeclIdx - addonIdx) == 1) {
+                        cDecl := trail get(addonIdx, Addon) base getMeta()
+                        mDecl := trail get(mDeclIdx, VariableDecl)
+
+                        fDecl := match (mDecl isStatic()) {
+                            case true => cDecl getLoadFunc()
+                            case      => cDecl getDefaultsFunc()
+                        }
+
                         fDecl getBody() add(this)
                         result = true
                     }

--- a/source/rock/middle/VariableDecl.ooc
+++ b/source/rock/middle/VariableDecl.ooc
@@ -3,7 +3,7 @@ import Type, Declaration, Expression, Visitor, TypeDecl, VariableAccess,
        Node, ClassDecl, FunctionCall, Argument, BinaryOp, Cast, Module,
        Block, Scope, FunctionDecl, Argument, BaseType, FuncType, Statement,
        NullLiteral, Tuple, TypeList, AddressOf, PropertyDecl, CommaSequence,
-       IntLiteral
+       IntLiteral, Addon
 import tinker/[Response, Resolver, Trail, Errors]
 import ../frontend/[BuildParams, Token]
 
@@ -272,15 +272,6 @@ VariableDecl: class extends Declaration {
                         fDecl getBody() add(this)
                         result = true
                     } else if (addonIdx != -1 && mDeclIdx != -1 && (mDeclIdx - addonIdx) == 1) {
-                        cDecl := trail get(addonIdx, Addon) base getMeta()
-                        mDecl := trail get(mDeclIdx, VariableDecl)
-
-                        fDecl := match (mDecl isStatic()) {
-                            case true => cDecl getLoadFunc()
-                            case      => cDecl getDefaultsFunc()
-                        }
-
-                        fDecl getBody() add(this)
                         result = true
                     }
                 }

--- a/test/compiler/addons/generic-addon-realized.ooc
+++ b/test/compiler/addons/generic-addon-realized.ooc
@@ -1,0 +1,7 @@
+//! shouldfail
+
+extend Cell <String> {
+    log: func {
+        val println()
+    }
+}

--- a/test/compiler/addons/generic-addon-return.ooc
+++ b/test/compiler/addons/generic-addon-return.ooc
@@ -1,0 +1,10 @@
+extend Cell <T> {
+    id: func -> T {
+        return val
+    }
+}
+
+describe("we should be able to return values of a generic type in generic addon", ||
+    cell := Cell new("hi")
+    expect("hi", cell id())
+)

--- a/test/compiler/addons/generic-addon-simple.ooc
+++ b/test/compiler/addons/generic-addon-simple.ooc
@@ -1,0 +1,28 @@
+Foo: class <T> {
+    val: T
+
+    init: func(=val)
+
+    printClass: func {
+        T name println()
+    }
+}
+
+
+extend Foo <T> {
+    id: func -> T {
+        val
+    }
+
+    equals?: func (other: Foo<T>) -> Bool {
+        val == other val
+    }
+}
+
+describe("we should be able to extend a generic class generically", ||
+    foo1 := Foo new(42)
+    foo2 := Foo new(42)
+
+    expect(false, foo1 equals?(foo2))
+    expect(true, foo1 id() == foo2 id())
+)

--- a/test/compiler/addons/generic-addon-template-realized.ooc
+++ b/test/compiler/addons/generic-addon-template-realized.ooc
@@ -1,0 +1,15 @@
+//! shouldfail
+
+Foo: class template <T> {
+    magic: static func -> T {
+        42
+    }
+}
+
+extend Foo<Int> {
+    withMagic: static func -> Int {
+        magic() + 1
+    }
+}
+
+Foo<LLong> withMagic()

--- a/test/compiler/addons/generic-mixed-addon.ooc
+++ b/test/compiler/addons/generic-mixed-addon.ooc
@@ -1,0 +1,17 @@
+Foo: class <T> template <U> {
+    val1: T
+    val2: U
+
+    init: func (=val1, =val2)
+}
+
+extend Foo<U, String> {
+    int_val: func -> Int {
+        val2 toInt()
+    }
+}
+
+describe("we should be able to extend a generic template class", ||
+    foo := Foo<Int, String> new(40, "2")
+    expect(42, foo val1 + foo int_val())
+)

--- a/test/compiler/functions/redefinition-in-extend-suffix.ooc
+++ b/test/compiler/functions/redefinition-in-extend-suffix.ooc
@@ -11,13 +11,13 @@ describe("redefinition in extend with suffix should work", ||
 
 // support code
 
-extend ArrayList<Int> {
+extend ArrayList<T> {
     exists?: func -> Bool {
         return false
     }
 }
 
-extend ArrayList<String> {
+extend ArrayList<T> {
     exists?: func ~string (i: String) -> Bool{
         return true
     }

--- a/test/compiler/functions/redefinition-in-extend.ooc
+++ b/test/compiler/functions/redefinition-in-extend.ooc
@@ -2,13 +2,13 @@
 
 import structs/ArrayList
 
-extend ArrayList<Int> {
+extend ArrayList<T> {
     exists?: func -> Bool{
         return false
     }
 }
 
-extend ArrayList<String> {
+extend ArrayList<t> {
     exists?: func (i: String) -> Bool{
         return true
     }


### PR DESCRIPTION
As well as template classes and mixed (generic template) classes.  

How the solution works:  

We construct a mapping of the new generic names to the old definitions.  
Then, we forward accesses to them to the original definitions.  

We also keep illegal names, old names that don't appear in the extended generic names so we can give accurate error messages if they are accessed.  

In addition to that, we need to change the way unrolling of properties is done inside the addon, since the addon never used to be in the trail.