### PR TITLE
improve error messages in override check

### DIFF
--- a/source/rock/middle/TypeDecl.ooc
+++ b/source/rock/middle/TypeDecl.ooc
@@ -1146,10 +1146,9 @@ TypeDecl: abstract class extends Declaration {
                 if (!(candidate isOverride) && !(candidate name startsWith?("__OP"))) {
                     //res throwError(AbstractContractNotSatisfied new(
                     res throwError(Warning new(
-                        token,"`%s`implements abstract function %s inherited from %s but it is not declared override" format(
-                        candidate getOwner() toString(),
-                        candidate name,
-                        fDecl getOwner() toString()
+                        candidate token,"`%s` should be override because it inherites from `%s`" format(
+                        candidate toString(),
+                        fDecl toString()
                     )))
                 }
             }
@@ -1597,6 +1596,6 @@ TypeArgSizeMismatch: class extends Error {
 
 DefinitionMismatch: class extends Error {
     init: func ~withToken (.token, call: FunctionDecl, cand: FunctionDecl) {
-        super(token, "Definition mismatch between { %s } (derived) and { %s } (base)" format(call toString(), cand toString()))
+        super(token, "Definition mismatch between `%s` (derived) and `%s` (base)" format(call toString(), cand toString()))
     }
 }

--- a/source/rock/middle/TypeDecl.ooc
+++ b/source/rock/middle/TypeDecl.ooc
@@ -1146,7 +1146,7 @@ TypeDecl: abstract class extends Declaration {
                 if (!(candidate isOverride) && !(candidate name startsWith?("__OP"))) {
                     //res throwError(AbstractContractNotSatisfied new(
                     res throwError(Warning new(
-                        candidate token,"`%s` should be override because it inherites from `%s`" format(
+                        candidate token,"`%s` should be override because it inherits from `%s`" format(
                         candidate toString(),
                         fDecl toString()
                     )))


### PR DESCRIPTION
Improve the error message for:

* If a function is not override but inherits from base definition: 
1.  print the token of function definition instead of the class definition.
2. use `candidate toString()` instead of `candidate name` because name used for `c` sources generation. Now error message prints things like `hasNext?()` instead of `hasNext__quest()`.

* DefinitionMismatch: 
use `\`` instead of `{}` to keep consistent with other messages