### PR TITLE
[Bounty] Fixes attempts at taking rvalue references when dealing with cover properties

### DIFF
--- a/source/rock/middle/ArrayAccess.ooc
+++ b/source/rock/middle/ArrayAccess.ooc
@@ -469,7 +469,18 @@ ArrayAccess: class extends Expression {
         b toString()
     }
 
-    isReferencable: func -> Bool { true }
+    isReferencable: func -> Bool {
+        if (array getType()) {
+            if (array getType() instanceOf?(ArrayType)) {
+                // ooc arrays are not referencable
+                return false
+            } else if (array getType() instanceOf?(PointerType)) {
+                return true
+            }
+        }
+
+        array isReferencable()
+    }
 
     replace: func (oldie, kiddo: Node) -> Bool {
         match oldie {

--- a/source/rock/middle/ArrayAccess.ooc
+++ b/source/rock/middle/ArrayAccess.ooc
@@ -480,8 +480,10 @@ ArrayAccess: class extends Expression {
     isReferencable: func -> Bool {
         if (array getType()) {
             if (array getType() instanceOf?(ArrayType)) {
-                // ooc arrays are not referencable
-                return false
+                // ArrayTypes with expressions are actually C arrays, which are referencable (while ooc arrays are not)
+                arrayType := array getType() as ArrayType
+
+                return arrayType expr != null
             } else if (array getType() instanceOf?(PointerType)) {
                 return true
             }

--- a/source/rock/middle/VariableAccess.ooc
+++ b/source/rock/middle/VariableAccess.ooc
@@ -818,8 +818,19 @@ VariableAccess: class extends Expression {
         expr ? (expr toString() + " " + prettyName) : prettyName
     }
 
-    isReferencable: func -> Bool { ref && ref instanceOf?(VariableDecl) && 
-    (ref as VariableDecl isExtern() && ref as VariableDecl isConst()) ? false : true }
+    isReferencable: func -> Bool {
+        if (ref && ref instanceOf?(VariableDecl)) {
+            if (ref as VariableDecl isExtern() && ref as VariableDecl isConst()) {
+                return false
+            }
+        }
+
+        if (expr) {
+            return expr isReferencable()
+        }
+
+        true
+    }
 
     replace: func (oldie, kiddo: Node) -> Bool {
         match oldie {

--- a/source/rock/middle/VariableAccess.ooc
+++ b/source/rock/middle/VariableAccess.ooc
@@ -869,10 +869,6 @@ VariableAccess: class extends Expression {
             }
         }
 
-        if (expr) {
-            return expr isReferencable()
-        }
-
         true
     }
 

--- a/test/compiler/arrays/array-retrieve-calculated-property.ooc
+++ b/test/compiler/arrays/array-retrieve-calculated-property.ooc
@@ -1,0 +1,11 @@
+Foo: cover {
+    calculated ::= 42
+}
+
+describe("should be able to directly use a calculated property of a cover stored in an ooc array", ||
+    arr := Foo[1] new()
+    foo: Foo
+    arr[0] = foo
+
+    expect(42, arr[0] calculated)
+)

--- a/test/compiler/generics/calculated-cover-property-operator-argument.ooc
+++ b/test/compiler/generics/calculated-cover-property-operator-argument.ooc
@@ -1,0 +1,22 @@
+import structs/ArrayList
+
+Foos: class {
+    init: func
+    operator [] (index: Int) -> Foo {
+        Foo new(42)
+    }
+}
+
+Foo: cover {
+    bar: Int
+    init: func@ (=bar)
+}
+
+describe("we should be able to call a generic function on a calculated property of a cover returned by an operator call", ||
+    foos := Foos new()
+    list := ArrayList<Int> new()
+
+    list add(foos[0] bar)
+
+    expect(42, list last())
+)


### PR DESCRIPTION
Description:  
Tightened up the way rock decides whether an expression is referencable.  
In particular, non extern const accesses where always deemed referencable (extern const values are presumed to be defined constants).  

However, this is untrue if the expression of the access is non-referencable itself.  
In addition to that, (at least in standard ooc), ooc array accesses cannot have their address taken but the compiler claimed all array accesses could do so.