### PR TITLE
Added method support to safe navigation operator

### DIFF
--- a/source/rock/frontend/AstBuilder.ooc
+++ b/source/rock/frontend/AstBuilder.ooc
@@ -1309,7 +1309,7 @@ AstBuilder: class {
 
     onSafeNavigationIdent: unmangled(nq_onSafeNavigationIdent) func (ident: CString) {
         safenav := peek(SafeNavigation)
-        safenav sections[safenav sections lastIndex()] = VariableAccess new(safenav sections last(), ident toString(), nullToken)
+        safenav sections[safenav sections lastIndex()] = VariableAccess new(safenav sections last(), ident toString(), token())
     }
 
     onSafeNavigationMethod: unmangled(nq_onSafeNavigationMethod) func (fCall: FunctionCall) {

--- a/source/rock/frontend/AstBuilder.ooc
+++ b/source/rock/frontend/AstBuilder.ooc
@@ -1304,11 +1304,18 @@ AstBuilder: class {
     }
 
     onSafeNavigationSection: unmangled(nq_onSafeNavigationSection) func {
-        peek(SafeNavigation) sections add(ArrayList<String> new())
+        peek(SafeNavigation) sections add(null as Expression)
     }
 
     onSafeNavigationIdent: unmangled(nq_onSafeNavigationIdent) func (ident: CString) {
-        peek(SafeNavigation) sections last() add(ident toString())
+        safenav := peek(SafeNavigation)
+        safenav sections[safenav sections lastIndex()] = VariableAccess new(safenav sections last(), ident toString(), nullToken)
+    }
+
+    onSafeNavigationMethod: unmangled(nq_onSafeNavigationMethod) func (fCall: FunctionCall) {
+        safenav := peek(SafeNavigation)
+        fCall setExpr(safenav sections last())
+        safenav sections[safenav sections lastIndex()] = fCall
     }
 
     onSafeNavigationEnd: unmangled(nq_onSafeNavigationEnd) func -> SafeNavigation {

--- a/source/rock/frontend/NagaQueen.c
+++ b/source/rock/frontend/NagaQueen.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 struct _GREG;
-#define YYRULECOUNT 228
+#define YYRULECOUNT 226
 
 #include <stdio.h>
 #include <string.h>
@@ -409,6 +409,7 @@ void *nq_onBinaryAnd(void *this, void *left, void *right);
 void nq_onSafeNavigationStart(void *this, void *expr);
 void nq_onSafeNavigationSection(void *this);
 void nq_onSafeNavigationIdent(void *this, char *ident);
+void nq_onSafeNavigationMethod(void *this, void *fcall);
 void *nq_onSafeNavigationEnd(void *this);
 
 void *nq_onLogicalNot(void *this, void *inner);
@@ -764,129 +765,127 @@ YY_LOCAL(void) yySet(GREG *G, char *text, int count, yythunk *thunk, YY_XTYPE YY
 
 #define YYACCEPT        yyAccept(G, yythunkpos0)
 
-YY_RULE(int) yy_TextInside(GREG *G); /* 228 */
-YY_RULE(int) yy_TextChunk(GREG *G); /* 227 */
-YY_RULE(int) yy_Interpolation(GREG *G); /* 226 */
-YY_RULE(int) yy_StringChunk(GREG *G); /* 225 */
-YY_RULE(int) yy_DOUBLE_QUOTE(GREG *G); /* 224 */
-YY_RULE(int) yy_SINGLE_QUOTE(GREG *G); /* 223 */
-YY_RULE(int) yy_FP_LIT_SUFFIX(GREG *G); /* 222 */
-YY_RULE(int) yy_INT_LIT_SUFFIX(GREG *G); /* 221 */
-YY_RULE(int) yy_CommentMultiLineWithDocs(GREG *G); /* 220 */
-YY_RULE(int) yy_Comment(GREG *G); /* 219 */
-YY_RULE(int) yy_CommentMultiLine(GREG *G); /* 218 */
-YY_RULE(int) yy_CLOS_COMMENT(GREG *G); /* 217 */
-YY_RULE(int) yy_KW(GREG *G); /* 216 */
-YY_RULE(int) yy_FALSE_KW(GREG *G); /* 215 */
-YY_RULE(int) yy_TRUE_KW(GREG *G); /* 214 */
-YY_RULE(int) yy_NULL_KW(GREG *G); /* 213 */
-YY_RULE(int) yy_BOOL_LIT(GREG *G); /* 212 */
-YY_RULE(int) yy_CHAR_LIT(GREG *G); /* 211 */
-YY_RULE(int) yy_STRING_LIT(GREG *G); /* 210 */
-YY_RULE(int) yy_TEXT_STRING_LIT(GREG *G); /* 209 */
-YY_RULE(int) yy_RAW_STRING_LIT(GREG *G); /* 208 */
-YY_RULE(int) yy_FLOAT_LIT(GREG *G); /* 207 */
-YY_RULE(int) yy_BIN_LIT(GREG *G); /* 206 */
-YY_RULE(int) yy_DEC_LIT(GREG *G); /* 205 */
-YY_RULE(int) yy_HEX_LIT(GREG *G); /* 204 */
-YY_RULE(int) yy_OCT_LIT(GREG *G); /* 203 */
-YY_RULE(int) yy_ArrayLiteral(GREG *G); /* 202 */
-YY_RULE(int) yy_ValueCore(GREG *G); /* 201 */
-YY_RULE(int) yy_VariableAccess(GREG *G); /* 200 */
-YY_RULE(int) yy_ACS(GREG *G); /* 199 */
-YY_RULE(int) yy_FunctionCallCore(GREG *G); /* 198 */
-YY_RULE(int) yy_FunctionCallNoname(GREG *G); /* 197 */
-YY_RULE(int) yy_AS_KW(GREG *G); /* 196 */
-YY_RULE(int) yy_CLOS_SQUAR(GREG *G); /* 195 */
-YY_RULE(int) yy_IDENT_CORE(GREG *G); /* 194 */
-YY_RULE(int) yy_SAFE_NAV(GREG *G); /* 193 */
-YY_RULE(int) yy_Access(GREG *G); /* 192 */
-YY_RULE(int) yy_SLASH(GREG *G); /* 191 */
-YY_RULE(int) yy_EXP(GREG *G); /* 190 */
-YY_RULE(int) yy_SafeNavAccess(GREG *G); /* 189 */
-YY_RULE(int) yy_B_NOT(GREG *G); /* 188 */
-YY_RULE(int) yy_L_NOT(GREG *G); /* 187 */
-YY_RULE(int) yy_ProductCore(GREG *G); /* 186 */
-YY_RULE(int) yy_ProductBinaryNot(GREG *G); /* 185 */
-YY_RULE(int) yy_ProductLogicalNot(GREG *G); /* 184 */
-YY_RULE(int) yy_PERCENT(GREG *G); /* 183 */
-YY_RULE(int) yy_MINUS(GREG *G); /* 182 */
-YY_RULE(int) yy_Product(GREG *G); /* 181 */
-YY_RULE(int) yy_B_RSHIFT(GREG *G); /* 180 */
-YY_RULE(int) yy_B_LSHIFT(GREG *G); /* 179 */
-YY_RULE(int) yy_Sum(GREG *G); /* 178 */
-YY_RULE(int) yy_DOUBLE_DOT(GREG *G); /* 177 */
-YY_RULE(int) yy_Shift(GREG *G); /* 176 */
-YY_RULE(int) yy_MORETHAN_EQ(GREG *G); /* 175 */
-YY_RULE(int) yy_LESSTHAN_EQ(GREG *G); /* 174 */
-YY_RULE(int) yy_CMP(GREG *G); /* 173 */
-YY_RULE(int) yy_Range(GREG *G); /* 172 */
-YY_RULE(int) yy_NOT_EQUALS(GREG *G); /* 171 */
-YY_RULE(int) yy_EQUALS(GREG *G); /* 170 */
-YY_RULE(int) yy_Inequality(GREG *G); /* 169 */
-YY_RULE(int) yy_B_AND(GREG *G); /* 168 */
-YY_RULE(int) yy_Equality(GREG *G); /* 167 */
-YY_RULE(int) yy_B_XOR(GREG *G); /* 166 */
-YY_RULE(int) yy_BinaryAnd(GREG *G); /* 165 */
-YY_RULE(int) yy_B_OR(GREG *G); /* 164 */
-YY_RULE(int) yy_BinaryXor(GREG *G); /* 163 */
-YY_RULE(int) yy_L_AND(GREG *G); /* 162 */
-YY_RULE(int) yy_BinaryOr(GREG *G); /* 161 */
-YY_RULE(int) yy_L_OR(GREG *G); /* 160 */
-YY_RULE(int) yy_LogicalAnd(GREG *G); /* 159 */
-YY_RULE(int) yy_DOUBLE_QUEST(GREG *G); /* 158 */
-YY_RULE(int) yy_LogicalOr(GREG *G); /* 157 */
-YY_RULE(int) yy_QUEST(GREG *G); /* 156 */
-YY_RULE(int) yy_NullCoalescing(GREG *G); /* 155 */
-YY_RULE(int) yy_ASS_B_AND(GREG *G); /* 154 */
-YY_RULE(int) yy_ASS_B_OR(GREG *G); /* 153 */
-YY_RULE(int) yy_ASS_B_XOR(GREG *G); /* 152 */
-YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G); /* 151 */
-YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G); /* 150 */
-YY_RULE(int) yy_ASS_DIV(GREG *G); /* 149 */
-YY_RULE(int) yy_ASS_EXP(GREG *G); /* 148 */
-YY_RULE(int) yy_ASS_MUL(GREG *G); /* 147 */
-YY_RULE(int) yy_ASS_SUB(GREG *G); /* 146 */
-YY_RULE(int) yy_ASS_MOD(GREG *G); /* 145 */
-YY_RULE(int) yy_ASS_ADD(GREG *G); /* 144 */
-YY_RULE(int) yy_Ternary(GREG *G); /* 143 */
-YY_RULE(int) yy_Assignment(GREG *G); /* 142 */
-YY_RULE(int) yy_FunctionCall(GREG *G); /* 141 */
-YY_RULE(int) yy_BinaryOperation(GREG *G); /* 140 */
-YY_RULE(int) yy_DoubleArrow(GREG *G); /* 139 */
-YY_RULE(int) yy_RETURN_KW(GREG *G); /* 138 */
-YY_RULE(int) yy_WHILE_KW(GREG *G); /* 137 */
-YY_RULE(int) yy_IN_KW(GREG *G); /* 136 */
-YY_RULE(int) yy_FOR_KW(GREG *G); /* 135 */
-YY_RULE(int) yy_ImplicitDecl(GREG *G); /* 134 */
-YY_RULE(int) yy_CONTINUE_KW(GREG *G); /* 133 */
-YY_RULE(int) yy_BREAK_KW(GREG *G); /* 132 */
-YY_RULE(int) yy_Continue(GREG *G); /* 131 */
-YY_RULE(int) yy_Break(GREG *G); /* 130 */
-YY_RULE(int) yy_While(GREG *G); /* 129 */
-YY_RULE(int) yy_Foreach(GREG *G); /* 128 */
-YY_RULE(int) yy_CATCH_KW(GREG *G); /* 127 */
-YY_RULE(int) yy_Catch(GREG *G); /* 126 */
-YY_RULE(int) yy_TRY_KW(GREG *G); /* 125 */
-YY_RULE(int) yy_Value(GREG *G); /* 124 */
-YY_RULE(int) yy_MATCH_KW(GREG *G); /* 123 */
-YY_RULE(int) yy_DOUBLE_ARROW(GREG *G); /* 122 */
-YY_RULE(int) yy_CaseExpr(GREG *G); /* 121 */
-YY_RULE(int) yy_CASE_KW(GREG *G); /* 120 */
-YY_RULE(int) yy_Case(GREG *G); /* 119 */
-YY_RULE(int) yy_ELSE_KW(GREG *G); /* 118 */
-YY_RULE(int) yy_Body(GREG *G); /* 117 */
-YY_RULE(int) yy_IF_KW(GREG *G); /* 116 */
-YY_RULE(int) yy_Else(GREG *G); /* 115 */
-YY_RULE(int) yy_If(GREG *G); /* 114 */
-YY_RULE(int) yy_Return(GREG *G); /* 113 */
-YY_RULE(int) yy_Try(GREG *G); /* 112 */
-YY_RULE(int) yy_Match(GREG *G); /* 111 */
-YY_RULE(int) yy_FlowControl(GREG *G); /* 110 */
-YY_RULE(int) yy_Block(GREG *G); /* 109 */
-YY_RULE(int) yy_Conditional(GREG *G); /* 108 */
-YY_RULE(int) yy_PreprocessorEndRegion(GREG *G); /* 107 */
-YY_RULE(int) yy_PreprocessorBeginRegion(GREG *G); /* 106 */
+YY_RULE(int) yy_TextInside(GREG *G); /* 226 */
+YY_RULE(int) yy_TextChunk(GREG *G); /* 225 */
+YY_RULE(int) yy_Interpolation(GREG *G); /* 224 */
+YY_RULE(int) yy_StringChunk(GREG *G); /* 223 */
+YY_RULE(int) yy_DOUBLE_QUOTE(GREG *G); /* 222 */
+YY_RULE(int) yy_SINGLE_QUOTE(GREG *G); /* 221 */
+YY_RULE(int) yy_FP_LIT_SUFFIX(GREG *G); /* 220 */
+YY_RULE(int) yy_INT_LIT_SUFFIX(GREG *G); /* 219 */
+YY_RULE(int) yy_CommentMultiLineWithDocs(GREG *G); /* 218 */
+YY_RULE(int) yy_Comment(GREG *G); /* 217 */
+YY_RULE(int) yy_CommentMultiLine(GREG *G); /* 216 */
+YY_RULE(int) yy_CLOS_COMMENT(GREG *G); /* 215 */
+YY_RULE(int) yy_KW(GREG *G); /* 214 */
+YY_RULE(int) yy_FALSE_KW(GREG *G); /* 213 */
+YY_RULE(int) yy_TRUE_KW(GREG *G); /* 212 */
+YY_RULE(int) yy_NULL_KW(GREG *G); /* 211 */
+YY_RULE(int) yy_BOOL_LIT(GREG *G); /* 210 */
+YY_RULE(int) yy_CHAR_LIT(GREG *G); /* 209 */
+YY_RULE(int) yy_STRING_LIT(GREG *G); /* 208 */
+YY_RULE(int) yy_TEXT_STRING_LIT(GREG *G); /* 207 */
+YY_RULE(int) yy_RAW_STRING_LIT(GREG *G); /* 206 */
+YY_RULE(int) yy_FLOAT_LIT(GREG *G); /* 205 */
+YY_RULE(int) yy_BIN_LIT(GREG *G); /* 204 */
+YY_RULE(int) yy_DEC_LIT(GREG *G); /* 203 */
+YY_RULE(int) yy_HEX_LIT(GREG *G); /* 202 */
+YY_RULE(int) yy_OCT_LIT(GREG *G); /* 201 */
+YY_RULE(int) yy_ArrayLiteral(GREG *G); /* 200 */
+YY_RULE(int) yy_ValueCore(GREG *G); /* 199 */
+YY_RULE(int) yy_VariableAccess(GREG *G); /* 198 */
+YY_RULE(int) yy_ACS(GREG *G); /* 197 */
+YY_RULE(int) yy_FunctionCallCore(GREG *G); /* 196 */
+YY_RULE(int) yy_FunctionCallNoname(GREG *G); /* 195 */
+YY_RULE(int) yy_AS_KW(GREG *G); /* 194 */
+YY_RULE(int) yy_CLOS_SQUAR(GREG *G); /* 193 */
+YY_RULE(int) yy_IDENT_CORE(GREG *G); /* 192 */
+YY_RULE(int) yy_SAFE_NAV(GREG *G); /* 191 */
+YY_RULE(int) yy_Access(GREG *G); /* 190 */
+YY_RULE(int) yy_SLASH(GREG *G); /* 189 */
+YY_RULE(int) yy_EXP(GREG *G); /* 188 */
+YY_RULE(int) yy_SafeNavAccess(GREG *G); /* 187 */
+YY_RULE(int) yy_B_NOT(GREG *G); /* 186 */
+YY_RULE(int) yy_L_NOT(GREG *G); /* 185 */
+YY_RULE(int) yy_ProductCore(GREG *G); /* 184 */
+YY_RULE(int) yy_ProductBinaryNot(GREG *G); /* 183 */
+YY_RULE(int) yy_ProductLogicalNot(GREG *G); /* 182 */
+YY_RULE(int) yy_PERCENT(GREG *G); /* 181 */
+YY_RULE(int) yy_MINUS(GREG *G); /* 180 */
+YY_RULE(int) yy_Product(GREG *G); /* 179 */
+YY_RULE(int) yy_B_RSHIFT(GREG *G); /* 178 */
+YY_RULE(int) yy_B_LSHIFT(GREG *G); /* 177 */
+YY_RULE(int) yy_Sum(GREG *G); /* 176 */
+YY_RULE(int) yy_DOUBLE_DOT(GREG *G); /* 175 */
+YY_RULE(int) yy_Shift(GREG *G); /* 174 */
+YY_RULE(int) yy_MORETHAN_EQ(GREG *G); /* 173 */
+YY_RULE(int) yy_LESSTHAN_EQ(GREG *G); /* 172 */
+YY_RULE(int) yy_CMP(GREG *G); /* 171 */
+YY_RULE(int) yy_Range(GREG *G); /* 170 */
+YY_RULE(int) yy_NOT_EQUALS(GREG *G); /* 169 */
+YY_RULE(int) yy_EQUALS(GREG *G); /* 168 */
+YY_RULE(int) yy_Inequality(GREG *G); /* 167 */
+YY_RULE(int) yy_B_AND(GREG *G); /* 166 */
+YY_RULE(int) yy_Equality(GREG *G); /* 165 */
+YY_RULE(int) yy_B_XOR(GREG *G); /* 164 */
+YY_RULE(int) yy_BinaryAnd(GREG *G); /* 163 */
+YY_RULE(int) yy_B_OR(GREG *G); /* 162 */
+YY_RULE(int) yy_BinaryXor(GREG *G); /* 161 */
+YY_RULE(int) yy_L_AND(GREG *G); /* 160 */
+YY_RULE(int) yy_BinaryOr(GREG *G); /* 159 */
+YY_RULE(int) yy_L_OR(GREG *G); /* 158 */
+YY_RULE(int) yy_LogicalAnd(GREG *G); /* 157 */
+YY_RULE(int) yy_DOUBLE_QUEST(GREG *G); /* 156 */
+YY_RULE(int) yy_LogicalOr(GREG *G); /* 155 */
+YY_RULE(int) yy_QUEST(GREG *G); /* 154 */
+YY_RULE(int) yy_NullCoalescing(GREG *G); /* 153 */
+YY_RULE(int) yy_ASS_B_AND(GREG *G); /* 152 */
+YY_RULE(int) yy_ASS_B_OR(GREG *G); /* 151 */
+YY_RULE(int) yy_ASS_B_XOR(GREG *G); /* 150 */
+YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G); /* 149 */
+YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G); /* 148 */
+YY_RULE(int) yy_ASS_DIV(GREG *G); /* 147 */
+YY_RULE(int) yy_ASS_EXP(GREG *G); /* 146 */
+YY_RULE(int) yy_ASS_MUL(GREG *G); /* 145 */
+YY_RULE(int) yy_ASS_SUB(GREG *G); /* 144 */
+YY_RULE(int) yy_ASS_MOD(GREG *G); /* 143 */
+YY_RULE(int) yy_ASS_ADD(GREG *G); /* 142 */
+YY_RULE(int) yy_Ternary(GREG *G); /* 141 */
+YY_RULE(int) yy_Assignment(GREG *G); /* 140 */
+YY_RULE(int) yy_FunctionCall(GREG *G); /* 139 */
+YY_RULE(int) yy_BinaryOperation(GREG *G); /* 138 */
+YY_RULE(int) yy_DoubleArrow(GREG *G); /* 137 */
+YY_RULE(int) yy_RETURN_KW(GREG *G); /* 136 */
+YY_RULE(int) yy_WHILE_KW(GREG *G); /* 135 */
+YY_RULE(int) yy_IN_KW(GREG *G); /* 134 */
+YY_RULE(int) yy_FOR_KW(GREG *G); /* 133 */
+YY_RULE(int) yy_ImplicitDecl(GREG *G); /* 132 */
+YY_RULE(int) yy_CONTINUE_KW(GREG *G); /* 131 */
+YY_RULE(int) yy_BREAK_KW(GREG *G); /* 130 */
+YY_RULE(int) yy_Continue(GREG *G); /* 129 */
+YY_RULE(int) yy_Break(GREG *G); /* 128 */
+YY_RULE(int) yy_While(GREG *G); /* 127 */
+YY_RULE(int) yy_Foreach(GREG *G); /* 126 */
+YY_RULE(int) yy_CATCH_KW(GREG *G); /* 125 */
+YY_RULE(int) yy_Catch(GREG *G); /* 124 */
+YY_RULE(int) yy_TRY_KW(GREG *G); /* 123 */
+YY_RULE(int) yy_Value(GREG *G); /* 122 */
+YY_RULE(int) yy_MATCH_KW(GREG *G); /* 121 */
+YY_RULE(int) yy_DOUBLE_ARROW(GREG *G); /* 120 */
+YY_RULE(int) yy_CaseExpr(GREG *G); /* 119 */
+YY_RULE(int) yy_CASE_KW(GREG *G); /* 118 */
+YY_RULE(int) yy_Case(GREG *G); /* 117 */
+YY_RULE(int) yy_ELSE_KW(GREG *G); /* 116 */
+YY_RULE(int) yy_Body(GREG *G); /* 115 */
+YY_RULE(int) yy_IF_KW(GREG *G); /* 114 */
+YY_RULE(int) yy_Else(GREG *G); /* 113 */
+YY_RULE(int) yy_If(GREG *G); /* 112 */
+YY_RULE(int) yy_Return(GREG *G); /* 111 */
+YY_RULE(int) yy_Try(GREG *G); /* 110 */
+YY_RULE(int) yy_Match(GREG *G); /* 109 */
+YY_RULE(int) yy_FlowControl(GREG *G); /* 108 */
+YY_RULE(int) yy_Block(GREG *G); /* 107 */
+YY_RULE(int) yy_Conditional(GREG *G); /* 106 */
 YY_RULE(int) yy_CommentLine(GREG *G); /* 105 */
 YY_RULE(int) yy_EoledStatement(GREG *G); /* 104 */
 YY_RULE(int) yy_StmtCore(GREG *G); /* 103 */
@@ -2044,48 +2043,69 @@ YY_ACTION(void) yy_1_Access(GREG *G, char *yytext, int yyleng, yythunk *thunk, Y
 #undef l
 #undef ident
 }
-YY_ACTION(void) yy_4_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+YY_ACTION(void) yy_5_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define i G->val[-1]
-#define expr G->val[-2]
-  yyprintf((stderr, "do yy_4_SafeNavAccess"));
+#define f G->val[-2]
+#define expr G->val[-3]
+  yyprintf((stderr, "do yy_5_SafeNavAccess"));
   yyprintfvTcontext(yytext);
   yyprintf((stderr, "\n  {yy=nq_onSafeNavigationEnd(core->this); }\n"));
   yy=nq_onSafeNavigationEnd(core->this); ;
 #undef i
+#undef f
+#undef expr
+}
+YY_ACTION(void) yy_4_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
+{
+#define i G->val[-1]
+#define f G->val[-2]
+#define expr G->val[-3]
+  yyprintf((stderr, "do yy_4_SafeNavAccess"));
+  yyprintfvTcontext(yytext);
+  yyprintf((stderr, "\n  {nq_onSafeNavigationIdent(core->this, i); }\n"));
+  nq_onSafeNavigationIdent(core->this, i); ;
+#undef i
+#undef f
 #undef expr
 }
 YY_ACTION(void) yy_3_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define i G->val[-1]
-#define expr G->val[-2]
+#define f G->val[-2]
+#define expr G->val[-3]
   yyprintf((stderr, "do yy_3_SafeNavAccess"));
   yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {nq_onSafeNavigationIdent(core->this, i); }\n"));
-  nq_onSafeNavigationIdent(core->this, i); ;
+  yyprintf((stderr, "\n  {nq_onSafeNavigationMethod(core->this, f); }\n"));
+  nq_onSafeNavigationMethod(core->this, f); ;
 #undef i
+#undef f
 #undef expr
 }
 YY_ACTION(void) yy_2_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define i G->val[-1]
-#define expr G->val[-2]
+#define f G->val[-2]
+#define expr G->val[-3]
   yyprintf((stderr, "do yy_2_SafeNavAccess"));
   yyprintfvTcontext(yytext);
   yyprintf((stderr, "\n  {nq_onSafeNavigationSection(core->this); }\n"));
   nq_onSafeNavigationSection(core->this); ;
 #undef i
+#undef f
 #undef expr
 }
 YY_ACTION(void) yy_1_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define i G->val[-1]
-#define expr G->val[-2]
+#define f G->val[-2]
+#define expr G->val[-3]
   yyprintf((stderr, "do yy_1_SafeNavAccess"));
   yyprintfvTcontext(yytext);
   yyprintf((stderr, "\n  {tokenPos; nq_onSafeNavigationStart(core->this, expr); }\n"));
   tokenPos; nq_onSafeNavigationStart(core->this, expr); ;
 #undef i
+#undef f
 #undef expr
 }
 YY_ACTION(void) yy_6_ProductCore(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
@@ -8014,23 +8034,39 @@ YY_RULE(int) yy_EXP(GREG *G)
   return 0;
 }
 YY_RULE(int) yy_SafeNavAccess(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
+{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "SafeNavAccess"));
   if (!yy_Access(G))  goto l220;
-  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yySet, -3, 0, "yySet");
 
   {  int yypos221= G->pos, yythunkpos221= G->thunkpos;  yyDo(G, yy_1_SafeNavAccess, G->begin, G->end, "yy_1_SafeNavAccess");
   if (!yy_SAFE_NAV(G))  goto l221;
   yyDo(G, yy_2_SafeNavAccess, G->begin, G->end, "yy_2_SafeNavAccess");
   if (!yy__(G))  goto l221;
-  if (!yy_IDENT(G))  goto l221;
-  yyDo(G, yySet, -1, 0, "yySet");
+
+  {  int yypos227= G->pos, yythunkpos227= G->thunkpos;  if (!yy_FunctionCall(G))  goto l228;
+  yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
+  goto l227;
+  l228:;	  G->pos= yypos227; G->thunkpos= yythunkpos227;  if (!yy_IDENT_CORE(G))  goto l221;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_4_SafeNavAccess, G->begin, G->end, "yy_4_SafeNavAccess");
+
+  }
+  l227:;	  if (!yy__(G))  goto l221;
 
   l225:;	
-  {  int yypos226= G->pos, yythunkpos226= G->thunkpos;  if (!yy_IDENT(G))  goto l226;
-  yyDo(G, yySet, -1, 0, "yySet");
+  {  int yypos226= G->pos, yythunkpos226= G->thunkpos;
+  {  int yypos229= G->pos, yythunkpos229= G->thunkpos;  if (!yy_FunctionCall(G))  goto l230;
+  yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
+  goto l229;
+  l230:;	  G->pos= yypos229; G->thunkpos= yythunkpos229;  if (!yy_IDENT_CORE(G))  goto l226;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_4_SafeNavAccess, G->begin, G->end, "yy_4_SafeNavAccess");
+
+  }
+  l229:;	  if (!yy__(G))  goto l226;
   goto l225;
   l226:;	  G->pos= yypos226; G->thunkpos= yythunkpos226;
   }
@@ -8038,26 +8074,42 @@ YY_RULE(int) yy_SafeNavAccess(GREG *G)
   {  int yypos224= G->pos, yythunkpos224= G->thunkpos;  if (!yy_SAFE_NAV(G))  goto l224;
   yyDo(G, yy_2_SafeNavAccess, G->begin, G->end, "yy_2_SafeNavAccess");
   if (!yy__(G))  goto l224;
-  if (!yy_IDENT(G))  goto l224;
-  yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
 
-  l227:;	
-  {  int yypos228= G->pos, yythunkpos228= G->thunkpos;  if (!yy_IDENT(G))  goto l228;
-  yyDo(G, yySet, -1, 0, "yySet");
+  {  int yypos233= G->pos, yythunkpos233= G->thunkpos;  if (!yy_FunctionCall(G))  goto l234;
+  yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
-  goto l227;
-  l228:;	  G->pos= yypos228; G->thunkpos= yythunkpos228;
+  goto l233;
+  l234:;	  G->pos= yypos233; G->thunkpos= yythunkpos233;  if (!yy_IDENT_CORE(G))  goto l224;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_4_SafeNavAccess, G->begin, G->end, "yy_4_SafeNavAccess");
+
+  }
+  l233:;	  if (!yy__(G))  goto l224;
+
+  l231:;	
+  {  int yypos232= G->pos, yythunkpos232= G->thunkpos;
+  {  int yypos235= G->pos, yythunkpos235= G->thunkpos;  if (!yy_FunctionCall(G))  goto l236;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
+  goto l235;
+  l236:;	  G->pos= yypos235; G->thunkpos= yythunkpos235;  if (!yy_IDENT_CORE(G))  goto l232;
+  yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_4_SafeNavAccess, G->begin, G->end, "yy_4_SafeNavAccess");
+
+  }
+  l235:;	  if (!yy__(G))  goto l232;
+  goto l231;
+  l232:;	  G->pos= yypos232; G->thunkpos= yythunkpos232;
   }  goto l223;
   l224:;	  G->pos= yypos224; G->thunkpos= yythunkpos224;
-  }  yyDo(G, yy_4_SafeNavAccess, G->begin, G->end, "yy_4_SafeNavAccess");
+  }  yyDo(G, yy_5_SafeNavAccess, G->begin, G->end, "yy_5_SafeNavAccess");
   goto l222;
   l221:;	  G->pos= yypos221; G->thunkpos= yythunkpos221;
   }
   l222:;	  yyprintf((stderr, "  ok   SafeNavAccess"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
-  yyDo(G, yyPop, 2, 0, "yyPop");
+  yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
   l220:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SafeNavAccess"));
   yyprintfvGcontext;
@@ -8067,18 +8119,18 @@ YY_RULE(int) yy_SafeNavAccess(GREG *G)
 }
 YY_RULE(int) yy_B_NOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_NOT"));
-  if (!yymatchChar(G, '~')) goto l229;
+  if (!yymatchChar(G, '~')) goto l237;
 
-  {  int yypos230= G->pos, yythunkpos230= G->thunkpos;  if (!yymatchChar(G, '=')) goto l230;
-  goto l229;
-  l230:;	  G->pos= yypos230; G->thunkpos= yythunkpos230;
-  }  if (!yy__(G))  goto l229;
+  {  int yypos238= G->pos, yythunkpos238= G->thunkpos;  if (!yymatchChar(G, '=')) goto l238;
+  goto l237;
+  l238:;	  G->pos= yypos238; G->thunkpos= yythunkpos238;
+  }  if (!yy__(G))  goto l237;
   yyprintf((stderr, "  ok   B_NOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l229:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_NOT"));
+  l237:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_NOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8086,18 +8138,18 @@ YY_RULE(int) yy_B_NOT(GREG *G)
 }
 YY_RULE(int) yy_L_NOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_NOT"));
-  if (!yymatchChar(G, '!')) goto l231;
+  if (!yymatchChar(G, '!')) goto l239;
 
-  {  int yypos232= G->pos, yythunkpos232= G->thunkpos;  if (!yymatchChar(G, '=')) goto l232;
-  goto l231;
-  l232:;	  G->pos= yypos232; G->thunkpos= yythunkpos232;
-  }  if (!yy__(G))  goto l231;
+  {  int yypos240= G->pos, yythunkpos240= G->thunkpos;  if (!yymatchChar(G, '=')) goto l240;
+  goto l239;
+  l240:;	  G->pos= yypos240; G->thunkpos= yythunkpos240;
+  }  if (!yy__(G))  goto l239;
   yyprintf((stderr, "  ok   L_NOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l231:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_NOT"));
+  l239:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_NOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8106,41 +8158,41 @@ YY_RULE(int) yy_L_NOT(GREG *G)
 YY_RULE(int) yy_ProductCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductCore"));
-  if (!yy_SafeNavAccess(G))  goto l233;
+  if (!yy_SafeNavAccess(G))  goto l241;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l234:;	
-  {  int yypos235= G->pos, yythunkpos235= G->thunkpos;
-  {  int yypos236= G->pos, yythunkpos236= G->thunkpos;  if (!yy_EXP(G))  goto l237;
+  l242:;	
+  {  int yypos243= G->pos, yythunkpos243= G->thunkpos;
+  {  int yypos244= G->pos, yythunkpos244= G->thunkpos;  if (!yy_EXP(G))  goto l245;
   yyDo(G, yy_1_ProductCore, G->begin, G->end, "yy_1_ProductCore");
-  if (!yy_WS(G))  goto l237;
-  if (!yy_Product(G))  goto l237;
+  if (!yy_WS(G))  goto l245;
+  if (!yy_Product(G))  goto l245;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_ProductCore, G->begin, G->end, "yy_2_ProductCore");
-  goto l236;
-  l237:;	  G->pos= yypos236; G->thunkpos= yythunkpos236;  if (!yy_STAR(G))  goto l238;
+  goto l244;
+  l245:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;  if (!yy_STAR(G))  goto l246;
   yyDo(G, yy_3_ProductCore, G->begin, G->end, "yy_3_ProductCore");
-  if (!yy_WS(G))  goto l238;
-  if (!yy_SafeNavAccess(G))  goto l238;
+  if (!yy_WS(G))  goto l246;
+  if (!yy_SafeNavAccess(G))  goto l246;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_ProductCore, G->begin, G->end, "yy_4_ProductCore");
-  goto l236;
-  l238:;	  G->pos= yypos236; G->thunkpos= yythunkpos236;  if (!yy_SLASH(G))  goto l235;
+  goto l244;
+  l246:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;  if (!yy_SLASH(G))  goto l243;
   yyDo(G, yy_5_ProductCore, G->begin, G->end, "yy_5_ProductCore");
-  if (!yy_WS(G))  goto l235;
-  if (!yy_SafeNavAccess(G))  goto l235;
+  if (!yy_WS(G))  goto l243;
+  if (!yy_SafeNavAccess(G))  goto l243;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_ProductCore, G->begin, G->end, "yy_6_ProductCore");
 
   }
-  l236:;	  goto l234;
-  l235:;	  G->pos= yypos235; G->thunkpos= yythunkpos235;
+  l244:;	  goto l242;
+  l243:;	  G->pos= yypos243; G->thunkpos= yythunkpos243;
   }  yyprintf((stderr, "  ok   ProductCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l233:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductCore"));
+  l241:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8149,19 +8201,19 @@ YY_RULE(int) yy_ProductCore(GREG *G)
 YY_RULE(int) yy_ProductBinaryNot(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductBinaryNot"));
-  if (!yy_B_NOT(G))  goto l239;
+  if (!yy_B_NOT(G))  goto l247;
   yyDo(G, yy_1_ProductBinaryNot, G->begin, G->end, "yy_1_ProductBinaryNot");
-  if (!yy__(G))  goto l239;
-  if (!yy_Product(G))  goto l239;
+  if (!yy__(G))  goto l247;
+  if (!yy_Product(G))  goto l247;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l239;
+  if (!yy__(G))  goto l247;
   yyDo(G, yy_2_ProductBinaryNot, G->begin, G->end, "yy_2_ProductBinaryNot");
   yyprintf((stderr, "  ok   ProductBinaryNot"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l239:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductBinaryNot"));
+  l247:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductBinaryNot"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8170,19 +8222,19 @@ YY_RULE(int) yy_ProductBinaryNot(GREG *G)
 YY_RULE(int) yy_ProductLogicalNot(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductLogicalNot"));
-  if (!yy_L_NOT(G))  goto l240;
+  if (!yy_L_NOT(G))  goto l248;
   yyDo(G, yy_1_ProductLogicalNot, G->begin, G->end, "yy_1_ProductLogicalNot");
-  if (!yy__(G))  goto l240;
-  if (!yy_Product(G))  goto l240;
+  if (!yy__(G))  goto l248;
+  if (!yy_Product(G))  goto l248;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l240;
+  if (!yy__(G))  goto l248;
   yyDo(G, yy_2_ProductLogicalNot, G->begin, G->end, "yy_2_ProductLogicalNot");
   yyprintf((stderr, "  ok   ProductLogicalNot"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l240:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductLogicalNot"));
+  l248:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductLogicalNot"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8190,18 +8242,18 @@ YY_RULE(int) yy_ProductLogicalNot(GREG *G)
 }
 YY_RULE(int) yy_PERCENT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PERCENT"));
-  if (!yymatchChar(G, '%')) goto l241;
+  if (!yymatchChar(G, '%')) goto l249;
 
-  {  int yypos242= G->pos, yythunkpos242= G->thunkpos;  if (!yymatchChar(G, '=')) goto l242;
-  goto l241;
-  l242:;	  G->pos= yypos242; G->thunkpos= yythunkpos242;
-  }  if (!yy__(G))  goto l241;
+  {  int yypos250= G->pos, yythunkpos250= G->thunkpos;  if (!yymatchChar(G, '=')) goto l250;
+  goto l249;
+  l250:;	  G->pos= yypos250; G->thunkpos= yythunkpos250;
+  }  if (!yy__(G))  goto l249;
   yyprintf((stderr, "  ok   PERCENT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l241:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PERCENT"));
+  l249:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PERCENT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8209,18 +8261,18 @@ YY_RULE(int) yy_PERCENT(GREG *G)
 }
 YY_RULE(int) yy_MINUS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MINUS"));
-  if (!yymatchChar(G, '-')) goto l243;
+  if (!yymatchChar(G, '-')) goto l251;
 
-  {  int yypos244= G->pos, yythunkpos244= G->thunkpos;  if (!yymatchChar(G, '=')) goto l244;
-  goto l243;
-  l244:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;
-  }  if (!yy__(G))  goto l243;
+  {  int yypos252= G->pos, yythunkpos252= G->thunkpos;  if (!yymatchChar(G, '=')) goto l252;
+  goto l251;
+  l252:;	  G->pos= yypos252; G->thunkpos= yythunkpos252;
+  }  if (!yy__(G))  goto l251;
   yyprintf((stderr, "  ok   MINUS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l243:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MINUS"));
+  l251:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MINUS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8229,19 +8281,19 @@ YY_RULE(int) yy_MINUS(GREG *G)
 YY_RULE(int) yy_Product(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Product"));
 
-  {  int yypos246= G->pos, yythunkpos246= G->thunkpos;  if (!yy_ProductLogicalNot(G))  goto l247;
-  goto l246;
-  l247:;	  G->pos= yypos246; G->thunkpos= yythunkpos246;  if (!yy_ProductBinaryNot(G))  goto l248;
-  goto l246;
-  l248:;	  G->pos= yypos246; G->thunkpos= yythunkpos246;  if (!yy_ProductCore(G))  goto l245;
+  {  int yypos254= G->pos, yythunkpos254= G->thunkpos;  if (!yy_ProductLogicalNot(G))  goto l255;
+  goto l254;
+  l255:;	  G->pos= yypos254; G->thunkpos= yythunkpos254;  if (!yy_ProductBinaryNot(G))  goto l256;
+  goto l254;
+  l256:;	  G->pos= yypos254; G->thunkpos= yythunkpos254;  if (!yy_ProductCore(G))  goto l253;
 
   }
-  l246:;	  yyprintf((stderr, "  ok   Product"));
+  l254:;	  yyprintf((stderr, "  ok   Product"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l245:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Product"));
+  l253:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Product"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8249,18 +8301,18 @@ YY_RULE(int) yy_Product(GREG *G)
 }
 YY_RULE(int) yy_B_RSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_RSHIFT"));
-  if (!yymatchString(G, ">>")) goto l249;
+  if (!yymatchString(G, ">>")) goto l257;
 
-  {  int yypos250= G->pos, yythunkpos250= G->thunkpos;  if (!yymatchChar(G, '=')) goto l250;
-  goto l249;
-  l250:;	  G->pos= yypos250; G->thunkpos= yythunkpos250;
-  }  if (!yy__(G))  goto l249;
+  {  int yypos258= G->pos, yythunkpos258= G->thunkpos;  if (!yymatchChar(G, '=')) goto l258;
+  goto l257;
+  l258:;	  G->pos= yypos258; G->thunkpos= yythunkpos258;
+  }  if (!yy__(G))  goto l257;
   yyprintf((stderr, "  ok   B_RSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l249:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_RSHIFT"));
+  l257:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_RSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8268,18 +8320,18 @@ YY_RULE(int) yy_B_RSHIFT(GREG *G)
 }
 YY_RULE(int) yy_B_LSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_LSHIFT"));
-  if (!yymatchString(G, "<<")) goto l251;
+  if (!yymatchString(G, "<<")) goto l259;
 
-  {  int yypos252= G->pos, yythunkpos252= G->thunkpos;  if (!yymatchChar(G, '=')) goto l252;
-  goto l251;
-  l252:;	  G->pos= yypos252; G->thunkpos= yythunkpos252;
-  }  if (!yy__(G))  goto l251;
+  {  int yypos260= G->pos, yythunkpos260= G->thunkpos;  if (!yymatchChar(G, '=')) goto l260;
+  goto l259;
+  l260:;	  G->pos= yypos260; G->thunkpos= yythunkpos260;
+  }  if (!yy__(G))  goto l259;
   yyprintf((stderr, "  ok   B_LSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l251:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_LSHIFT"));
+  l259:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_LSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8288,41 +8340,41 @@ YY_RULE(int) yy_B_LSHIFT(GREG *G)
 YY_RULE(int) yy_Sum(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Sum"));
-  if (!yy_Product(G))  goto l253;
+  if (!yy_Product(G))  goto l261;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l254:;	
-  {  int yypos255= G->pos, yythunkpos255= G->thunkpos;
-  {  int yypos256= G->pos, yythunkpos256= G->thunkpos;  if (!yy_PLUS(G))  goto l257;
+  l262:;	
+  {  int yypos263= G->pos, yythunkpos263= G->thunkpos;
+  {  int yypos264= G->pos, yythunkpos264= G->thunkpos;  if (!yy_PLUS(G))  goto l265;
   yyDo(G, yy_1_Sum, G->begin, G->end, "yy_1_Sum");
-  if (!yy_WS(G))  goto l257;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+") ; } goto l257; }
+  if (!yy_WS(G))  goto l265;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+") ; } goto l265; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Sum, G->begin, G->end, "yy_2_Sum");
-  goto l256;
-  l257:;	  G->pos= yypos256; G->thunkpos= yythunkpos256;  if (!yy_MINUS(G))  goto l258;
+  goto l264;
+  l265:;	  G->pos= yypos264; G->thunkpos= yythunkpos264;  if (!yy_MINUS(G))  goto l266;
   yyDo(G, yy_3_Sum, G->begin, G->end, "yy_3_Sum");
-  if (!yy_WS(G))  goto l258;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-") ; } goto l258; }
+  if (!yy_WS(G))  goto l266;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-") ; } goto l266; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Sum, G->begin, G->end, "yy_4_Sum");
-  goto l256;
-  l258:;	  G->pos= yypos256; G->thunkpos= yythunkpos256;  if (!yy_PERCENT(G))  goto l255;
+  goto l264;
+  l266:;	  G->pos= yypos264; G->thunkpos= yythunkpos264;  if (!yy_PERCENT(G))  goto l263;
   yyDo(G, yy_5_Sum, G->begin, G->end, "yy_5_Sum");
-  if (!yy_WS(G))  goto l255;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%") ; } goto l255; }
+  if (!yy_WS(G))  goto l263;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%") ; } goto l263; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Sum, G->begin, G->end, "yy_6_Sum");
 
   }
-  l256:;	  goto l254;
-  l255:;	  G->pos= yypos255; G->thunkpos= yythunkpos255;
+  l264:;	  goto l262;
+  l263:;	  G->pos= yypos263; G->thunkpos= yythunkpos263;
   }  yyprintf((stderr, "  ok   Sum"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l253:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Sum"));
+  l261:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Sum"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8330,14 +8382,14 @@ YY_RULE(int) yy_Sum(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_DOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_DOT"));
-  if (!yymatchString(G, "..")) goto l259;
-  if (!yy__(G))  goto l259;
+  if (!yymatchString(G, "..")) goto l267;
+  if (!yy__(G))  goto l267;
   yyprintf((stderr, "  ok   DOUBLE_DOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l259:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_DOT"));
+  l267:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_DOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8346,34 +8398,34 @@ YY_RULE(int) yy_DOUBLE_DOT(GREG *G)
 YY_RULE(int) yy_Shift(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Shift"));
-  if (!yy_Sum(G))  goto l260;
+  if (!yy_Sum(G))  goto l268;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l261:;	
-  {  int yypos262= G->pos, yythunkpos262= G->thunkpos;
-  {  int yypos263= G->pos, yythunkpos263= G->thunkpos;  if (!yy_B_LSHIFT(G))  goto l264;
+  l269:;	
+  {  int yypos270= G->pos, yythunkpos270= G->thunkpos;
+  {  int yypos271= G->pos, yythunkpos271= G->thunkpos;  if (!yy_B_LSHIFT(G))  goto l272;
   yyDo(G, yy_1_Shift, G->begin, G->end, "yy_1_Shift");
-  if (!yy_WS(G))  goto l264;
-  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<") ; } goto l264; }
+  if (!yy_WS(G))  goto l272;
+  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<") ; } goto l272; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Shift, G->begin, G->end, "yy_2_Shift");
-  goto l263;
-  l264:;	  G->pos= yypos263; G->thunkpos= yythunkpos263;  if (!yy_B_RSHIFT(G))  goto l262;
+  goto l271;
+  l272:;	  G->pos= yypos271; G->thunkpos= yythunkpos271;  if (!yy_B_RSHIFT(G))  goto l270;
   yyDo(G, yy_3_Shift, G->begin, G->end, "yy_3_Shift");
-  if (!yy_WS(G))  goto l262;
-  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>") ; } goto l262; }
+  if (!yy_WS(G))  goto l270;
+  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>") ; } goto l270; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Shift, G->begin, G->end, "yy_4_Shift");
 
   }
-  l263:;	  goto l261;
-  l262:;	  G->pos= yypos262; G->thunkpos= yythunkpos262;
+  l271:;	  goto l269;
+  l270:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;
   }  yyprintf((stderr, "  ok   Shift"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l260:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Shift"));
+  l268:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Shift"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8381,14 +8433,14 @@ YY_RULE(int) yy_Shift(GREG *G)
 }
 YY_RULE(int) yy_MORETHAN_EQ(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MORETHAN_EQ"));
-  if (!yymatchString(G, ">=")) goto l265;
-  if (!yy__(G))  goto l265;
+  if (!yymatchString(G, ">=")) goto l273;
+  if (!yy__(G))  goto l273;
   yyprintf((stderr, "  ok   MORETHAN_EQ"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l265:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN_EQ"));
+  l273:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN_EQ"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8396,14 +8448,14 @@ YY_RULE(int) yy_MORETHAN_EQ(GREG *G)
 }
 YY_RULE(int) yy_LESSTHAN_EQ(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "LESSTHAN_EQ"));
-  if (!yymatchString(G, "<=")) goto l266;
-  if (!yy__(G))  goto l266;
+  if (!yymatchString(G, "<=")) goto l274;
+  if (!yy__(G))  goto l274;
   yyprintf((stderr, "  ok   LESSTHAN_EQ"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l266:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN_EQ"));
+  l274:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN_EQ"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8411,14 +8463,14 @@ YY_RULE(int) yy_LESSTHAN_EQ(GREG *G)
 }
 YY_RULE(int) yy_CMP(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CMP"));
-  if (!yymatchString(G, "<=>")) goto l267;
-  if (!yy__(G))  goto l267;
+  if (!yymatchString(G, "<=>")) goto l275;
+  if (!yy__(G))  goto l275;
   yyprintf((stderr, "  ok   CMP"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l267:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CMP"));
+  l275:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CMP"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8427,24 +8479,24 @@ YY_RULE(int) yy_CMP(GREG *G)
 YY_RULE(int) yy_Range(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Range"));
-  if (!yy_Shift(G))  goto l268;
+  if (!yy_Shift(G))  goto l276;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l269:;	
-  {  int yypos270= G->pos, yythunkpos270= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l270;
+  l277:;	
+  {  int yypos278= G->pos, yythunkpos278= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l278;
   yyDo(G, yy_1_Range, G->begin, G->end, "yy_1_Range");
-  if (!yy_WS(G))  goto l270;
-  if (!yy_Shift(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("..") ; } goto l270; }
+  if (!yy_WS(G))  goto l278;
+  if (!yy_Shift(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("..") ; } goto l278; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Range, G->begin, G->end, "yy_2_Range");
-  goto l269;
-  l270:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;
+  goto l277;
+  l278:;	  G->pos= yypos278; G->thunkpos= yythunkpos278;
   }  yyprintf((stderr, "  ok   Range"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l268:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Range"));
+  l276:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Range"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8452,14 +8504,14 @@ YY_RULE(int) yy_Range(GREG *G)
 }
 YY_RULE(int) yy_NOT_EQUALS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "NOT_EQUALS"));
-  if (!yymatchString(G, "!=")) goto l271;
-  if (!yy__(G))  goto l271;
+  if (!yymatchString(G, "!=")) goto l279;
+  if (!yy__(G))  goto l279;
   yyprintf((stderr, "  ok   NOT_EQUALS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l271:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NOT_EQUALS"));
+  l279:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NOT_EQUALS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8467,14 +8519,14 @@ YY_RULE(int) yy_NOT_EQUALS(GREG *G)
 }
 YY_RULE(int) yy_EQUALS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EQUALS"));
-  if (!yymatchString(G, "==")) goto l272;
-  if (!yy__(G))  goto l272;
+  if (!yymatchString(G, "==")) goto l280;
+  if (!yy__(G))  goto l280;
   yyprintf((stderr, "  ok   EQUALS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l272:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EQUALS"));
+  l280:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EQUALS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8483,55 +8535,55 @@ YY_RULE(int) yy_EQUALS(GREG *G)
 YY_RULE(int) yy_Inequality(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Inequality"));
-  if (!yy_Range(G))  goto l273;
+  if (!yy_Range(G))  goto l281;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l274:;	
-  {  int yypos275= G->pos, yythunkpos275= G->thunkpos;
-  {  int yypos276= G->pos, yythunkpos276= G->thunkpos;  if (!yy_LESSTHAN(G))  goto l277;
+  l282:;	
+  {  int yypos283= G->pos, yythunkpos283= G->thunkpos;
+  {  int yypos284= G->pos, yythunkpos284= G->thunkpos;  if (!yy_LESSTHAN(G))  goto l285;
   yyDo(G, yy_1_Inequality, G->begin, G->end, "yy_1_Inequality");
-  if (!yy_WS(G))  goto l277;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<") ; } goto l277; }
+  if (!yy_WS(G))  goto l285;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<") ; } goto l285; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Inequality, G->begin, G->end, "yy_2_Inequality");
-  goto l276;
-  l277:;	  G->pos= yypos276; G->thunkpos= yythunkpos276;  if (!yy_MORETHAN(G))  goto l278;
+  goto l284;
+  l285:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;  if (!yy_MORETHAN(G))  goto l286;
   yyDo(G, yy_3_Inequality, G->begin, G->end, "yy_3_Inequality");
-  if (!yy_WS(G))  goto l278;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">") ; } goto l278; }
+  if (!yy_WS(G))  goto l286;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">") ; } goto l286; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Inequality, G->begin, G->end, "yy_4_Inequality");
-  goto l276;
-  l278:;	  G->pos= yypos276; G->thunkpos= yythunkpos276;  if (!yy_CMP(G))  goto l279;
+  goto l284;
+  l286:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;  if (!yy_CMP(G))  goto l287;
   yyDo(G, yy_5_Inequality, G->begin, G->end, "yy_5_Inequality");
-  if (!yy_WS(G))  goto l279;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=>") ; } goto l279; }
+  if (!yy_WS(G))  goto l287;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=>") ; } goto l287; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Inequality, G->begin, G->end, "yy_6_Inequality");
-  goto l276;
-  l279:;	  G->pos= yypos276; G->thunkpos= yythunkpos276;  if (!yy_LESSTHAN_EQ(G))  goto l280;
+  goto l284;
+  l287:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;  if (!yy_LESSTHAN_EQ(G))  goto l288;
   yyDo(G, yy_7_Inequality, G->begin, G->end, "yy_7_Inequality");
-  if (!yy_WS(G))  goto l280;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=") ; } goto l280; }
+  if (!yy_WS(G))  goto l288;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=") ; } goto l288; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Inequality, G->begin, G->end, "yy_8_Inequality");
-  goto l276;
-  l280:;	  G->pos= yypos276; G->thunkpos= yythunkpos276;  if (!yy_MORETHAN_EQ(G))  goto l275;
+  goto l284;
+  l288:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;  if (!yy_MORETHAN_EQ(G))  goto l283;
   yyDo(G, yy_9_Inequality, G->begin, G->end, "yy_9_Inequality");
-  if (!yy_WS(G))  goto l275;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">=") ; } goto l275; }
+  if (!yy_WS(G))  goto l283;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">=") ; } goto l283; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_Inequality, G->begin, G->end, "yy_10_Inequality");
 
   }
-  l276:;	  goto l274;
-  l275:;	  G->pos= yypos275; G->thunkpos= yythunkpos275;
+  l284:;	  goto l282;
+  l283:;	  G->pos= yypos283; G->thunkpos= yythunkpos283;
   }  yyprintf((stderr, "  ok   Inequality"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l273:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Inequality"));
+  l281:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Inequality"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8540,21 +8592,21 @@ YY_RULE(int) yy_Inequality(GREG *G)
 YY_RULE(int) yy_B_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_AND"));
 
-  {  int yypos282= G->pos, yythunkpos282= G->thunkpos;  if (!yy_L_AND(G))  goto l282;
-  goto l281;
-  l282:;	  G->pos= yypos282; G->thunkpos= yythunkpos282;
-  }  if (!yymatchChar(G, '&')) goto l281;
+  {  int yypos290= G->pos, yythunkpos290= G->thunkpos;  if (!yy_L_AND(G))  goto l290;
+  goto l289;
+  l290:;	  G->pos= yypos290; G->thunkpos= yythunkpos290;
+  }  if (!yymatchChar(G, '&')) goto l289;
 
-  {  int yypos283= G->pos, yythunkpos283= G->thunkpos;  if (!yymatchChar(G, '=')) goto l283;
-  goto l281;
-  l283:;	  G->pos= yypos283; G->thunkpos= yythunkpos283;
-  }  if (!yy__(G))  goto l281;
+  {  int yypos291= G->pos, yythunkpos291= G->thunkpos;  if (!yymatchChar(G, '=')) goto l291;
+  goto l289;
+  l291:;	  G->pos= yypos291; G->thunkpos= yythunkpos291;
+  }  if (!yy__(G))  goto l289;
   yyprintf((stderr, "  ok   B_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l281:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_AND"));
+  l289:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8563,34 +8615,34 @@ YY_RULE(int) yy_B_AND(GREG *G)
 YY_RULE(int) yy_Equality(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Equality"));
-  if (!yy_Inequality(G))  goto l284;
+  if (!yy_Inequality(G))  goto l292;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l285:;	
-  {  int yypos286= G->pos, yythunkpos286= G->thunkpos;
-  {  int yypos287= G->pos, yythunkpos287= G->thunkpos;  if (!yy_EQUALS(G))  goto l288;
+  l293:;	
+  {  int yypos294= G->pos, yythunkpos294= G->thunkpos;
+  {  int yypos295= G->pos, yythunkpos295= G->thunkpos;  if (!yy_EQUALS(G))  goto l296;
   yyDo(G, yy_1_Equality, G->begin, G->end, "yy_1_Equality");
-  if (!yy_WS(G))  goto l288;
-  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("==") ; } goto l288; }
+  if (!yy_WS(G))  goto l296;
+  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("==") ; } goto l296; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Equality, G->begin, G->end, "yy_2_Equality");
-  goto l287;
-  l288:;	  G->pos= yypos287; G->thunkpos= yythunkpos287;  if (!yy_NOT_EQUALS(G))  goto l286;
+  goto l295;
+  l296:;	  G->pos= yypos295; G->thunkpos= yythunkpos295;  if (!yy_NOT_EQUALS(G))  goto l294;
   yyDo(G, yy_3_Equality, G->begin, G->end, "yy_3_Equality");
-  if (!yy_WS(G))  goto l286;
-  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("!=") ; } goto l286; }
+  if (!yy_WS(G))  goto l294;
+  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("!=") ; } goto l294; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Equality, G->begin, G->end, "yy_4_Equality");
 
   }
-  l287:;	  goto l285;
-  l286:;	  G->pos= yypos286; G->thunkpos= yythunkpos286;
+  l295:;	  goto l293;
+  l294:;	  G->pos= yypos294; G->thunkpos= yythunkpos294;
   }  yyprintf((stderr, "  ok   Equality"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l284:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Equality"));
+  l292:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Equality"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8598,18 +8650,18 @@ YY_RULE(int) yy_Equality(GREG *G)
 }
 YY_RULE(int) yy_B_XOR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_XOR"));
-  if (!yymatchChar(G, '^')) goto l289;
+  if (!yymatchChar(G, '^')) goto l297;
 
-  {  int yypos290= G->pos, yythunkpos290= G->thunkpos;  if (!yymatchChar(G, '=')) goto l290;
-  goto l289;
-  l290:;	  G->pos= yypos290; G->thunkpos= yythunkpos290;
-  }  if (!yy__(G))  goto l289;
+  {  int yypos298= G->pos, yythunkpos298= G->thunkpos;  if (!yymatchChar(G, '=')) goto l298;
+  goto l297;
+  l298:;	  G->pos= yypos298; G->thunkpos= yythunkpos298;
+  }  if (!yy__(G))  goto l297;
   yyprintf((stderr, "  ok   B_XOR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l289:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_XOR"));
+  l297:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_XOR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8618,24 +8670,24 @@ YY_RULE(int) yy_B_XOR(GREG *G)
 YY_RULE(int) yy_BinaryAnd(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryAnd"));
-  if (!yy_Equality(G))  goto l291;
+  if (!yy_Equality(G))  goto l299;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l292:;	
-  {  int yypos293= G->pos, yythunkpos293= G->thunkpos;  if (!yy_B_AND(G))  goto l293;
+  l300:;	
+  {  int yypos301= G->pos, yythunkpos301= G->thunkpos;  if (!yy_B_AND(G))  goto l301;
   yyDo(G, yy_1_BinaryAnd, G->begin, G->end, "yy_1_BinaryAnd");
-  if (!yy_WS(G))  goto l293;
-  if (!yy_Equality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&") ; } goto l293; }
+  if (!yy_WS(G))  goto l301;
+  if (!yy_Equality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&") ; } goto l301; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryAnd, G->begin, G->end, "yy_2_BinaryAnd");
-  goto l292;
-  l293:;	  G->pos= yypos293; G->thunkpos= yythunkpos293;
+  goto l300;
+  l301:;	  G->pos= yypos301; G->thunkpos= yythunkpos301;
   }  yyprintf((stderr, "  ok   BinaryAnd"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l291:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryAnd"));
+  l299:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryAnd"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8644,21 +8696,21 @@ YY_RULE(int) yy_BinaryAnd(GREG *G)
 YY_RULE(int) yy_B_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_OR"));
 
-  {  int yypos295= G->pos, yythunkpos295= G->thunkpos;  if (!yy_L_OR(G))  goto l295;
-  goto l294;
-  l295:;	  G->pos= yypos295; G->thunkpos= yythunkpos295;
-  }  if (!yymatchChar(G, '|')) goto l294;
+  {  int yypos303= G->pos, yythunkpos303= G->thunkpos;  if (!yy_L_OR(G))  goto l303;
+  goto l302;
+  l303:;	  G->pos= yypos303; G->thunkpos= yythunkpos303;
+  }  if (!yymatchChar(G, '|')) goto l302;
 
-  {  int yypos296= G->pos, yythunkpos296= G->thunkpos;  if (!yymatchChar(G, '=')) goto l296;
-  goto l294;
-  l296:;	  G->pos= yypos296; G->thunkpos= yythunkpos296;
-  }  if (!yy__(G))  goto l294;
+  {  int yypos304= G->pos, yythunkpos304= G->thunkpos;  if (!yymatchChar(G, '=')) goto l304;
+  goto l302;
+  l304:;	  G->pos= yypos304; G->thunkpos= yythunkpos304;
+  }  if (!yy__(G))  goto l302;
   yyprintf((stderr, "  ok   B_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l294:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_OR"));
+  l302:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8667,24 +8719,24 @@ YY_RULE(int) yy_B_OR(GREG *G)
 YY_RULE(int) yy_BinaryXor(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryXor"));
-  if (!yy_BinaryAnd(G))  goto l297;
+  if (!yy_BinaryAnd(G))  goto l305;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l298:;	
-  {  int yypos299= G->pos, yythunkpos299= G->thunkpos;  if (!yy_B_XOR(G))  goto l299;
+  l306:;	
+  {  int yypos307= G->pos, yythunkpos307= G->thunkpos;  if (!yy_B_XOR(G))  goto l307;
   yyDo(G, yy_1_BinaryXor, G->begin, G->end, "yy_1_BinaryXor");
-  if (!yy_WS(G))  goto l299;
-  if (!yy_BinaryAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^") ; } goto l299; }
+  if (!yy_WS(G))  goto l307;
+  if (!yy_BinaryAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^") ; } goto l307; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryXor, G->begin, G->end, "yy_2_BinaryXor");
-  goto l298;
-  l299:;	  G->pos= yypos299; G->thunkpos= yythunkpos299;
+  goto l306;
+  l307:;	  G->pos= yypos307; G->thunkpos= yythunkpos307;
   }  yyprintf((stderr, "  ok   BinaryXor"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l297:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryXor"));
+  l305:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryXor"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8692,14 +8744,14 @@ YY_RULE(int) yy_BinaryXor(GREG *G)
 }
 YY_RULE(int) yy_L_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_AND"));
-  if (!yymatchString(G, "&&")) goto l300;
-  if (!yy__(G))  goto l300;
+  if (!yymatchString(G, "&&")) goto l308;
+  if (!yy__(G))  goto l308;
   yyprintf((stderr, "  ok   L_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l300:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_AND"));
+  l308:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8708,24 +8760,24 @@ YY_RULE(int) yy_L_AND(GREG *G)
 YY_RULE(int) yy_BinaryOr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryOr"));
-  if (!yy_BinaryXor(G))  goto l301;
+  if (!yy_BinaryXor(G))  goto l309;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l302:;	
-  {  int yypos303= G->pos, yythunkpos303= G->thunkpos;  if (!yy_B_OR(G))  goto l303;
+  l310:;	
+  {  int yypos311= G->pos, yythunkpos311= G->thunkpos;  if (!yy_B_OR(G))  goto l311;
   yyDo(G, yy_1_BinaryOr, G->begin, G->end, "yy_1_BinaryOr");
-  if (!yy_WS(G))  goto l303;
-  if (!yy_BinaryXor(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|") ; } goto l303; }
+  if (!yy_WS(G))  goto l311;
+  if (!yy_BinaryXor(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|") ; } goto l311; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryOr, G->begin, G->end, "yy_2_BinaryOr");
-  goto l302;
-  l303:;	  G->pos= yypos303; G->thunkpos= yythunkpos303;
+  goto l310;
+  l311:;	  G->pos= yypos311; G->thunkpos= yythunkpos311;
   }  yyprintf((stderr, "  ok   BinaryOr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l301:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOr"));
+  l309:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8733,14 +8785,14 @@ YY_RULE(int) yy_BinaryOr(GREG *G)
 }
 YY_RULE(int) yy_L_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_OR"));
-  if (!yymatchString(G, "||")) goto l304;
-  if (!yy__(G))  goto l304;
+  if (!yymatchString(G, "||")) goto l312;
+  if (!yy__(G))  goto l312;
   yyprintf((stderr, "  ok   L_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l304:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_OR"));
+  l312:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8749,24 +8801,24 @@ YY_RULE(int) yy_L_OR(GREG *G)
 YY_RULE(int) yy_LogicalAnd(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "LogicalAnd"));
-  if (!yy_BinaryOr(G))  goto l305;
+  if (!yy_BinaryOr(G))  goto l313;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l306:;	
-  {  int yypos307= G->pos, yythunkpos307= G->thunkpos;  if (!yy_L_AND(G))  goto l307;
+  l314:;	
+  {  int yypos315= G->pos, yythunkpos315= G->thunkpos;  if (!yy_L_AND(G))  goto l315;
   yyDo(G, yy_1_LogicalAnd, G->begin, G->end, "yy_1_LogicalAnd");
-  if (!yy_WS(G))  goto l307;
-  if (!yy_BinaryOr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&&") ; } goto l307; }
+  if (!yy_WS(G))  goto l315;
+  if (!yy_BinaryOr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&&") ; } goto l315; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_LogicalAnd, G->begin, G->end, "yy_2_LogicalAnd");
-  goto l306;
-  l307:;	  G->pos= yypos307; G->thunkpos= yythunkpos307;
+  goto l314;
+  l315:;	  G->pos= yypos315; G->thunkpos= yythunkpos315;
   }  yyprintf((stderr, "  ok   LogicalAnd"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l305:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalAnd"));
+  l313:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalAnd"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8774,14 +8826,14 @@ YY_RULE(int) yy_LogicalAnd(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_QUEST(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_QUEST"));
-  if (!yymatchString(G, "??")) goto l308;
-  if (!yy__(G))  goto l308;
+  if (!yymatchString(G, "??")) goto l316;
+  if (!yy__(G))  goto l316;
   yyprintf((stderr, "  ok   DOUBLE_QUEST"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l308:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_QUEST"));
+  l316:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_QUEST"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8790,24 +8842,24 @@ YY_RULE(int) yy_DOUBLE_QUEST(GREG *G)
 YY_RULE(int) yy_LogicalOr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "LogicalOr"));
-  if (!yy_LogicalAnd(G))  goto l309;
+  if (!yy_LogicalAnd(G))  goto l317;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l310:;	
-  {  int yypos311= G->pos, yythunkpos311= G->thunkpos;  if (!yy_L_OR(G))  goto l311;
+  l318:;	
+  {  int yypos319= G->pos, yythunkpos319= G->thunkpos;  if (!yy_L_OR(G))  goto l319;
   yyDo(G, yy_1_LogicalOr, G->begin, G->end, "yy_1_LogicalOr");
-  if (!yy_WS(G))  goto l311;
-  if (!yy_LogicalAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("||") ; } goto l311; }
+  if (!yy_WS(G))  goto l319;
+  if (!yy_LogicalAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("||") ; } goto l319; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_LogicalOr, G->begin, G->end, "yy_2_LogicalOr");
-  goto l310;
-  l311:;	  G->pos= yypos311; G->thunkpos= yythunkpos311;
+  goto l318;
+  l319:;	  G->pos= yypos319; G->thunkpos= yythunkpos319;
   }  yyprintf((stderr, "  ok   LogicalOr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l309:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalOr"));
+  l317:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalOr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8815,14 +8867,14 @@ YY_RULE(int) yy_LogicalOr(GREG *G)
 }
 YY_RULE(int) yy_QUEST(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "QUEST"));
-  if (!yymatchChar(G, '?')) goto l312;
-  if (!yy__(G))  goto l312;
+  if (!yymatchChar(G, '?')) goto l320;
+  if (!yy__(G))  goto l320;
   yyprintf((stderr, "  ok   QUEST"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l312:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "QUEST"));
+  l320:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "QUEST"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8831,24 +8883,24 @@ YY_RULE(int) yy_QUEST(GREG *G)
 YY_RULE(int) yy_NullCoalescing(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "NullCoalescing"));
-  if (!yy_LogicalOr(G))  goto l313;
+  if (!yy_LogicalOr(G))  goto l321;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  {  int yypos314= G->pos, yythunkpos314= G->thunkpos;  if (!yy_DOUBLE_QUEST(G))  goto l314;
+  {  int yypos322= G->pos, yythunkpos322= G->thunkpos;  if (!yy_DOUBLE_QUEST(G))  goto l322;
   yyDo(G, yy_1_NullCoalescing, G->begin, G->end, "yy_1_NullCoalescing");
-  if (!yy_WS(G))  goto l314;
-  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("??") ; } goto l314; }
+  if (!yy_WS(G))  goto l322;
+  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("??") ; } goto l322; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_NullCoalescing, G->begin, G->end, "yy_2_NullCoalescing");
-  goto l315;
-  l314:;	  G->pos= yypos314; G->thunkpos= yythunkpos314;
+  goto l323;
+  l322:;	  G->pos= yypos322; G->thunkpos= yythunkpos322;
   }
-  l315:;	  yyprintf((stderr, "  ok   NullCoalescing"));
+  l323:;	  yyprintf((stderr, "  ok   NullCoalescing"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l313:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NullCoalescing"));
+  l321:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NullCoalescing"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8856,14 +8908,14 @@ YY_RULE(int) yy_NullCoalescing(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_AND"));
-  if (!yymatchString(G, "&=")) goto l316;
-  if (!yy__(G))  goto l316;
+  if (!yymatchString(G, "&=")) goto l324;
+  if (!yy__(G))  goto l324;
   yyprintf((stderr, "  ok   ASS_B_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l316:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_AND"));
+  l324:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8871,14 +8923,14 @@ YY_RULE(int) yy_ASS_B_AND(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_OR"));
-  if (!yymatchString(G, "|=")) goto l317;
-  if (!yy__(G))  goto l317;
+  if (!yymatchString(G, "|=")) goto l325;
+  if (!yy__(G))  goto l325;
   yyprintf((stderr, "  ok   ASS_B_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l317:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_OR"));
+  l325:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8886,14 +8938,14 @@ YY_RULE(int) yy_ASS_B_OR(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_XOR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_XOR"));
-  if (!yymatchString(G, "^=")) goto l318;
-  if (!yy__(G))  goto l318;
+  if (!yymatchString(G, "^=")) goto l326;
+  if (!yy__(G))  goto l326;
   yyprintf((stderr, "  ok   ASS_B_XOR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l318:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_XOR"));
+  l326:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_XOR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8901,14 +8953,14 @@ YY_RULE(int) yy_ASS_B_XOR(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_RSHIFT"));
-  if (!yymatchString(G, ">>=")) goto l319;
-  if (!yy__(G))  goto l319;
+  if (!yymatchString(G, ">>=")) goto l327;
+  if (!yy__(G))  goto l327;
   yyprintf((stderr, "  ok   ASS_B_RSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l319:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_RSHIFT"));
+  l327:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_RSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8916,14 +8968,14 @@ YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_LSHIFT"));
-  if (!yymatchString(G, "<<=")) goto l320;
-  if (!yy__(G))  goto l320;
+  if (!yymatchString(G, "<<=")) goto l328;
+  if (!yy__(G))  goto l328;
   yyprintf((stderr, "  ok   ASS_B_LSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l320:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_LSHIFT"));
+  l328:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_LSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8931,14 +8983,14 @@ YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G)
 }
 YY_RULE(int) yy_ASS_DIV(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_DIV"));
-  if (!yymatchString(G, "/=")) goto l321;
-  if (!yy__(G))  goto l321;
+  if (!yymatchString(G, "/=")) goto l329;
+  if (!yy__(G))  goto l329;
   yyprintf((stderr, "  ok   ASS_DIV"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l321:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DIV"));
+  l329:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DIV"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8946,14 +8998,14 @@ YY_RULE(int) yy_ASS_DIV(GREG *G)
 }
 YY_RULE(int) yy_ASS_EXP(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_EXP"));
-  if (!yymatchString(G, "**=")) goto l322;
-  if (!yy__(G))  goto l322;
+  if (!yymatchString(G, "**=")) goto l330;
+  if (!yy__(G))  goto l330;
   yyprintf((stderr, "  ok   ASS_EXP"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l322:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_EXP"));
+  l330:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_EXP"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8961,14 +9013,14 @@ YY_RULE(int) yy_ASS_EXP(GREG *G)
 }
 YY_RULE(int) yy_ASS_MUL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_MUL"));
-  if (!yymatchString(G, "*=")) goto l323;
-  if (!yy__(G))  goto l323;
+  if (!yymatchString(G, "*=")) goto l331;
+  if (!yy__(G))  goto l331;
   yyprintf((stderr, "  ok   ASS_MUL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l323:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MUL"));
+  l331:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MUL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8976,14 +9028,14 @@ YY_RULE(int) yy_ASS_MUL(GREG *G)
 }
 YY_RULE(int) yy_ASS_SUB(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_SUB"));
-  if (!yymatchString(G, "-=")) goto l324;
-  if (!yy__(G))  goto l324;
+  if (!yymatchString(G, "-=")) goto l332;
+  if (!yy__(G))  goto l332;
   yyprintf((stderr, "  ok   ASS_SUB"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l324:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_SUB"));
+  l332:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_SUB"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8991,14 +9043,14 @@ YY_RULE(int) yy_ASS_SUB(GREG *G)
 }
 YY_RULE(int) yy_ASS_MOD(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_MOD"));
-  if (!yymatchString(G, "%=")) goto l325;
-  if (!yy__(G))  goto l325;
+  if (!yymatchString(G, "%=")) goto l333;
+  if (!yy__(G))  goto l333;
   yyprintf((stderr, "  ok   ASS_MOD"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l325:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MOD"));
+  l333:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MOD"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9006,14 +9058,14 @@ YY_RULE(int) yy_ASS_MOD(GREG *G)
 }
 YY_RULE(int) yy_ASS_ADD(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_ADD"));
-  if (!yymatchString(G, "+=")) goto l326;
-  if (!yy__(G))  goto l326;
+  if (!yymatchString(G, "+=")) goto l334;
+  if (!yy__(G))  goto l334;
   yyprintf((stderr, "  ok   ASS_ADD"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l326:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_ADD"));
+  l334:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_ADD"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9022,30 +9074,30 @@ YY_RULE(int) yy_ASS_ADD(GREG *G)
 YY_RULE(int) yy_Ternary(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Ternary"));
-  if (!yy_NullCoalescing(G))  goto l327;
+  if (!yy_NullCoalescing(G))  goto l335;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos328= G->pos, yythunkpos328= G->thunkpos;  if (!yy__(G))  goto l328;
-  if (!yy_QUEST(G))  goto l328;
+  {  int yypos336= G->pos, yythunkpos336= G->thunkpos;  if (!yy__(G))  goto l336;
+  if (!yy_QUEST(G))  goto l336;
   yyDo(G, yy_1_Ternary, G->begin, G->end, "yy_1_Ternary");
-  if (!yy_WS(G))  goto l328;
-  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_MALFORMED_TERNARY, "Expected expression between ? and : in ternary expression!\n") ; } goto l328; }
+  if (!yy_WS(G))  goto l336;
+  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_MALFORMED_TERNARY, "Expected expression between ? and : in ternary expression!\n") ; } goto l336; }
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l328;
-  if (!yy_COLON(G))  goto l328;
-  if (!yy_WS(G))  goto l328;
-  if (!yy_NullCoalescing(G))  goto l328;
+  if (!yy__(G))  goto l336;
+  if (!yy_COLON(G))  goto l336;
+  if (!yy_WS(G))  goto l336;
+  if (!yy_NullCoalescing(G))  goto l336;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Ternary, G->begin, G->end, "yy_2_Ternary");
-  goto l329;
-  l328:;	  G->pos= yypos328; G->thunkpos= yythunkpos328;
+  goto l337;
+  l336:;	  G->pos= yypos336; G->thunkpos= yythunkpos336;
   }
-  l329:;	  yyprintf((stderr, "  ok   Ternary"));
+  l337:;	  yyprintf((stderr, "  ok   Ternary"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l327:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Ternary"));
+  l335:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Ternary"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9054,111 +9106,111 @@ YY_RULE(int) yy_Ternary(GREG *G)
 YY_RULE(int) yy_Assignment(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Assignment"));
-  if (!yy_Ternary(G))  goto l330;
+  if (!yy_Ternary(G))  goto l338;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l331:;	
-  {  int yypos332= G->pos, yythunkpos332= G->thunkpos;
-  {  int yypos333= G->pos, yythunkpos333= G->thunkpos;  if (!yy_ASS(G))  goto l334;
+  l339:;	
+  {  int yypos340= G->pos, yythunkpos340= G->thunkpos;
+  {  int yypos341= G->pos, yythunkpos341= G->thunkpos;  if (!yy_ASS(G))  goto l342;
   yyDo(G, yy_1_Assignment, G->begin, G->end, "yy_1_Assignment");
-  if (!yy_WS(G))  goto l334;
-  if (!yy_Ternary(G))  goto l334;
+  if (!yy_WS(G))  goto l342;
+  if (!yy_Ternary(G))  goto l342;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Assignment, G->begin, G->end, "yy_2_Assignment");
-  goto l333;
-  l334:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS(G))  goto l335;
+  goto l341;
+  l342:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS(G))  goto l343;
   yyDo(G, yy_3_Assignment, G->begin, G->end, "yy_3_Assignment");
-  if (!yy_WS(G))  goto l335;
-  if (!yy_AnonymousFunctionDecl(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=") ; } goto l335; }
+  if (!yy_WS(G))  goto l343;
+  if (!yy_AnonymousFunctionDecl(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=") ; } goto l343; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Assignment, G->begin, G->end, "yy_4_Assignment");
-  goto l333;
-  l335:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_ADD(G))  goto l336;
+  goto l341;
+  l343:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_ADD(G))  goto l344;
   yyDo(G, yy_5_Assignment, G->begin, G->end, "yy_5_Assignment");
-  if (!yy_WS(G))  goto l336;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+=") ; } goto l336; }
+  if (!yy_WS(G))  goto l344;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+=") ; } goto l344; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Assignment, G->begin, G->end, "yy_6_Assignment");
-  goto l333;
-  l336:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_MOD(G))  goto l337;
+  goto l341;
+  l344:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_MOD(G))  goto l345;
   yyDo(G, yy_7_Assignment, G->begin, G->end, "yy_7_Assignment");
-  if (!yy_WS(G))  goto l337;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%=") ; } goto l337; }
+  if (!yy_WS(G))  goto l345;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%=") ; } goto l345; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Assignment, G->begin, G->end, "yy_8_Assignment");
-  goto l333;
-  l337:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_SUB(G))  goto l338;
+  goto l341;
+  l345:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_SUB(G))  goto l346;
   yyDo(G, yy_9_Assignment, G->begin, G->end, "yy_9_Assignment");
-  if (!yy_WS(G))  goto l338;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-=") ; } goto l338; }
+  if (!yy_WS(G))  goto l346;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-=") ; } goto l346; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_Assignment, G->begin, G->end, "yy_10_Assignment");
-  goto l333;
-  l338:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_MUL(G))  goto l339;
+  goto l341;
+  l346:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_MUL(G))  goto l347;
   yyDo(G, yy_11_Assignment, G->begin, G->end, "yy_11_Assignment");
-  if (!yy_WS(G))  goto l339;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("*=") ; } goto l339; }
+  if (!yy_WS(G))  goto l347;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("*=") ; } goto l347; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_12_Assignment, G->begin, G->end, "yy_12_Assignment");
-  goto l333;
-  l339:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_EXP(G))  goto l340;
+  goto l341;
+  l347:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_EXP(G))  goto l348;
   yyDo(G, yy_13_Assignment, G->begin, G->end, "yy_13_Assignment");
-  if (!yy_WS(G))  goto l340;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("**=") ; } goto l340; }
+  if (!yy_WS(G))  goto l348;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("**=") ; } goto l348; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_14_Assignment, G->begin, G->end, "yy_14_Assignment");
-  goto l333;
-  l340:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_DIV(G))  goto l341;
+  goto l341;
+  l348:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_DIV(G))  goto l349;
   yyDo(G, yy_15_Assignment, G->begin, G->end, "yy_15_Assignment");
-  if (!yy_WS(G))  goto l341;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("/=") ; } goto l341; }
+  if (!yy_WS(G))  goto l349;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("/=") ; } goto l349; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_16_Assignment, G->begin, G->end, "yy_16_Assignment");
-  goto l333;
-  l341:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_B_LSHIFT(G))  goto l342;
+  goto l341;
+  l349:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_B_LSHIFT(G))  goto l350;
   yyDo(G, yy_17_Assignment, G->begin, G->end, "yy_17_Assignment");
-  if (!yy_WS(G))  goto l342;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<=") ; } goto l342; }
+  if (!yy_WS(G))  goto l350;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<=") ; } goto l350; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_18_Assignment, G->begin, G->end, "yy_18_Assignment");
-  goto l333;
-  l342:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_B_RSHIFT(G))  goto l343;
+  goto l341;
+  l350:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_B_RSHIFT(G))  goto l351;
   yyDo(G, yy_19_Assignment, G->begin, G->end, "yy_19_Assignment");
-  if (!yy_WS(G))  goto l343;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>=") ; } goto l343; }
+  if (!yy_WS(G))  goto l351;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>=") ; } goto l351; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_20_Assignment, G->begin, G->end, "yy_20_Assignment");
-  goto l333;
-  l343:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_B_XOR(G))  goto l344;
+  goto l341;
+  l351:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_B_XOR(G))  goto l352;
   yyDo(G, yy_21_Assignment, G->begin, G->end, "yy_21_Assignment");
-  if (!yy_WS(G))  goto l344;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^=") ; } goto l344; }
+  if (!yy_WS(G))  goto l352;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^=") ; } goto l352; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_22_Assignment, G->begin, G->end, "yy_22_Assignment");
-  goto l333;
-  l344:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_B_OR(G))  goto l345;
+  goto l341;
+  l352:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_B_OR(G))  goto l353;
   yyDo(G, yy_23_Assignment, G->begin, G->end, "yy_23_Assignment");
-  if (!yy_WS(G))  goto l345;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|=") ; } goto l345; }
+  if (!yy_WS(G))  goto l353;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|=") ; } goto l353; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_24_Assignment, G->begin, G->end, "yy_24_Assignment");
-  goto l333;
-  l345:;	  G->pos= yypos333; G->thunkpos= yythunkpos333;  if (!yy_ASS_B_AND(G))  goto l332;
+  goto l341;
+  l353:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_B_AND(G))  goto l340;
   yyDo(G, yy_25_Assignment, G->begin, G->end, "yy_25_Assignment");
-  if (!yy_WS(G))  goto l332;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&=") ; } goto l332; }
+  if (!yy_WS(G))  goto l340;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&=") ; } goto l340; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_26_Assignment, G->begin, G->end, "yy_26_Assignment");
 
   }
-  l333:;	  goto l331;
-  l332:;	  G->pos= yypos332; G->thunkpos= yythunkpos332;
+  l341:;	  goto l339;
+  l340:;	  G->pos= yypos340; G->thunkpos= yythunkpos340;
   }  yyprintf((stderr, "  ok   Assignment"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l330:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Assignment"));
+  l338:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Assignment"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9167,17 +9219,17 @@ YY_RULE(int) yy_Assignment(GREG *G)
 YY_RULE(int) yy_FunctionCall(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionCall"));
-  if (!yy_IDENT(G))  goto l346;
+  if (!yy_IDENT(G))  goto l354;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_FunctionCall, G->begin, G->end, "yy_1_FunctionCall");
-  if (!yy_FunctionCallCore(G))  goto l346;
+  if (!yy_FunctionCallCore(G))  goto l354;
   yyDo(G, yy_2_FunctionCall, G->begin, G->end, "yy_2_FunctionCall");
   yyprintf((stderr, "  ok   FunctionCall"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l346:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionCall"));
+  l354:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionCall"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9185,13 +9237,13 @@ YY_RULE(int) yy_FunctionCall(GREG *G)
 }
 YY_RULE(int) yy_BinaryOperation(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "BinaryOperation"));
-  if (!yy_Assignment(G))  goto l347;
+  if (!yy_Assignment(G))  goto l355;
   yyprintf((stderr, "  ok   BinaryOperation"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l347:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOperation"));
+  l355:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOperation"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9200,12 +9252,12 @@ YY_RULE(int) yy_BinaryOperation(GREG *G)
 YY_RULE(int) yy_DoubleArrow(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "DoubleArrow"));
-  if (!yy_Assignment(G))  goto l348;
+  if (!yy_Assignment(G))  goto l356;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DOUBLE_ARROW(G))  goto l348;
+  if (!yy_DOUBLE_ARROW(G))  goto l356;
   yyDo(G, yy_1_DoubleArrow, G->begin, G->end, "yy_1_DoubleArrow");
-  if (!yy_WS(G))  goto l348;
-  if (!yy_Expr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=>") ; } goto l348; }
+  if (!yy_WS(G))  goto l356;
+  if (!yy_Expr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=>") ; } goto l356; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_DoubleArrow, G->begin, G->end, "yy_2_DoubleArrow");
   yyprintf((stderr, "  ok   DoubleArrow"));
@@ -9213,7 +9265,7 @@ YY_RULE(int) yy_DoubleArrow(GREG *G)
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l348:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DoubleArrow"));
+  l356:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DoubleArrow"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9221,13 +9273,13 @@ YY_RULE(int) yy_DoubleArrow(GREG *G)
 }
 YY_RULE(int) yy_RETURN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "RETURN_KW"));
-  if (!yymatchString(G, "return")) goto l349;
+  if (!yymatchString(G, "return")) goto l357;
   yyprintf((stderr, "  ok   RETURN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l349:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RETURN_KW"));
+  l357:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RETURN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9235,13 +9287,13 @@ YY_RULE(int) yy_RETURN_KW(GREG *G)
 }
 YY_RULE(int) yy_WHILE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "WHILE_KW"));
-  if (!yymatchString(G, "while")) goto l350;
+  if (!yymatchString(G, "while")) goto l358;
   yyprintf((stderr, "  ok   WHILE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l350:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "WHILE_KW"));
+  l358:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "WHILE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9249,13 +9301,13 @@ YY_RULE(int) yy_WHILE_KW(GREG *G)
 }
 YY_RULE(int) yy_IN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IN_KW"));
-  if (!yymatchString(G, "in")) goto l351;
+  if (!yymatchString(G, "in")) goto l359;
   yyprintf((stderr, "  ok   IN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l351:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IN_KW"));
+  l359:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9263,13 +9315,13 @@ YY_RULE(int) yy_IN_KW(GREG *G)
 }
 YY_RULE(int) yy_FOR_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FOR_KW"));
-  if (!yymatchString(G, "for")) goto l352;
+  if (!yymatchString(G, "for")) goto l360;
   yyprintf((stderr, "  ok   FOR_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l352:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FOR_KW"));
+  l360:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FOR_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9279,25 +9331,25 @@ YY_RULE(int) yy_ImplicitDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ImplicitDecl"));
 
-  {  int yypos354= G->pos, yythunkpos354= G->thunkpos;  if (!yy_VariableDecl(G))  goto l355;
+  {  int yypos362= G->pos, yythunkpos362= G->thunkpos;  if (!yy_VariableDecl(G))  goto l363;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_ImplicitDecl, G->begin, G->end, "yy_1_ImplicitDecl");
-  goto l354;
-  l355:;	  G->pos= yypos354; G->thunkpos= yythunkpos354;  if (!yy_Tuple(G))  goto l356;
+  goto l362;
+  l363:;	  G->pos= yypos362; G->thunkpos= yythunkpos362;  if (!yy_Tuple(G))  goto l364;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_ImplicitDecl, G->begin, G->end, "yy_2_ImplicitDecl");
-  goto l354;
-  l356:;	  G->pos= yypos354; G->thunkpos= yythunkpos354;  if (!yy_IDENT(G))  goto l353;
+  goto l362;
+  l364:;	  G->pos= yypos362; G->thunkpos= yythunkpos362;  if (!yy_IDENT(G))  goto l361;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_ImplicitDecl, G->begin, G->end, "yy_3_ImplicitDecl");
 
   }
-  l354:;	  yyprintf((stderr, "  ok   ImplicitDecl"));
+  l362:;	  yyprintf((stderr, "  ok   ImplicitDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l353:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImplicitDecl"));
+  l361:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImplicitDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9305,13 +9357,13 @@ YY_RULE(int) yy_ImplicitDecl(GREG *G)
 }
 YY_RULE(int) yy_CONTINUE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CONTINUE_KW"));
-  if (!yymatchString(G, "continue")) goto l357;
+  if (!yymatchString(G, "continue")) goto l365;
   yyprintf((stderr, "  ok   CONTINUE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l357:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONTINUE_KW"));
+  l365:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONTINUE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9319,13 +9371,13 @@ YY_RULE(int) yy_CONTINUE_KW(GREG *G)
 }
 YY_RULE(int) yy_BREAK_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "BREAK_KW"));
-  if (!yymatchString(G, "break")) goto l358;
+  if (!yymatchString(G, "break")) goto l366;
   yyprintf((stderr, "  ok   BREAK_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l358:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BREAK_KW"));
+  l366:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BREAK_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9333,14 +9385,14 @@ YY_RULE(int) yy_BREAK_KW(GREG *G)
 }
 YY_RULE(int) yy_Continue(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Continue"));
-  if (!yy_CONTINUE_KW(G))  goto l359;
+  if (!yy_CONTINUE_KW(G))  goto l367;
   yyDo(G, yy_1_Continue, G->begin, G->end, "yy_1_Continue");
   yyprintf((stderr, "  ok   Continue"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l359:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Continue"));
+  l367:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Continue"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9348,14 +9400,14 @@ YY_RULE(int) yy_Continue(GREG *G)
 }
 YY_RULE(int) yy_Break(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Break"));
-  if (!yy_BREAK_KW(G))  goto l360;
+  if (!yy_BREAK_KW(G))  goto l368;
   yyDo(G, yy_1_Break, G->begin, G->end, "yy_1_Break");
   yyprintf((stderr, "  ok   Break"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l360:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Break"));
+  l368:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Break"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9364,27 +9416,27 @@ YY_RULE(int) yy_Break(GREG *G)
 YY_RULE(int) yy_While(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "While"));
-  if (!yy_WHILE_KW(G))  goto l361;
+  if (!yy_WHILE_KW(G))  goto l369;
   yyDo(G, yy_1_While, G->begin, G->end, "yy_1_While");
-  if (!yy_WS(G))  goto l361;
-  if (!yymatchChar(G, '(')) goto l361;
-  if (!yy_WS(G))  goto l361;
-  if (!yy__(G))  goto l361;
-  if (!yy_Expr(G))  goto l361;
+  if (!yy_WS(G))  goto l369;
+  if (!yymatchChar(G, '(')) goto l369;
+  if (!yy_WS(G))  goto l369;
+  if (!yy__(G))  goto l369;
+  if (!yy_Expr(G))  goto l369;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l361;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed while! Expected ')' to close condition.\n"); ; } goto l361; }
+  if (!yy_WS(G))  goto l369;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed while! Expected ')' to close condition.\n"); ; } goto l369; }
   yyDo(G, yy_2_While, G->begin, G->end, "yy_2_While");
-  if (!yy__(G))  goto l361;
-  if (!yy_Body(G))  goto l361;
-  if (!yy__(G))  goto l361;
+  if (!yy__(G))  goto l369;
+  if (!yy_Body(G))  goto l369;
+  if (!yy__(G))  goto l369;
   yyDo(G, yy_3_While, G->begin, G->end, "yy_3_While");
   yyprintf((stderr, "  ok   While"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l361:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "While"));
+  l369:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "While"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9393,32 +9445,32 @@ YY_RULE(int) yy_While(GREG *G)
 YY_RULE(int) yy_Foreach(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Foreach"));
-  if (!yy_FOR_KW(G))  goto l362;
+  if (!yy_FOR_KW(G))  goto l370;
   yyDo(G, yy_1_Foreach, G->begin, G->end, "yy_1_Foreach");
-  if (!yy_WS(G))  goto l362;
-  if (!yymatchChar(G, '(')) goto l362;
-  if (!yy_WS(G))  goto l362;
-  if (!yy__(G))  goto l362;
-  if (!yy_ImplicitDecl(G))  goto l362;
+  if (!yy_WS(G))  goto l370;
+  if (!yymatchChar(G, '(')) goto l370;
+  if (!yy_WS(G))  goto l370;
+  if (!yy__(G))  goto l370;
+  if (!yy_ImplicitDecl(G))  goto l370;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l362;
-  if (!yy_IN_KW(G))  goto l362;
-  if (!yy__(G))  goto l362;
-  if (!yy_Expr(G))  goto l362;
+  if (!yy__(G))  goto l370;
+  if (!yy_IN_KW(G))  goto l370;
+  if (!yy__(G))  goto l370;
+  if (!yy_Expr(G))  goto l370;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l362;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed foreach, expected ')' to close condition!\n") ; } goto l362; }
+  if (!yy_WS(G))  goto l370;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed foreach, expected ')' to close condition!\n") ; } goto l370; }
   yyDo(G, yy_2_Foreach, G->begin, G->end, "yy_2_Foreach");
-  if (!yy__(G))  goto l362;
-  if (!yy_Body(G))  goto l362;
-  if (!yy__(G))  goto l362;
+  if (!yy__(G))  goto l370;
+  if (!yy_Body(G))  goto l370;
+  if (!yy__(G))  goto l370;
   yyDo(G, yy_3_Foreach, G->begin, G->end, "yy_3_Foreach");
   yyprintf((stderr, "  ok   Foreach"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l362:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Foreach"));
+  l370:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Foreach"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9426,13 +9478,13 @@ YY_RULE(int) yy_Foreach(GREG *G)
 }
 YY_RULE(int) yy_CATCH_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CATCH_KW"));
-  if (!yymatchString(G, "catch")) goto l363;
+  if (!yymatchString(G, "catch")) goto l371;
   yyprintf((stderr, "  ok   CATCH_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l363:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CATCH_KW"));
+  l371:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CATCH_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9441,36 +9493,36 @@ YY_RULE(int) yy_CATCH_KW(GREG *G)
 YY_RULE(int) yy_Catch(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Catch"));
-  if (!yy_CATCH_KW(G))  goto l364;
+  if (!yy_CATCH_KW(G))  goto l372;
   yyDo(G, yy_1_Catch, G->begin, G->end, "yy_1_Catch");
 
-  {  int yypos365= G->pos, yythunkpos365= G->thunkpos;  if (!yy__(G))  goto l365;
-  if (!yy_Expr(G))  goto l365;
+  {  int yypos373= G->pos, yythunkpos373= G->thunkpos;  if (!yy__(G))  goto l373;
+  if (!yy_Expr(G))  goto l373;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_Catch, G->begin, G->end, "yy_2_Catch");
-  goto l366;
-  l365:;	  G->pos= yypos365; G->thunkpos= yythunkpos365;
+  goto l374;
+  l373:;	  G->pos= yypos373; G->thunkpos= yythunkpos373;
   }
-  l366:;	  if (!yy_WS(G))  goto l364;
-  if (!yymatchChar(G, '{')) goto l364;
+  l374:;	  if (!yy_WS(G))  goto l372;
+  if (!yymatchChar(G, '{')) goto l372;
 
-  l367:;	
-  {  int yypos368= G->pos, yythunkpos368= G->thunkpos;  if (!yy_WS(G))  goto l368;
-  if (!yy_Stmt(G))  goto l368;
+  l375:;	
+  {  int yypos376= G->pos, yythunkpos376= G->thunkpos;  if (!yy_WS(G))  goto l376;
+  if (!yy_Stmt(G))  goto l376;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l368;
+  if (!yy_WS(G))  goto l376;
   yyDo(G, yy_3_Catch, G->begin, G->end, "yy_3_Catch");
-  goto l367;
-  l368:;	  G->pos= yypos368; G->thunkpos= yythunkpos368;
-  }  if (!yy_WS(G))  goto l364;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close catch block."); ; } goto l364; }
+  goto l375;
+  l376:;	  G->pos= yypos376; G->thunkpos= yythunkpos376;
+  }  if (!yy_WS(G))  goto l372;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close catch block."); ; } goto l372; }
   yyDo(G, yy_4_Catch, G->begin, G->end, "yy_4_Catch");
   yyprintf((stderr, "  ok   Catch"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l364:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Catch"));
+  l372:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Catch"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9478,13 +9530,13 @@ YY_RULE(int) yy_Catch(GREG *G)
 }
 YY_RULE(int) yy_TRY_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "TRY_KW"));
-  if (!yymatchString(G, "try")) goto l369;
+  if (!yymatchString(G, "try")) goto l377;
   yyprintf((stderr, "  ok   TRY_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l369:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TRY_KW"));
+  l377:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TRY_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9494,73 +9546,73 @@ YY_RULE(int) yy_Value(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Value"));
 
-  {  int yypos371= G->pos, yythunkpos371= G->thunkpos;  if (!yymatchChar(G, '-')) goto l372;
-  if (!yy__(G))  goto l372;
-  if (!yymatchChar(G, '(')) goto l372;
+  {  int yypos379= G->pos, yythunkpos379= G->thunkpos;  if (!yymatchChar(G, '-')) goto l380;
+  if (!yy__(G))  goto l380;
+  if (!yymatchChar(G, '(')) goto l380;
   yyDo(G, yy_1_Value, G->begin, G->end, "yy_1_Value");
-  if (!yy_WS(G))  goto l372;
-  if (!yy_Expr(G))  goto l372;
+  if (!yy_WS(G))  goto l380;
+  if (!yy_Expr(G))  goto l380;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l372;
-  if (!yymatchChar(G, ')')) goto l372;
+  if (!yy_WS(G))  goto l380;
+  if (!yymatchChar(G, ')')) goto l380;
   yyDo(G, yy_2_Value, G->begin, G->end, "yy_2_Value");
-  if (!yy__(G))  goto l372;
-  goto l371;
-  l372:;	  G->pos= yypos371; G->thunkpos= yythunkpos371;  if (!yymatchChar(G, '+')) goto l373;
-  if (!yy__(G))  goto l373;
-  if (!yymatchChar(G, '(')) goto l373;
+  if (!yy__(G))  goto l380;
+  goto l379;
+  l380:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;  if (!yymatchChar(G, '+')) goto l381;
+  if (!yy__(G))  goto l381;
+  if (!yymatchChar(G, '(')) goto l381;
   yyDo(G, yy_3_Value, G->begin, G->end, "yy_3_Value");
-  if (!yy_WS(G))  goto l373;
-  if (!yy_Expr(G))  goto l373;
+  if (!yy_WS(G))  goto l381;
+  if (!yy_Expr(G))  goto l381;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l373;
-  if (!yymatchChar(G, ')')) goto l373;
+  if (!yy_WS(G))  goto l381;
+  if (!yymatchChar(G, ')')) goto l381;
   yyDo(G, yy_4_Value, G->begin, G->end, "yy_4_Value");
-  if (!yy__(G))  goto l373;
-  goto l371;
-  l373:;	  G->pos= yypos371; G->thunkpos= yythunkpos371;  if (!yymatchChar(G, '-')) goto l374;
-  if (!yy__(G))  goto l374;
+  if (!yy__(G))  goto l381;
+  goto l379;
+  l381:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;  if (!yymatchChar(G, '-')) goto l382;
+  if (!yy__(G))  goto l382;
   yyDo(G, yy_5_Value, G->begin, G->end, "yy_5_Value");
-  if (!yy_SafeNavAccess(G))  goto l374;
+  if (!yy_SafeNavAccess(G))  goto l382;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Value, G->begin, G->end, "yy_6_Value");
-  goto l371;
-  l374:;	  G->pos= yypos371; G->thunkpos= yythunkpos371;  if (!yymatchChar(G, '+')) goto l375;
-  if (!yy__(G))  goto l375;
+  goto l379;
+  l382:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;  if (!yymatchChar(G, '+')) goto l383;
+  if (!yy__(G))  goto l383;
   yyDo(G, yy_7_Value, G->begin, G->end, "yy_7_Value");
-  if (!yy_SafeNavAccess(G))  goto l375;
+  if (!yy_SafeNavAccess(G))  goto l383;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Value, G->begin, G->end, "yy_8_Value");
-  goto l371;
-  l375:;	  G->pos= yypos371; G->thunkpos= yythunkpos371;  if (!yymatchChar(G, '(')) goto l376;
+  goto l379;
+  l383:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;  if (!yymatchChar(G, '(')) goto l384;
   yyDo(G, yy_9_Value, G->begin, G->end, "yy_9_Value");
-  if (!yy_WS(G))  goto l376;
-  if (!yy_Expr(G))  goto l376;
+  if (!yy_WS(G))  goto l384;
+  if (!yy_Expr(G))  goto l384;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l376;
-  if (!yymatchChar(G, ')')) goto l376;
+  if (!yy_WS(G))  goto l384;
+  if (!yymatchChar(G, ')')) goto l384;
   yyDo(G, yy_10_Value, G->begin, G->end, "yy_10_Value");
 
-  {  int yypos377= G->pos, yythunkpos377= G->thunkpos;  if (!yymatchChar(G, '&')) goto l377;
+  {  int yypos385= G->pos, yythunkpos385= G->thunkpos;  if (!yymatchChar(G, '&')) goto l385;
 
-  {  int yypos379= G->pos, yythunkpos379= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l379;
-  goto l377;
-  l379:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;
+  {  int yypos387= G->pos, yythunkpos387= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l387;
+  goto l385;
+  l387:;	  G->pos= yypos387; G->thunkpos= yythunkpos387;
   }  yyDo(G, yy_11_Value, G->begin, G->end, "yy_11_Value");
-  goto l378;
-  l377:;	  G->pos= yypos377; G->thunkpos= yythunkpos377;
+  goto l386;
+  l385:;	  G->pos= yypos385; G->thunkpos= yythunkpos385;
   }
-  l378:;	  if (!yy__(G))  goto l376;
-  goto l371;
-  l376:;	  G->pos= yypos371; G->thunkpos= yythunkpos371;  if (!yy_ValueCore(G))  goto l370;
+  l386:;	  if (!yy__(G))  goto l384;
+  goto l379;
+  l384:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;  if (!yy_ValueCore(G))  goto l378;
 
   }
-  l371:;	  yyprintf((stderr, "  ok   Value"));
+  l379:;	  yyprintf((stderr, "  ok   Value"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l370:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Value"));
+  l378:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Value"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9568,13 +9620,13 @@ YY_RULE(int) yy_Value(GREG *G)
 }
 YY_RULE(int) yy_MATCH_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MATCH_KW"));
-  if (!yymatchString(G, "match")) goto l380;
+  if (!yymatchString(G, "match")) goto l388;
   yyprintf((stderr, "  ok   MATCH_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l380:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MATCH_KW"));
+  l388:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MATCH_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9582,13 +9634,13 @@ YY_RULE(int) yy_MATCH_KW(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_ARROW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_ARROW"));
-  if (!yymatchString(G, "=>")) goto l381;
+  if (!yymatchString(G, "=>")) goto l389;
   yyprintf((stderr, "  ok   DOUBLE_ARROW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l381:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_ARROW"));
+  l389:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_ARROW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9598,40 +9650,40 @@ YY_RULE(int) yy_CaseExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "CaseExpr"));
 
-  {  int yypos383= G->pos, yythunkpos383= G->thunkpos;  if (!yy_VariableDecl(G))  goto l384;
+  {  int yypos391= G->pos, yythunkpos391= G->thunkpos;  if (!yy_VariableDecl(G))  goto l392;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l384;
-  goto l383;
-  l384:;	  G->pos= yypos383; G->thunkpos= yythunkpos383;  if (!yy_BinaryOperation(G))  goto l385;
+  if (!yy__(G))  goto l392;
+  goto l391;
+  l392:;	  G->pos= yypos391; G->thunkpos= yythunkpos391;  if (!yy_BinaryOperation(G))  goto l393;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l385;
+  if (!yy__(G))  goto l393;
 
-  l386:;	
-  {  int yypos387= G->pos, yythunkpos387= G->thunkpos;  if (!yy__(G))  goto l387;
-  if (!yymatchChar(G, '.')) goto l387;
+  l394:;	
+  {  int yypos395= G->pos, yythunkpos395= G->thunkpos;  if (!yy__(G))  goto l395;
+  if (!yymatchChar(G, '.')) goto l395;
   yyDo(G, yy_1_CaseExpr, G->begin, G->end, "yy_1_CaseExpr");
-  if (!yy_WS(G))  goto l387;
-  if (!yy_FunctionCall(G))  goto l387;
+  if (!yy_WS(G))  goto l395;
+  if (!yy_FunctionCall(G))  goto l395;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_CaseExpr, G->begin, G->end, "yy_2_CaseExpr");
-  goto l386;
-  l387:;	  G->pos= yypos387; G->thunkpos= yythunkpos387;
-  }  goto l383;
-  l385:;	  G->pos= yypos383; G->thunkpos= yythunkpos383;  if (!yy_AnonymousFunctionDecl(G))  goto l388;
-  goto l383;
-  l388:;	  G->pos= yypos383; G->thunkpos= yythunkpos383;  if (!yymatchChar(G, '(')) goto l382;
-  if (!yy__(G))  goto l382;
-  if (!yy_Expr(G))  goto l382;
-  if (!yy__(G))  goto l382;
-  if (!yymatchChar(G, ')')) goto l382;
+  goto l394;
+  l395:;	  G->pos= yypos395; G->thunkpos= yythunkpos395;
+  }  goto l391;
+  l393:;	  G->pos= yypos391; G->thunkpos= yythunkpos391;  if (!yy_AnonymousFunctionDecl(G))  goto l396;
+  goto l391;
+  l396:;	  G->pos= yypos391; G->thunkpos= yythunkpos391;  if (!yymatchChar(G, '(')) goto l390;
+  if (!yy__(G))  goto l390;
+  if (!yy_Expr(G))  goto l390;
+  if (!yy__(G))  goto l390;
+  if (!yymatchChar(G, ')')) goto l390;
 
   }
-  l383:;	  yyprintf((stderr, "  ok   CaseExpr"));
+  l391:;	  yyprintf((stderr, "  ok   CaseExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l382:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CaseExpr"));
+  l390:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CaseExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9639,13 +9691,13 @@ YY_RULE(int) yy_CaseExpr(GREG *G)
 }
 YY_RULE(int) yy_CASE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CASE_KW"));
-  if (!yymatchString(G, "case")) goto l389;
+  if (!yymatchString(G, "case")) goto l397;
   yyprintf((stderr, "  ok   CASE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l389:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CASE_KW"));
+  l397:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CASE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9654,35 +9706,35 @@ YY_RULE(int) yy_CASE_KW(GREG *G)
 YY_RULE(int) yy_Case(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Case"));
-  if (!yy_CASE_KW(G))  goto l390;
+  if (!yy_CASE_KW(G))  goto l398;
   yyDo(G, yy_1_Case, G->begin, G->end, "yy_1_Case");
 
-  {  int yypos391= G->pos, yythunkpos391= G->thunkpos;  if (!yy__(G))  goto l391;
-  if (!yy_CaseExpr(G))  goto l391;
+  {  int yypos399= G->pos, yythunkpos399= G->thunkpos;  if (!yy__(G))  goto l399;
+  if (!yy_CaseExpr(G))  goto l399;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_Case, G->begin, G->end, "yy_2_Case");
-  goto l392;
-  l391:;	  G->pos= yypos391; G->thunkpos= yythunkpos391;
+  goto l400;
+  l399:;	  G->pos= yypos399; G->thunkpos= yythunkpos399;
   }
-  l392:;	  if (!yy_WS(G))  goto l390;
-  if (!yy_DOUBLE_ARROW(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_DOUBLE_ARROW, "Expected double arrow after case expression!\n"); ; } goto l390; }
+  l400:;	  if (!yy_WS(G))  goto l398;
+  if (!yy_DOUBLE_ARROW(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_DOUBLE_ARROW, "Expected double arrow after case expression!\n"); ; } goto l398; }
 
-  l393:;	
-  {  int yypos394= G->pos, yythunkpos394= G->thunkpos;  if (!yy_WS(G))  goto l394;
-  if (!yy_Stmt(G))  goto l394;
+  l401:;	
+  {  int yypos402= G->pos, yythunkpos402= G->thunkpos;  if (!yy_WS(G))  goto l402;
+  if (!yy_Stmt(G))  goto l402;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_Case, G->begin, G->end, "yy_3_Case");
-  if (!yy_WS(G))  goto l394;
-  goto l393;
-  l394:;	  G->pos= yypos394; G->thunkpos= yythunkpos394;
-  }  if (!yy_WS(G))  goto l390;
+  if (!yy_WS(G))  goto l402;
+  goto l401;
+  l402:;	  G->pos= yypos402; G->thunkpos= yythunkpos402;
+  }  if (!yy_WS(G))  goto l398;
   yyDo(G, yy_4_Case, G->begin, G->end, "yy_4_Case");
   yyprintf((stderr, "  ok   Case"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l390:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Case"));
+  l398:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Case"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9690,13 +9742,13 @@ YY_RULE(int) yy_Case(GREG *G)
 }
 YY_RULE(int) yy_ELSE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ELSE_KW"));
-  if (!yymatchString(G, "else")) goto l395;
+  if (!yymatchString(G, "else")) goto l403;
   yyprintf((stderr, "  ok   ELSE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l395:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ELSE_KW"));
+  l403:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ELSE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9706,30 +9758,30 @@ YY_RULE(int) yy_Body(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Body"));
 
-  {  int yypos397= G->pos, yythunkpos397= G->thunkpos;  if (!yymatchChar(G, '{')) goto l398;
+  {  int yypos405= G->pos, yythunkpos405= G->thunkpos;  if (!yymatchChar(G, '{')) goto l406;
 
-  l399:;	
-  {  int yypos400= G->pos, yythunkpos400= G->thunkpos;  if (!yy_WS(G))  goto l400;
-  if (!yy_Stmt(G))  goto l400;
+  l407:;	
+  {  int yypos408= G->pos, yythunkpos408= G->thunkpos;  if (!yy_WS(G))  goto l408;
+  if (!yy_Stmt(G))  goto l408;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_Body, G->begin, G->end, "yy_1_Body");
-  if (!yy_WS(G))  goto l400;
-  goto l399;
-  l400:;	  G->pos= yypos400; G->thunkpos= yythunkpos400;
-  }  if (!yy_WS(G))  goto l398;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Expected statement or '"_CSBRACK"' to close body.!\n") ; } goto l398; }
-  goto l397;
-  l398:;	  G->pos= yypos397; G->thunkpos= yythunkpos397;  if (!yy_Stmt(G))  goto l396;
+  if (!yy_WS(G))  goto l408;
+  goto l407;
+  l408:;	  G->pos= yypos408; G->thunkpos= yythunkpos408;
+  }  if (!yy_WS(G))  goto l406;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Expected statement or '"_CSBRACK"' to close body.!\n") ; } goto l406; }
+  goto l405;
+  l406:;	  G->pos= yypos405; G->thunkpos= yythunkpos405;  if (!yy_Stmt(G))  goto l404;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Body, G->begin, G->end, "yy_2_Body");
 
   }
-  l397:;	  yyprintf((stderr, "  ok   Body"));
+  l405:;	  yyprintf((stderr, "  ok   Body"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l396:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Body"));
+  l404:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Body"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9737,13 +9789,13 @@ YY_RULE(int) yy_Body(GREG *G)
 }
 YY_RULE(int) yy_IF_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IF_KW"));
-  if (!yymatchString(G, "if")) goto l401;
+  if (!yymatchString(G, "if")) goto l409;
   yyprintf((stderr, "  ok   IF_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l401:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IF_KW"));
+  l409:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IF_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9751,18 +9803,18 @@ YY_RULE(int) yy_IF_KW(GREG *G)
 }
 YY_RULE(int) yy_Else(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Else"));
-  if (!yy_ELSE_KW(G))  goto l402;
+  if (!yy_ELSE_KW(G))  goto l410;
   yyDo(G, yy_1_Else, G->begin, G->end, "yy_1_Else");
   yyDo(G, yy_2_Else, G->begin, G->end, "yy_2_Else");
-  if (!yy__(G))  goto l402;
-  if (!yy_Body(G))  goto l402;
+  if (!yy__(G))  goto l410;
+  if (!yy_Body(G))  goto l410;
   yyDo(G, yy_3_Else, G->begin, G->end, "yy_3_Else");
   yyprintf((stderr, "  ok   Else"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l402:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Else"));
+  l410:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Else"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9771,26 +9823,26 @@ YY_RULE(int) yy_Else(GREG *G)
 YY_RULE(int) yy_If(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "If"));
-  if (!yy_IF_KW(G))  goto l403;
+  if (!yy_IF_KW(G))  goto l411;
   yyDo(G, yy_1_If, G->begin, G->end, "yy_1_If");
-  if (!yy_WS(G))  goto l403;
-  if (!yymatchChar(G, '(')) goto l403;
-  if (!yy_WS(G))  goto l403;
-  if (!yy__(G))  goto l403;
-  if (!yy_Expr(G))  goto l403;
+  if (!yy_WS(G))  goto l411;
+  if (!yymatchChar(G, '(')) goto l411;
+  if (!yy_WS(G))  goto l411;
+  if (!yy__(G))  goto l411;
+  if (!yy_Expr(G))  goto l411;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_If, G->begin, G->end, "yy_2_If");
-  if (!yy_WS(G))  goto l403;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected if condition or ')'.") ; } goto l403; }
-  if (!yy__(G))  goto l403;
-  if (!yy_Body(G))  goto l403;
+  if (!yy_WS(G))  goto l411;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected if condition or ')'.") ; } goto l411; }
+  if (!yy__(G))  goto l411;
+  if (!yy_Body(G))  goto l411;
   yyDo(G, yy_3_If, G->begin, G->end, "yy_3_If");
   yyprintf((stderr, "  ok   If"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l403:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "If"));
+  l411:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "If"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9800,31 +9852,31 @@ YY_RULE(int) yy_Return(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Return"));
 
-  {  int yypos405= G->pos, yythunkpos405= G->thunkpos;  if (!yy_RETURN_KW(G))  goto l406;
+  {  int yypos413= G->pos, yythunkpos413= G->thunkpos;  if (!yy_RETURN_KW(G))  goto l414;
 
-  {  int yypos407= G->pos, yythunkpos407= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l406;
-  G->pos= yypos407; G->thunkpos= yythunkpos407;
+  {  int yypos415= G->pos, yythunkpos415= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l414;
+  G->pos= yypos415; G->thunkpos= yythunkpos415;
   }  yyDo(G, yy_1_Return, G->begin, G->end, "yy_1_Return");
-  if (!yy__(G))  goto l406;
-  if (!yy_Expr(G))  goto l406;
+  if (!yy__(G))  goto l414;
+  if (!yy_Expr(G))  goto l414;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Return, G->begin, G->end, "yy_2_Return");
-  goto l405;
-  l406:;	  G->pos= yypos405; G->thunkpos= yythunkpos405;  if (!yy_RETURN_KW(G))  goto l404;
+  goto l413;
+  l414:;	  G->pos= yypos413; G->thunkpos= yythunkpos413;  if (!yy_RETURN_KW(G))  goto l412;
 
-  {  int yypos408= G->pos, yythunkpos408= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l404;
-  G->pos= yypos408; G->thunkpos= yythunkpos408;
+  {  int yypos416= G->pos, yythunkpos416= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l412;
+  G->pos= yypos416; G->thunkpos= yythunkpos416;
   }  yyDo(G, yy_3_Return, G->begin, G->end, "yy_3_Return");
-  if (!yy__(G))  goto l404;
+  if (!yy__(G))  goto l412;
   yyDo(G, yy_4_Return, G->begin, G->end, "yy_4_Return");
 
   }
-  l405:;	  yyprintf((stderr, "  ok   Return"));
+  l413:;	  yyprintf((stderr, "  ok   Return"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l404:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Return"));
+  l412:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Return"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9832,24 +9884,24 @@ YY_RULE(int) yy_Return(GREG *G)
 }
 YY_RULE(int) yy_Try(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Try"));
-  if (!yy_TRY_KW(G))  goto l409;
+  if (!yy_TRY_KW(G))  goto l417;
   yyDo(G, yy_1_Try, G->begin, G->end, "yy_1_Try");
-  if (!yy__(G))  goto l409;
-  if (!yy_Body(G))  goto l409;
+  if (!yy__(G))  goto l417;
+  if (!yy_Body(G))  goto l417;
 
-  l410:;	
-  {  int yypos411= G->pos, yythunkpos411= G->thunkpos;  if (!yy_WS(G))  goto l411;
-  if (!yy_Catch(G))  goto l411;
-  if (!yy_WS(G))  goto l411;
-  goto l410;
-  l411:;	  G->pos= yypos411; G->thunkpos= yythunkpos411;
+  l418:;	
+  {  int yypos419= G->pos, yythunkpos419= G->thunkpos;  if (!yy_WS(G))  goto l419;
+  if (!yy_Catch(G))  goto l419;
+  if (!yy_WS(G))  goto l419;
+  goto l418;
+  l419:;	  G->pos= yypos419; G->thunkpos= yythunkpos419;
   }  yyDo(G, yy_2_Try, G->begin, G->end, "yy_2_Try");
   yyprintf((stderr, "  ok   Try"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l409:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Try"));
+  l417:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Try"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9858,34 +9910,34 @@ YY_RULE(int) yy_Try(GREG *G)
 YY_RULE(int) yy_Match(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Match"));
-  if (!yy_MATCH_KW(G))  goto l412;
+  if (!yy_MATCH_KW(G))  goto l420;
   yyDo(G, yy_1_Match, G->begin, G->end, "yy_1_Match");
 
-  {  int yypos413= G->pos, yythunkpos413= G->thunkpos;  if (!yy__(G))  goto l413;
-  if (!yy_Value(G))  goto l413;
+  {  int yypos421= G->pos, yythunkpos421= G->thunkpos;  if (!yy__(G))  goto l421;
+  if (!yy_Value(G))  goto l421;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Match, G->begin, G->end, "yy_2_Match");
-  goto l414;
-  l413:;	  G->pos= yypos413; G->thunkpos= yythunkpos413;
+  goto l422;
+  l421:;	  G->pos= yypos421; G->thunkpos= yythunkpos421;
   }
-  l414:;	  if (!yy_WS(G))  goto l412;
-  if (!yymatchChar(G, '{')) goto l412;
+  l422:;	  if (!yy_WS(G))  goto l420;
+  if (!yymatchChar(G, '{')) goto l420;
 
-  l415:;	
-  {  int yypos416= G->pos, yythunkpos416= G->thunkpos;  if (!yy_WS(G))  goto l416;
-  if (!yy_Case(G))  goto l416;
-  if (!yy_WS(G))  goto l416;
-  goto l415;
-  l416:;	  G->pos= yypos416; G->thunkpos= yythunkpos416;
-  }  if (!yy_WS(G))  goto l412;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CASE_IN_MATCH, "Expected case or '"_CSBRACK"' to close match block.") ; } goto l412; }
+  l423:;	
+  {  int yypos424= G->pos, yythunkpos424= G->thunkpos;  if (!yy_WS(G))  goto l424;
+  if (!yy_Case(G))  goto l424;
+  if (!yy_WS(G))  goto l424;
+  goto l423;
+  l424:;	  G->pos= yypos424; G->thunkpos= yythunkpos424;
+  }  if (!yy_WS(G))  goto l420;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CASE_IN_MATCH, "Expected case or '"_CSBRACK"' to close match block.") ; } goto l420; }
   yyDo(G, yy_3_Match, G->begin, G->end, "yy_3_Match");
   yyprintf((stderr, "  ok   Match"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l412:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Match"));
+  l420:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Match"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9894,21 +9946,21 @@ YY_RULE(int) yy_Match(GREG *G)
 YY_RULE(int) yy_FlowControl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FlowControl"));
 
-  {  int yypos418= G->pos, yythunkpos418= G->thunkpos;  if (!yy_Foreach(G))  goto l419;
-  goto l418;
-  l419:;	  G->pos= yypos418; G->thunkpos= yythunkpos418;  if (!yy_While(G))  goto l420;
-  goto l418;
-  l420:;	  G->pos= yypos418; G->thunkpos= yythunkpos418;  if (!yy_Break(G))  goto l421;
-  goto l418;
-  l421:;	  G->pos= yypos418; G->thunkpos= yythunkpos418;  if (!yy_Continue(G))  goto l417;
+  {  int yypos426= G->pos, yythunkpos426= G->thunkpos;  if (!yy_Foreach(G))  goto l427;
+  goto l426;
+  l427:;	  G->pos= yypos426; G->thunkpos= yythunkpos426;  if (!yy_While(G))  goto l428;
+  goto l426;
+  l428:;	  G->pos= yypos426; G->thunkpos= yythunkpos426;  if (!yy_Break(G))  goto l429;
+  goto l426;
+  l429:;	  G->pos= yypos426; G->thunkpos= yythunkpos426;  if (!yy_Continue(G))  goto l425;
 
   }
-  l418:;	  yyprintf((stderr, "  ok   FlowControl"));
+  l426:;	  yyprintf((stderr, "  ok   FlowControl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l417:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FlowControl"));
+  l425:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FlowControl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9917,26 +9969,26 @@ YY_RULE(int) yy_FlowControl(GREG *G)
 YY_RULE(int) yy_Block(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Block"));
-  if (!yymatchChar(G, '{')) goto l422;
+  if (!yymatchChar(G, '{')) goto l430;
   yyDo(G, yy_1_Block, G->begin, G->end, "yy_1_Block");
 
-  l423:;	
-  {  int yypos424= G->pos, yythunkpos424= G->thunkpos;  if (!yy_WS(G))  goto l424;
-  if (!yy_Stmt(G))  goto l424;
+  l431:;	
+  {  int yypos432= G->pos, yythunkpos432= G->thunkpos;  if (!yy_WS(G))  goto l432;
+  if (!yy_Stmt(G))  goto l432;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Block, G->begin, G->end, "yy_2_Block");
-  if (!yy_WS(G))  goto l424;
-  goto l423;
-  l424:;	  G->pos= yypos424; G->thunkpos= yythunkpos424;
-  }  if (!yy_WS(G))  goto l422;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close block."); ; } goto l422; }
+  if (!yy_WS(G))  goto l432;
+  goto l431;
+  l432:;	  G->pos= yypos432; G->thunkpos= yythunkpos432;
+  }  if (!yy_WS(G))  goto l430;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close block."); ; } goto l430; }
   yyDo(G, yy_3_Block, G->begin, G->end, "yy_3_Block");
   yyprintf((stderr, "  ok   Block"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l422:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Block"));
+  l430:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Block"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9945,68 +9997,22 @@ YY_RULE(int) yy_Block(GREG *G)
 YY_RULE(int) yy_Conditional(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Conditional"));
-  if (!yy_If(G))  goto l425;
+  if (!yy_If(G))  goto l433;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  {  int yypos426= G->pos, yythunkpos426= G->thunkpos;  if (!yy_WS(G))  goto l426;
-  if (!yy_Else(G))  goto l426;
+  {  int yypos434= G->pos, yythunkpos434= G->thunkpos;  if (!yy_WS(G))  goto l434;
+  if (!yy_Else(G))  goto l434;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_Conditional, G->begin, G->end, "yy_1_Conditional");
-  goto l427;
-  l426:;	  G->pos= yypos426; G->thunkpos= yythunkpos426;
+  goto l435;
+  l434:;	  G->pos= yypos434; G->thunkpos= yythunkpos434;
   }
-  l427:;	  yyprintf((stderr, "  ok   Conditional"));
+  l435:;	  yyprintf((stderr, "  ok   Conditional"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l425:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Conditional"));
-  yyprintfvGcontext;
-  yyprintfv((stderr, "\n"));
-
-  return 0;
-}
-YY_RULE(int) yy_PreprocessorEndRegion(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PreprocessorEndRegion"));
-  if (!yymatchString(G, "#endregion")) goto l428;
-
-  l429:;	
-  {  int yypos430= G->pos, yythunkpos430= G->thunkpos;
-  {  int yypos431= G->pos, yythunkpos431= G->thunkpos;  if (!yy_EOL(G))  goto l431;
-  goto l430;
-  l431:;	  G->pos= yypos431; G->thunkpos= yythunkpos431;
-  }  if (!yymatchDot(G)) goto l430;  goto l429;
-  l430:;	  G->pos= yypos430; G->thunkpos= yythunkpos430;
-  }  if (!yy_EOL(G))  goto l428;
-  yyprintf((stderr, "  ok   PreprocessorEndRegion"));
-  yyprintfGcontext;
-  yyprintf((stderr, "\n"));
-
-  return 1;
-  l428:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PreprocessorEndRegion"));
-  yyprintfvGcontext;
-  yyprintfv((stderr, "\n"));
-
-  return 0;
-}
-YY_RULE(int) yy_PreprocessorBeginRegion(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PreprocessorBeginRegion"));
-  if (!yymatchString(G, "#region")) goto l432;
-
-  l433:;	
-  {  int yypos434= G->pos, yythunkpos434= G->thunkpos;
-  {  int yypos435= G->pos, yythunkpos435= G->thunkpos;  if (!yy_EOL(G))  goto l435;
-  goto l434;
-  l435:;	  G->pos= yypos435; G->thunkpos= yythunkpos435;
-  }  if (!yymatchDot(G)) goto l434;  goto l433;
-  l434:;	  G->pos= yypos434; G->thunkpos= yythunkpos434;
-  }  if (!yy_EOL(G))  goto l432;
-  yyprintf((stderr, "  ok   PreprocessorBeginRegion"));
-  yyprintfGcontext;
-  yyprintf((stderr, "\n"));
-
-  return 1;
-  l432:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PreprocessorBeginRegion"));
+  l433:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Conditional"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10089,47 +10095,39 @@ YY_RULE(int) yy_StmtCore(GREG *G)
   G->pos= yypos456; G->thunkpos= yythunkpos456;
   }  goto l447;
   l455:;	  G->pos= yypos447; G->thunkpos= yythunkpos447;
-  {  int yypos458= G->pos, yythunkpos458= G->thunkpos;  if (!yy_CommentLine(G))  goto l457;
-  G->pos= yypos458; G->thunkpos= yythunkpos458;
-  }  goto l447;
-  l457:;	  G->pos= yypos447; G->thunkpos= yythunkpos447;
-  {  int yypos460= G->pos, yythunkpos460= G->thunkpos;  if (!yy_PreprocessorBeginRegion(G))  goto l459;
-  G->pos= yypos460; G->thunkpos= yythunkpos460;
-  }  goto l447;
-  l459:;	  G->pos= yypos447; G->thunkpos= yythunkpos447;
-  {  int yypos461= G->pos, yythunkpos461= G->thunkpos;  if (!yy_PreprocessorEndRegion(G))  goto l446;
-  G->pos= yypos461; G->thunkpos= yythunkpos461;
+  {  int yypos457= G->pos, yythunkpos457= G->thunkpos;  if (!yy_CommentLine(G))  goto l446;
+  G->pos= yypos457; G->thunkpos= yythunkpos457;
   }
   }
   l447:;	  goto l445;
   l446:;	  G->pos= yypos445; G->thunkpos= yythunkpos445;
-  {  int yypos462= G->pos, yythunkpos462= G->thunkpos;  if (!yy_WS(G))  goto l463;
-  if (!yy_Conditional(G))  goto l463;
+  {  int yypos458= G->pos, yythunkpos458= G->thunkpos;  if (!yy_WS(G))  goto l459;
+  if (!yy_Conditional(G))  goto l459;
   yyDo(G, yySet, 0, 0, "yySet");
-  goto l462;
-  l463:;	  G->pos= yypos462; G->thunkpos= yythunkpos462;  if (!yy_WS(G))  goto l464;
-  if (!yy_Block(G))  goto l464;
+  goto l458;
+  l459:;	  G->pos= yypos458; G->thunkpos= yythunkpos458;  if (!yy_WS(G))  goto l460;
+  if (!yy_Block(G))  goto l460;
   yyDo(G, yySet, 0, 0, "yySet");
-  goto l462;
-  l464:;	  G->pos= yypos462; G->thunkpos= yythunkpos462;  if (!yy_WS(G))  goto l465;
-  if (!yy_FlowControl(G))  goto l465;
+  goto l458;
+  l460:;	  G->pos= yypos458; G->thunkpos= yythunkpos458;  if (!yy_WS(G))  goto l461;
+  if (!yy_FlowControl(G))  goto l461;
   yyDo(G, yySet, 0, 0, "yySet");
 
-  l466:;	
-  {  int yypos467= G->pos, yythunkpos467= G->thunkpos;  if (!yy_Terminator(G))  goto l467;
-  goto l466;
-  l467:;	  G->pos= yypos467; G->thunkpos= yythunkpos467;
-  }  goto l462;
-  l465:;	  G->pos= yypos462; G->thunkpos= yythunkpos462;  if (!yy_WS(G))  goto l468;
-  if (!yy_Match(G))  goto l468;
-  yyDo(G, yySet, 0, 0, "yySet");
+  l462:;	
+  {  int yypos463= G->pos, yythunkpos463= G->thunkpos;  if (!yy_Terminator(G))  goto l463;
   goto l462;
-  l468:;	  G->pos= yypos462; G->thunkpos= yythunkpos462;  if (!yy_WS(G))  goto l444;
+  l463:;	  G->pos= yypos463; G->thunkpos= yythunkpos463;
+  }  goto l458;
+  l461:;	  G->pos= yypos458; G->thunkpos= yythunkpos458;  if (!yy_WS(G))  goto l464;
+  if (!yy_Match(G))  goto l464;
+  yyDo(G, yySet, 0, 0, "yySet");
+  goto l458;
+  l464:;	  G->pos= yypos458; G->thunkpos= yythunkpos458;  if (!yy_WS(G))  goto l444;
   if (!yy_Try(G))  goto l444;
   yyDo(G, yySet, 0, 0, "yySet");
 
   }
-  l462:;	
+  l458:;	
   }
   l445:;	  yyprintf((stderr, "  ok   StmtCore"));
   yyprintfGcontext;
@@ -10144,17 +10142,17 @@ YY_RULE(int) yy_StmtCore(GREG *G)
 }
 YY_RULE(int) yy_FuncTypeCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FuncTypeCore"));
-  if (!yymatchString(G, "Func")) goto l469;
+  if (!yymatchString(G, "Func")) goto l465;
 
-  {  int yypos470= G->pos, yythunkpos470= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z0-9_")) goto l469;
-  G->pos= yypos470; G->thunkpos= yythunkpos470;
+  {  int yypos466= G->pos, yythunkpos466= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z0-9_")) goto l465;
+  G->pos= yypos466; G->thunkpos= yythunkpos466;
   }  yyDo(G, yy_1_FuncTypeCore, G->begin, G->end, "yy_1_FuncTypeCore");
   yyprintf((stderr, "  ok   FuncTypeCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l469:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncTypeCore"));
+  l465:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncTypeCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10168,7 +10166,7 @@ YY_RULE(int) yy_TypeListCore(GREG *G)
   yyprintf((stderr, "\n"));
 
   return 1;
-  l471:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeListCore"));
+  l467:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeListCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10177,32 +10175,32 @@ YY_RULE(int) yy_TypeListCore(GREG *G)
 YY_RULE(int) yy_TypeList(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "TypeList"));
-  if (!yymatchChar(G, '(')) goto l472;
-  if (!yy_WS(G))  goto l472;
-  if (!yy_TypeListCore(G))  goto l472;
+  if (!yymatchChar(G, '(')) goto l468;
+  if (!yy_WS(G))  goto l468;
+  if (!yy_TypeListCore(G))  goto l468;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_Type(G))  goto l472;
+  if (!yy_Type(G))  goto l468;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_TypeList, G->begin, G->end, "yy_1_TypeList");
 
-  l473:;	
-  {  int yypos474= G->pos, yythunkpos474= G->thunkpos;  if (!yy_WS(G))  goto l474;
-  if (!yymatchChar(G, ',')) goto l474;
-  if (!yy_WS(G))  goto l474;
-  if (!yy_Type(G))  goto l474;
+  l469:;	
+  {  int yypos470= G->pos, yythunkpos470= G->thunkpos;  if (!yy_WS(G))  goto l470;
+  if (!yymatchChar(G, ',')) goto l470;
+  if (!yy_WS(G))  goto l470;
+  if (!yy_Type(G))  goto l470;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_TypeList, G->begin, G->end, "yy_2_TypeList");
-  goto l473;
-  l474:;	  G->pos= yypos474; G->thunkpos= yythunkpos474;
-  }  if (!yymatchChar(G, ')')) goto l472;
-  if (!yy__(G))  goto l472;
+  goto l469;
+  l470:;	  G->pos= yypos470; G->thunkpos= yythunkpos470;
+  }  if (!yymatchChar(G, ')')) goto l468;
+  if (!yy__(G))  goto l468;
   yyDo(G, yy_3_TypeList, G->begin, G->end, "yy_3_TypeList");
   yyprintf((stderr, "  ok   TypeList"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l472:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeList"));
+  l468:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeList"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10216,7 +10214,7 @@ YY_RULE(int) yy_Old(GREG *G)
   yyprintf((stderr, "\n"));
 
   return 1;
-  l475:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Old"));
+  l471:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Old"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10226,123 +10224,123 @@ YY_RULE(int) yy_GenericType(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "GenericType"));
 
-  {  int yypos477= G->pos, yythunkpos477= G->thunkpos;  if (!yy_Old(G))  goto l478;
+  {  int yypos473= G->pos, yythunkpos473= G->thunkpos;  if (!yy_Old(G))  goto l474;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy__(G))  goto l478;
-  if (!yy_IDENT(G))  goto l478;
+  if (!yy__(G))  goto l474;
+  if (!yy_IDENT(G))  goto l474;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_1_GenericType, G->begin, G->end, "yy_1_GenericType");
-  if (!yy__(G))  goto l478;
-  if (!yy_TypeBase(G))  goto l478;
+  if (!yy__(G))  goto l474;
+  if (!yy_TypeBase(G))  goto l474;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos479= G->pos, yythunkpos479= G->thunkpos;  if (!yy_FuncType(G))  goto l479;
-  goto l478;
-  l479:;	  G->pos= yypos479; G->thunkpos= yythunkpos479;
+  {  int yypos475= G->pos, yythunkpos475= G->thunkpos;  if (!yy_FuncType(G))  goto l475;
+  goto l474;
+  l475:;	  G->pos= yypos475; G->thunkpos= yythunkpos475;
   }  yyDo(G, yy_2_GenericType, G->begin, G->end, "yy_2_GenericType");
-  if (!yy__(G))  goto l478;
-  if (!yymatchChar(G, '<')) goto l478;
-  if (!yy__(G))  goto l478;
-  if (!yy_Type(G))  goto l478;
+  if (!yy__(G))  goto l474;
+  if (!yymatchChar(G, '<')) goto l474;
+  if (!yy__(G))  goto l474;
+  if (!yy_Type(G))  goto l474;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_GenericType, G->begin, G->end, "yy_3_GenericType");
 
-  l480:;	
-  {  int yypos481= G->pos, yythunkpos481= G->thunkpos;  if (!yy__(G))  goto l481;
-  if (!yymatchChar(G, ',')) goto l481;
-  if (!yy__(G))  goto l481;
-  if (!yy_Type(G))  goto l481;
+  l476:;	
+  {  int yypos477= G->pos, yythunkpos477= G->thunkpos;  if (!yy__(G))  goto l477;
+  if (!yymatchChar(G, ',')) goto l477;
+  if (!yy__(G))  goto l477;
+  if (!yy_Type(G))  goto l477;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_GenericType, G->begin, G->end, "yy_4_GenericType");
-  goto l480;
-  l481:;	  G->pos= yypos481; G->thunkpos= yythunkpos481;
-  }  if (!yy__(G))  goto l478;
-  if (!yymatchChar(G, '>')) goto l478;
-  if (!yy__(G))  goto l478;
+  goto l476;
+  l477:;	  G->pos= yypos477; G->thunkpos= yythunkpos477;
+  }  if (!yy__(G))  goto l474;
+  if (!yymatchChar(G, '>')) goto l474;
+  if (!yy__(G))  goto l474;
 
-  l482:;	
-  {  int yypos483= G->pos, yythunkpos483= G->thunkpos;
-  {  int yypos484= G->pos, yythunkpos484= G->thunkpos;  if (!yymatchChar(G, '*')) goto l485;
+  l478:;	
+  {  int yypos479= G->pos, yythunkpos479= G->thunkpos;
+  {  int yypos480= G->pos, yythunkpos480= G->thunkpos;  if (!yymatchChar(G, '*')) goto l481;
   yyDo(G, yy_5_GenericType, G->begin, G->end, "yy_5_GenericType");
-  goto l484;
-  l485:;	  G->pos= yypos484; G->thunkpos= yythunkpos484;  if (!yymatchChar(G, '@')) goto l486;
+  goto l480;
+  l481:;	  G->pos= yypos480; G->thunkpos= yythunkpos480;  if (!yymatchChar(G, '@')) goto l482;
   yyDo(G, yy_6_GenericType, G->begin, G->end, "yy_6_GenericType");
-  goto l484;
-  l486:;	  G->pos= yypos484; G->thunkpos= yythunkpos484;  if (!yymatchChar(G, '[')) goto l483;
-  if (!yy_WS(G))  goto l483;
+  goto l480;
+  l482:;	  G->pos= yypos480; G->thunkpos= yythunkpos480;  if (!yymatchChar(G, '[')) goto l479;
+  if (!yy_WS(G))  goto l479;
   yyDo(G, yy_7_GenericType, G->begin, G->end, "yy_7_GenericType");
-  if (!yy__(G))  goto l483;
+  if (!yy__(G))  goto l479;
 
-  {  int yypos487= G->pos, yythunkpos487= G->thunkpos;  if (!yy_Expr(G))  goto l487;
+  {  int yypos483= G->pos, yythunkpos483= G->thunkpos;  if (!yy_Expr(G))  goto l483;
   yyDo(G, yySet, -1, 0, "yySet");
-  goto l488;
-  l487:;	  G->pos= yypos487; G->thunkpos= yythunkpos487;
+  goto l484;
+  l483:;	  G->pos= yypos483; G->thunkpos= yythunkpos483;
   }
-  l488:;	  if (!yymatchChar(G, ']')) goto l483;
+  l484:;	  if (!yymatchChar(G, ']')) goto l479;
   yyDo(G, yy_8_GenericType, G->begin, G->end, "yy_8_GenericType");
 
   }
-  l484:;	  goto l482;
-  l483:;	  G->pos= yypos483; G->thunkpos= yythunkpos483;
-  }  if (!yy__(G))  goto l478;
+  l480:;	  goto l478;
+  l479:;	  G->pos= yypos479; G->thunkpos= yythunkpos479;
+  }  if (!yy__(G))  goto l474;
   yyDo(G, yy_9_GenericType, G->begin, G->end, "yy_9_GenericType");
-  goto l477;
-  l478:;	  G->pos= yypos477; G->thunkpos= yythunkpos477;  if (!yy_TypeBase(G))  goto l476;
+  goto l473;
+  l474:;	  G->pos= yypos473; G->thunkpos= yythunkpos473;  if (!yy_TypeBase(G))  goto l472;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l476;
-  if (!yymatchChar(G, '<')) goto l476;
-  if (!yy__(G))  goto l476;
-  if (!yy_Type(G))  goto l476;
+  if (!yy__(G))  goto l472;
+  if (!yymatchChar(G, '<')) goto l472;
+  if (!yy__(G))  goto l472;
+  if (!yy_Type(G))  goto l472;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_10_GenericType, G->begin, G->end, "yy_10_GenericType");
 
-  l489:;	
-  {  int yypos490= G->pos, yythunkpos490= G->thunkpos;  if (!yy__(G))  goto l490;
-  if (!yymatchChar(G, ',')) goto l490;
-  if (!yy__(G))  goto l490;
-  if (!yy_Type(G))  goto l490;
+  l485:;	
+  {  int yypos486= G->pos, yythunkpos486= G->thunkpos;  if (!yy__(G))  goto l486;
+  if (!yymatchChar(G, ',')) goto l486;
+  if (!yy__(G))  goto l486;
+  if (!yy_Type(G))  goto l486;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_11_GenericType, G->begin, G->end, "yy_11_GenericType");
-  goto l489;
-  l490:;	  G->pos= yypos490; G->thunkpos= yythunkpos490;
-  }  if (!yy__(G))  goto l476;
-  if (!yymatchChar(G, '>')) goto l476;
-  if (!yy__(G))  goto l476;
+  goto l485;
+  l486:;	  G->pos= yypos486; G->thunkpos= yythunkpos486;
+  }  if (!yy__(G))  goto l472;
+  if (!yymatchChar(G, '>')) goto l472;
+  if (!yy__(G))  goto l472;
 
-  l491:;	
-  {  int yypos492= G->pos, yythunkpos492= G->thunkpos;
-  {  int yypos493= G->pos, yythunkpos493= G->thunkpos;  if (!yymatchChar(G, '*')) goto l494;
+  l487:;	
+  {  int yypos488= G->pos, yythunkpos488= G->thunkpos;
+  {  int yypos489= G->pos, yythunkpos489= G->thunkpos;  if (!yymatchChar(G, '*')) goto l490;
   yyDo(G, yy_12_GenericType, G->begin, G->end, "yy_12_GenericType");
-  goto l493;
-  l494:;	  G->pos= yypos493; G->thunkpos= yythunkpos493;  if (!yymatchChar(G, '@')) goto l495;
+  goto l489;
+  l490:;	  G->pos= yypos489; G->thunkpos= yythunkpos489;  if (!yymatchChar(G, '@')) goto l491;
   yyDo(G, yy_13_GenericType, G->begin, G->end, "yy_13_GenericType");
-  goto l493;
-  l495:;	  G->pos= yypos493; G->thunkpos= yythunkpos493;  if (!yymatchChar(G, '[')) goto l492;
-  if (!yy_WS(G))  goto l492;
+  goto l489;
+  l491:;	  G->pos= yypos489; G->thunkpos= yythunkpos489;  if (!yymatchChar(G, '[')) goto l488;
+  if (!yy_WS(G))  goto l488;
   yyDo(G, yy_14_GenericType, G->begin, G->end, "yy_14_GenericType");
-  if (!yy__(G))  goto l492;
+  if (!yy__(G))  goto l488;
 
-  {  int yypos496= G->pos, yythunkpos496= G->thunkpos;  if (!yy_Expr(G))  goto l496;
+  {  int yypos492= G->pos, yythunkpos492= G->thunkpos;  if (!yy_Expr(G))  goto l492;
   yyDo(G, yySet, -1, 0, "yySet");
-  goto l497;
-  l496:;	  G->pos= yypos496; G->thunkpos= yythunkpos496;
+  goto l493;
+  l492:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;
   }
-  l497:;	  if (!yymatchChar(G, ']')) goto l492;
+  l493:;	  if (!yymatchChar(G, ']')) goto l488;
   yyDo(G, yy_15_GenericType, G->begin, G->end, "yy_15_GenericType");
 
   }
-  l493:;	  goto l491;
-  l492:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;
-  }  if (!yy__(G))  goto l476;
+  l489:;	  goto l487;
+  l488:;	  G->pos= yypos488; G->thunkpos= yythunkpos488;
+  }  if (!yy__(G))  goto l472;
   yyDo(G, yy_16_GenericType, G->begin, G->end, "yy_16_GenericType");
 
   }
-  l477:;	  yyprintf((stderr, "  ok   GenericType"));
+  l473:;	  yyprintf((stderr, "  ok   GenericType"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l476:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericType"));
+  l472:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericType"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10351,79 +10349,79 @@ YY_RULE(int) yy_GenericType(GREG *G)
 YY_RULE(int) yy_FuncType(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FuncType"));
-  if (!yy_FuncTypeCore(G))  goto l498;
+  if (!yy_FuncTypeCore(G))  goto l494;
   yyDo(G, yySet, -4, 0, "yySet");
 
-  {  int yypos499= G->pos, yythunkpos499= G->thunkpos;  if (!yy__(G))  goto l499;
-  if (!yymatchChar(G, '<')) goto l499;
-  if (!yy__(G))  goto l499;
-  if (!yy_IDENT(G))  goto l499;
+  {  int yypos495= G->pos, yythunkpos495= G->thunkpos;  if (!yy__(G))  goto l495;
+  if (!yymatchChar(G, '<')) goto l495;
+  if (!yy__(G))  goto l495;
+  if (!yy_IDENT(G))  goto l495;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_FuncType, G->begin, G->end, "yy_1_FuncType");
 
-  l501:;	
-  {  int yypos502= G->pos, yythunkpos502= G->thunkpos;  if (!yy__(G))  goto l502;
-  if (!yymatchChar(G, ',')) goto l502;
-  if (!yy__(G))  goto l502;
-  if (!yy_IDENT(G))  goto l502;
+  l497:;	
+  {  int yypos498= G->pos, yythunkpos498= G->thunkpos;  if (!yy__(G))  goto l498;
+  if (!yymatchChar(G, ',')) goto l498;
+  if (!yy__(G))  goto l498;
+  if (!yy_IDENT(G))  goto l498;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_2_FuncType, G->begin, G->end, "yy_2_FuncType");
-  goto l501;
-  l502:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;
-  }  if (!yy__(G))  goto l499;
-  if (!yymatchChar(G, '>')) goto l499;
+  goto l497;
+  l498:;	  G->pos= yypos498; G->thunkpos= yythunkpos498;
+  }  if (!yy__(G))  goto l495;
+  if (!yymatchChar(G, '>')) goto l495;
+  goto l496;
+  l495:;	  G->pos= yypos495; G->thunkpos= yythunkpos495;
+  }
+  l496:;	
+  {  int yypos499= G->pos, yythunkpos499= G->thunkpos;  if (!yy__(G))  goto l499;
+  if (!yymatchChar(G, '(')) goto l499;
+
+  {  int yypos501= G->pos, yythunkpos501= G->thunkpos;  if (!yy__(G))  goto l501;
+  if (!yy_Type(G))  goto l501;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_3_FuncType, G->begin, G->end, "yy_3_FuncType");
+
+  l503:;	
+  {  int yypos504= G->pos, yythunkpos504= G->thunkpos;  if (!yymatchChar(G, ',')) goto l504;
+  if (!yy__(G))  goto l504;
+  if (!yy_Type(G))  goto l504;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_4_FuncType, G->begin, G->end, "yy_4_FuncType");
+  goto l503;
+  l504:;	  G->pos= yypos504; G->thunkpos= yythunkpos504;
+  }  goto l502;
+  l501:;	  G->pos= yypos501; G->thunkpos= yythunkpos501;
+  }
+  l502:;	
+  {  int yypos505= G->pos, yythunkpos505= G->thunkpos;  if (!yymatchString(G, "...")) goto l505;
+  if (!yy__(G))  goto l505;
+  yyDo(G, yy_5_FuncType, G->begin, G->end, "yy_5_FuncType");
+  goto l506;
+  l505:;	  G->pos= yypos505; G->thunkpos= yythunkpos505;
+  }
+  l506:;	  if (!yy__(G))  goto l499;
+  if (!yymatchChar(G, ')')) goto l499;
   goto l500;
   l499:;	  G->pos= yypos499; G->thunkpos= yythunkpos499;
   }
   l500:;	
-  {  int yypos503= G->pos, yythunkpos503= G->thunkpos;  if (!yy__(G))  goto l503;
-  if (!yymatchChar(G, '(')) goto l503;
-
-  {  int yypos505= G->pos, yythunkpos505= G->thunkpos;  if (!yy__(G))  goto l505;
-  if (!yy_Type(G))  goto l505;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_3_FuncType, G->begin, G->end, "yy_3_FuncType");
-
-  l507:;	
-  {  int yypos508= G->pos, yythunkpos508= G->thunkpos;  if (!yymatchChar(G, ',')) goto l508;
-  if (!yy__(G))  goto l508;
-  if (!yy_Type(G))  goto l508;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_4_FuncType, G->begin, G->end, "yy_4_FuncType");
-  goto l507;
-  l508:;	  G->pos= yypos508; G->thunkpos= yythunkpos508;
-  }  goto l506;
-  l505:;	  G->pos= yypos505; G->thunkpos= yythunkpos505;
-  }
-  l506:;	
-  {  int yypos509= G->pos, yythunkpos509= G->thunkpos;  if (!yymatchString(G, "...")) goto l509;
-  if (!yy__(G))  goto l509;
-  yyDo(G, yy_5_FuncType, G->begin, G->end, "yy_5_FuncType");
-  goto l510;
-  l509:;	  G->pos= yypos509; G->thunkpos= yythunkpos509;
-  }
-  l510:;	  if (!yy__(G))  goto l503;
-  if (!yymatchChar(G, ')')) goto l503;
-  goto l504;
-  l503:;	  G->pos= yypos503; G->thunkpos= yythunkpos503;
-  }
-  l504:;	
-  {  int yypos511= G->pos, yythunkpos511= G->thunkpos;  if (!yy__(G))  goto l511;
-  if (!yymatchString(G, "->")) goto l511;
-  if (!yy__(G))  goto l511;
-  if (!yy_Type(G))  goto l511;
+  {  int yypos507= G->pos, yythunkpos507= G->thunkpos;  if (!yy__(G))  goto l507;
+  if (!yymatchString(G, "->")) goto l507;
+  if (!yy__(G))  goto l507;
+  if (!yy_Type(G))  goto l507;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_FuncType, G->begin, G->end, "yy_6_FuncType");
-  goto l512;
-  l511:;	  G->pos= yypos511; G->thunkpos= yythunkpos511;
+  goto l508;
+  l507:;	  G->pos= yypos507; G->thunkpos= yythunkpos507;
   }
-  l512:;	  yyDo(G, yy_7_FuncType, G->begin, G->end, "yy_7_FuncType");
+  l508:;	  yyDo(G, yy_7_FuncType, G->begin, G->end, "yy_7_FuncType");
   yyprintf((stderr, "  ok   FuncType"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l498:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncType"));
+  l494:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncType"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10433,65 +10431,65 @@ YY_RULE(int) yy_TypeBase(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "TypeBase"));
 
-  {  int yypos514= G->pos, yythunkpos514= G->thunkpos;  if (!yy_FuncType(G))  goto l515;
-  goto l514;
-  l515:;	  G->pos= yypos514; G->thunkpos= yythunkpos514;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l513;  yyDo(G, yy_1_TypeBase, G->begin, G->end, "yy_1_TypeBase");
+  {  int yypos510= G->pos, yythunkpos510= G->thunkpos;  if (!yy_FuncType(G))  goto l511;
+  goto l510;
+  l511:;	  G->pos= yypos510; G->thunkpos= yythunkpos510;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l509;  yyDo(G, yy_1_TypeBase, G->begin, G->end, "yy_1_TypeBase");
 
-  {  int yypos516= G->pos, yythunkpos516= G->thunkpos;  if (!yy_CONST_KW(G))  goto l516;
-  if (!yy__(G))  goto l516;
-  goto l517;
-  l516:;	  G->pos= yypos516; G->thunkpos= yythunkpos516;
+  {  int yypos512= G->pos, yythunkpos512= G->thunkpos;  if (!yy_CONST_KW(G))  goto l512;
+  if (!yy__(G))  goto l512;
+  goto l513;
+  l512:;	  G->pos= yypos512; G->thunkpos= yythunkpos512;
   }
-  l517:;	
-  l518:;	
-  {  int yypos519= G->pos, yythunkpos519= G->thunkpos;
-  {  int yypos520= G->pos, yythunkpos520= G->thunkpos;  if (!yymatchString(G, "unsigned")) goto l521;
+  l513:;	
+  l514:;	
+  {  int yypos515= G->pos, yythunkpos515= G->thunkpos;
+  {  int yypos516= G->pos, yythunkpos516= G->thunkpos;  if (!yymatchString(G, "unsigned")) goto l517;
   yyDo(G, yy_2_TypeBase, G->begin, G->end, "yy_2_TypeBase");
-  if (!yy__(G))  goto l521;
-  goto l520;
-  l521:;	  G->pos= yypos520; G->thunkpos= yythunkpos520;  if (!yymatchString(G, "signed")) goto l522;
+  if (!yy__(G))  goto l517;
+  goto l516;
+  l517:;	  G->pos= yypos516; G->thunkpos= yythunkpos516;  if (!yymatchString(G, "signed")) goto l518;
   yyDo(G, yy_3_TypeBase, G->begin, G->end, "yy_3_TypeBase");
-  if (!yy__(G))  goto l522;
-  goto l520;
-  l522:;	  G->pos= yypos520; G->thunkpos= yythunkpos520;  if (!yymatchString(G, "long")) goto l523;
+  if (!yy__(G))  goto l518;
+  goto l516;
+  l518:;	  G->pos= yypos516; G->thunkpos= yythunkpos516;  if (!yymatchString(G, "long")) goto l519;
 
-  {  int yypos524= G->pos, yythunkpos524= G->thunkpos;  if (!yy__(G))  goto l523;
+  {  int yypos520= G->pos, yythunkpos520= G->thunkpos;  if (!yy__(G))  goto l519;
 
-  {  int yypos525= G->pos, yythunkpos525= G->thunkpos;  if (!yymatchString(G, "long")) goto l526;
-  goto l525;
-  l526:;	  G->pos= yypos525; G->thunkpos= yythunkpos525;  if (!yymatchString(G, "double")) goto l527;
-  goto l525;
-  l527:;	  G->pos= yypos525; G->thunkpos= yythunkpos525;  if (!yymatchString(G, "int")) goto l523;
+  {  int yypos521= G->pos, yythunkpos521= G->thunkpos;  if (!yymatchString(G, "long")) goto l522;
+  goto l521;
+  l522:;	  G->pos= yypos521; G->thunkpos= yythunkpos521;  if (!yymatchString(G, "double")) goto l523;
+  goto l521;
+  l523:;	  G->pos= yypos521; G->thunkpos= yythunkpos521;  if (!yymatchString(G, "int")) goto l519;
 
   }
-  l525:;	  G->pos= yypos524; G->thunkpos= yythunkpos524;
+  l521:;	  G->pos= yypos520; G->thunkpos= yythunkpos520;
   }  yyDo(G, yy_4_TypeBase, G->begin, G->end, "yy_4_TypeBase");
-  if (!yy__(G))  goto l523;
-  goto l520;
-  l523:;	  G->pos= yypos520; G->thunkpos= yythunkpos520;  if (!yymatchString(G, "struct")) goto l528;
-  yyDo(G, yy_5_TypeBase, G->begin, G->end, "yy_5_TypeBase");
-  if (!yy__(G))  goto l528;
-  goto l520;
-  l528:;	  G->pos= yypos520; G->thunkpos= yythunkpos520;  if (!yymatchString(G, "union")) goto l519;
-  yyDo(G, yy_6_TypeBase, G->begin, G->end, "yy_6_TypeBase");
   if (!yy__(G))  goto l519;
+  goto l516;
+  l519:;	  G->pos= yypos516; G->thunkpos= yythunkpos516;  if (!yymatchString(G, "struct")) goto l524;
+  yyDo(G, yy_5_TypeBase, G->begin, G->end, "yy_5_TypeBase");
+  if (!yy__(G))  goto l524;
+  goto l516;
+  l524:;	  G->pos= yypos516; G->thunkpos= yythunkpos516;  if (!yymatchString(G, "union")) goto l515;
+  yyDo(G, yy_6_TypeBase, G->begin, G->end, "yy_6_TypeBase");
+  if (!yy__(G))  goto l515;
 
   }
-  l520:;	  if (!yy__(G))  goto l519;
-  goto l518;
-  l519:;	  G->pos= yypos519; G->thunkpos= yythunkpos519;
-  }  if (!yy_IDENT(G))  goto l513;
+  l516:;	  if (!yy__(G))  goto l515;
+  goto l514;
+  l515:;	  G->pos= yypos515; G->thunkpos= yythunkpos515;
+  }  if (!yy_IDENT(G))  goto l509;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_7_TypeBase, G->begin, G->end, "yy_7_TypeBase");
-  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l513;  yyDo(G, yy_8_TypeBase, G->begin, G->end, "yy_8_TypeBase");
+  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l509;  yyDo(G, yy_8_TypeBase, G->begin, G->end, "yy_8_TypeBase");
 
   }
-  l514:;	  yyprintf((stderr, "  ok   TypeBase"));
+  l510:;	  yyprintf((stderr, "  ok   TypeBase"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l513:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeBase"));
+  l509:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeBase"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10499,13 +10497,13 @@ YY_RULE(int) yy_TypeBase(GREG *G)
 }
 YY_RULE(int) yy_SET_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "SET_KW"));
-  if (!yymatchString(G, "set")) goto l529;
+  if (!yymatchString(G, "set")) goto l525;
   yyprintf((stderr, "  ok   SET_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l529:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SET_KW"));
+  l525:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SET_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10513,13 +10511,13 @@ YY_RULE(int) yy_SET_KW(GREG *G)
 }
 YY_RULE(int) yy_GET_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "GET_KW"));
-  if (!yymatchString(G, "get")) goto l530;
+  if (!yymatchString(G, "get")) goto l526;
   yyprintf((stderr, "  ok   GET_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l530:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GET_KW"));
+  l526:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GET_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10528,59 +10526,59 @@ YY_RULE(int) yy_GET_KW(GREG *G)
 YY_RULE(int) yy_PropertyDeclSetter(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclSetter"));
-  if (!yy_OocDoc(G))  goto l531;
+  if (!yy_OocDoc(G))  goto l527;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclSetter, G->begin, G->end, "yy_1_PropertyDeclSetter");
-  if (!yy_WS(G))  goto l531;
-  if (!yy_SET_KW(G))  goto l531;
-  if (!yy_WS(G))  goto l531;
+  if (!yy_WS(G))  goto l527;
+  if (!yy_SET_KW(G))  goto l527;
+  if (!yy_WS(G))  goto l527;
 
-  {  int yypos532= G->pos, yythunkpos532= G->thunkpos;  if (!yy_COLON(G))  goto l532;
-  if (!yy_WS(G))  goto l532;
-  if (!yy_ExternName(G))  goto l532;
+  {  int yypos528= G->pos, yythunkpos528= G->thunkpos;  if (!yy_COLON(G))  goto l528;
+  if (!yy_WS(G))  goto l528;
+  if (!yy_ExternName(G))  goto l528;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_PropertyDeclSetter, G->begin, G->end, "yy_2_PropertyDeclSetter");
-  goto l533;
-  l532:;	  G->pos= yypos532; G->thunkpos= yythunkpos532;
+  goto l529;
+  l528:;	  G->pos= yypos528; G->thunkpos= yythunkpos528;
   }
-  l533:;	
-  {  int yypos534= G->pos, yythunkpos534= G->thunkpos;  if (!yymatchChar(G, '(')) goto l534;
-  if (!yy_WS(G))  goto l534;
+  l529:;	
+  {  int yypos530= G->pos, yythunkpos530= G->thunkpos;  if (!yymatchChar(G, '(')) goto l530;
+  if (!yy_WS(G))  goto l530;
 
-  {  int yypos536= G->pos, yythunkpos536= G->thunkpos;  if (!yy_IDENT(G))  goto l537;
+  {  int yypos532= G->pos, yythunkpos532= G->thunkpos;  if (!yy_IDENT(G))  goto l533;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclSetter, G->begin, G->end, "yy_3_PropertyDeclSetter");
-  goto l536;
-  l537:;	  G->pos= yypos536; G->thunkpos= yythunkpos536;  if (!yy_ASS(G))  goto l534;
-  if (!yy_IDENT(G))  goto l534;
+  goto l532;
+  l533:;	  G->pos= yypos532; G->thunkpos= yythunkpos532;  if (!yy_ASS(G))  goto l530;
+  if (!yy_IDENT(G))  goto l530;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l534;
+  if (!yy__(G))  goto l530;
   yyDo(G, yy_4_PropertyDeclSetter, G->begin, G->end, "yy_4_PropertyDeclSetter");
 
   }
-  l536:;	  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected ')' to close property setter argument list.\n"); ; } goto l534; }
-  if (!yy_WS(G))  goto l534;
-  if (!yymatchChar(G, '{')) goto l534;
+  l532:;	  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected ')' to close property setter argument list.\n"); ; } goto l530; }
+  if (!yy_WS(G))  goto l530;
+  if (!yymatchChar(G, '{')) goto l530;
 
-  l538:;	
-  {  int yypos539= G->pos, yythunkpos539= G->thunkpos;  if (!yy_WS(G))  goto l539;
-  if (!yy_Stmt(G))  goto l539;
+  l534:;	
+  {  int yypos535= G->pos, yythunkpos535= G->thunkpos;  if (!yy_WS(G))  goto l535;
+  if (!yy_Stmt(G))  goto l535;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_5_PropertyDeclSetter, G->begin, G->end, "yy_5_PropertyDeclSetter");
-  if (!yy_WS(G))  goto l539;
-  goto l538;
-  l539:;	  G->pos= yypos539; G->thunkpos= yythunkpos539;
-  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '??<' to close property setter body.\n"); ; } goto l534; }
-  goto l535;
-  l534:;	  G->pos= yypos534; G->thunkpos= yythunkpos534;
+  if (!yy_WS(G))  goto l535;
+  goto l534;
+  l535:;	  G->pos= yypos535; G->thunkpos= yythunkpos535;
+  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '??<' to close property setter body.\n"); ; } goto l530; }
+  goto l531;
+  l530:;	  G->pos= yypos530; G->thunkpos= yythunkpos530;
   }
-  l535:;	  yyDo(G, yy_6_PropertyDeclSetter, G->begin, G->end, "yy_6_PropertyDeclSetter");
+  l531:;	  yyDo(G, yy_6_PropertyDeclSetter, G->begin, G->end, "yy_6_PropertyDeclSetter");
   yyprintf((stderr, "  ok   PropertyDeclSetter"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l531:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclSetter"));
+  l527:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclSetter"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10589,43 +10587,43 @@ YY_RULE(int) yy_PropertyDeclSetter(GREG *G)
 YY_RULE(int) yy_PropertyDeclGetter(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclGetter"));
-  if (!yy_OocDoc(G))  goto l540;
+  if (!yy_OocDoc(G))  goto l536;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclGetter, G->begin, G->end, "yy_1_PropertyDeclGetter");
-  if (!yy_WS(G))  goto l540;
-  if (!yy_GET_KW(G))  goto l540;
-  if (!yy_WS(G))  goto l540;
+  if (!yy_WS(G))  goto l536;
+  if (!yy_GET_KW(G))  goto l536;
+  if (!yy_WS(G))  goto l536;
 
-  {  int yypos541= G->pos, yythunkpos541= G->thunkpos;  if (!yy_COLON(G))  goto l541;
-  if (!yy_WS(G))  goto l541;
-  if (!yy_ExternName(G))  goto l541;
+  {  int yypos537= G->pos, yythunkpos537= G->thunkpos;  if (!yy_COLON(G))  goto l537;
+  if (!yy_WS(G))  goto l537;
+  if (!yy_ExternName(G))  goto l537;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_PropertyDeclGetter, G->begin, G->end, "yy_2_PropertyDeclGetter");
-  goto l542;
-  l541:;	  G->pos= yypos541; G->thunkpos= yythunkpos541;
+  goto l538;
+  l537:;	  G->pos= yypos537; G->thunkpos= yythunkpos537;
   }
-  l542:;	
-  {  int yypos543= G->pos, yythunkpos543= G->thunkpos;  if (!yymatchChar(G, '{')) goto l543;
+  l538:;	
+  {  int yypos539= G->pos, yythunkpos539= G->thunkpos;  if (!yymatchChar(G, '{')) goto l539;
 
-  l545:;	
-  {  int yypos546= G->pos, yythunkpos546= G->thunkpos;  if (!yy_WS(G))  goto l546;
-  if (!yy_Stmt(G))  goto l546;
+  l541:;	
+  {  int yypos542= G->pos, yythunkpos542= G->thunkpos;  if (!yy_WS(G))  goto l542;
+  if (!yy_Stmt(G))  goto l542;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclGetter, G->begin, G->end, "yy_3_PropertyDeclGetter");
-  if (!yy_WS(G))  goto l546;
-  goto l545;
-  l546:;	  G->pos= yypos546; G->thunkpos= yythunkpos546;
-  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property getter\n"); ; } goto l543; }
-  goto l544;
-  l543:;	  G->pos= yypos543; G->thunkpos= yythunkpos543;
+  if (!yy_WS(G))  goto l542;
+  goto l541;
+  l542:;	  G->pos= yypos542; G->thunkpos= yythunkpos542;
+  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property getter\n"); ; } goto l539; }
+  goto l540;
+  l539:;	  G->pos= yypos539; G->thunkpos= yythunkpos539;
   }
-  l544:;	  yyDo(G, yy_4_PropertyDeclGetter, G->begin, G->end, "yy_4_PropertyDeclGetter");
+  l540:;	  yyDo(G, yy_4_PropertyDeclGetter, G->begin, G->end, "yy_4_PropertyDeclGetter");
   yyprintf((stderr, "  ok   PropertyDeclGetter"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l540:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclGetter"));
+  l536:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclGetter"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10633,14 +10631,14 @@ YY_RULE(int) yy_PropertyDeclGetter(GREG *G)
 }
 YY_RULE(int) yy_PROPASS_DECL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PROPASS_DECL"));
-  if (!yymatchString(G, "::=")) goto l547;
-  if (!yy__(G))  goto l547;
+  if (!yymatchString(G, "::=")) goto l543;
+  if (!yy__(G))  goto l543;
   yyprintf((stderr, "  ok   PROPASS_DECL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l547:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROPASS_DECL"));
+  l543:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROPASS_DECL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10649,15 +10647,15 @@ YY_RULE(int) yy_PROPASS_DECL(GREG *G)
 YY_RULE(int) yy_PropertyDeclCore(GREG *G)
 {  yyprintfv((stderr, "%s\n", "PropertyDeclCore"));
 
-  l549:;	
-  {  int yypos550= G->pos, yythunkpos550= G->thunkpos;
-  {  int yypos551= G->pos, yythunkpos551= G->thunkpos;  if (!yy_PropertyDeclGetter(G))  goto l552;
-  goto l551;
-  l552:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;  if (!yy_PropertyDeclSetter(G))  goto l550;
+  l545:;	
+  {  int yypos546= G->pos, yythunkpos546= G->thunkpos;
+  {  int yypos547= G->pos, yythunkpos547= G->thunkpos;  if (!yy_PropertyDeclGetter(G))  goto l548;
+  goto l547;
+  l548:;	  G->pos= yypos547; G->thunkpos= yythunkpos547;  if (!yy_PropertyDeclSetter(G))  goto l546;
 
   }
-  l551:;	  goto l549;
-  l550:;	  G->pos= yypos550; G->thunkpos= yythunkpos550;
+  l547:;	  goto l545;
+  l546:;	  G->pos= yypos546; G->thunkpos= yythunkpos546;
   }  yyprintf((stderr, "  ok   PropertyDeclCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -10667,37 +10665,37 @@ YY_RULE(int) yy_PropertyDeclCore(GREG *G)
 YY_RULE(int) yy_ConventionalPropertyDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ConventionalPropertyDecl"));
-  if (!yy_OocDoc(G))  goto l553;
+  if (!yy_OocDoc(G))  goto l549;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_IDENT(G))  goto l553;
+  if (!yy_IDENT(G))  goto l549;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_ConventionalPropertyDecl, G->begin, G->end, "yy_1_ConventionalPropertyDecl");
-  if (!yy_WS(G))  goto l553;
-  if (!yy_COLON(G))  goto l553;
-  if (!yy_WS(G))  goto l553;
+  if (!yy_WS(G))  goto l549;
+  if (!yy_COLON(G))  goto l549;
+  if (!yy_WS(G))  goto l549;
 
-  {  int yypos554= G->pos, yythunkpos554= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l554;
+  {  int yypos550= G->pos, yythunkpos550= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l550;
   yyDo(G, yy_2_ConventionalPropertyDecl, G->begin, G->end, "yy_2_ConventionalPropertyDecl");
-  goto l555;
-  l554:;	  G->pos= yypos554; G->thunkpos= yythunkpos554;
+  goto l551;
+  l550:;	  G->pos= yypos550; G->thunkpos= yythunkpos550;
   }
-  l555:;	  if (!yy_WS(G))  goto l553;
-  if (!yy_Type(G))  goto l553;
+  l551:;	  if (!yy_WS(G))  goto l549;
+  if (!yy_Type(G))  goto l549;
   yyDo(G, yy_3_ConventionalPropertyDecl, G->begin, G->end, "yy_3_ConventionalPropertyDecl");
-  if (!yy_WS(G))  goto l553;
-  if (!yymatchChar(G, '{')) goto l553;
-  if (!yy_WS(G))  goto l553;
-  if (!yy_PropertyDeclCore(G))  goto l553;
-  if (!yy_WS(G))  goto l553;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property decl!\n"); ; } goto l553; }
-  if (!yy_WS(G))  goto l553;
+  if (!yy_WS(G))  goto l549;
+  if (!yymatchChar(G, '{')) goto l549;
+  if (!yy_WS(G))  goto l549;
+  if (!yy_PropertyDeclCore(G))  goto l549;
+  if (!yy_WS(G))  goto l549;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property decl!\n"); ; } goto l549; }
+  if (!yy_WS(G))  goto l549;
   yyDo(G, yy_4_ConventionalPropertyDecl, G->begin, G->end, "yy_4_ConventionalPropertyDecl");
   yyprintf((stderr, "  ok   ConventionalPropertyDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l553:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalPropertyDecl"));
+  l549:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalPropertyDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10706,35 +10704,35 @@ YY_RULE(int) yy_ConventionalPropertyDecl(GREG *G)
 YY_RULE(int) yy_PropertyDeclFromExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclFromExpr"));
-  if (!yy_OocDoc(G))  goto l556;
+  if (!yy_OocDoc(G))  goto l552;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy_IDENT(G))  goto l556;
+  if (!yy_IDENT(G))  goto l552;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclFromExpr, G->begin, G->end, "yy_1_PropertyDeclFromExpr");
-  if (!yy__(G))  goto l556;
-  if (!yy_PROPASS_DECL(G))  goto l556;
+  if (!yy__(G))  goto l552;
+  if (!yy_PROPASS_DECL(G))  goto l552;
 
-  l557:;	
-  {  int yypos558= G->pos, yythunkpos558= G->thunkpos;  if (!yy__(G))  goto l558;
-  if (!yy_STATIC_KW(G))  goto l558;
+  l553:;	
+  {  int yypos554= G->pos, yythunkpos554= G->thunkpos;  if (!yy__(G))  goto l554;
+  if (!yy_STATIC_KW(G))  goto l554;
   yyDo(G, yy_2_PropertyDeclFromExpr, G->begin, G->end, "yy_2_PropertyDeclFromExpr");
 
-  {  int yypos559= G->pos, yythunkpos559= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l558;
-  G->pos= yypos559; G->thunkpos= yythunkpos559;
-  }  goto l557;
-  l558:;	  G->pos= yypos558; G->thunkpos= yythunkpos558;
-  }  if (!yy__(G))  goto l556;
-  if (!yy_Expr(G))  goto l556;
+  {  int yypos555= G->pos, yythunkpos555= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l554;
+  G->pos= yypos555; G->thunkpos= yythunkpos555;
+  }  goto l553;
+  l554:;	  G->pos= yypos554; G->thunkpos= yythunkpos554;
+  }  if (!yy__(G))  goto l552;
+  if (!yy_Expr(G))  goto l552;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclFromExpr, G->begin, G->end, "yy_3_PropertyDeclFromExpr");
-  if (!yy__(G))  goto l556;
+  if (!yy__(G))  goto l552;
   yyDo(G, yy_4_PropertyDeclFromExpr, G->begin, G->end, "yy_4_PropertyDeclFromExpr");
   yyprintf((stderr, "  ok   PropertyDeclFromExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l556:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclFromExpr"));
+  l552:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclFromExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10744,91 +10742,91 @@ YY_RULE(int) yy_ConventionalVarDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ConventionalVarDecl"));
   yyDo(G, yy_1_ConventionalVarDecl, G->begin, G->end, "yy_1_ConventionalVarDecl");
-  if (!yy_OocDoc(G))  goto l560;
+  if (!yy_OocDoc(G))  goto l556;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_IDENT(G))  goto l560;
+  if (!yy_IDENT(G))  goto l556;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_ConventionalVarDecl, G->begin, G->end, "yy_2_ConventionalVarDecl");
+
+  {  int yypos557= G->pos, yythunkpos557= G->thunkpos;  if (!yy__(G))  goto l557;
+  if (!yy_ASS(G))  goto l557;
+  if (!yy__(G))  goto l557;
+  if (!yy_Expr(G))  goto l557;
+  yyDo(G, yy_3_ConventionalVarDecl, G->begin, G->end, "yy_3_ConventionalVarDecl");
+  goto l558;
+  l557:;	  G->pos= yypos557; G->thunkpos= yythunkpos557;
+  }
+  l558:;	
+  l559:;	
+  {  int yypos560= G->pos, yythunkpos560= G->thunkpos;  if (!yy__(G))  goto l560;
+  if (!yymatchChar(G, ',')) goto l560;
+  if (!yy_OocDoc(G))  goto l560;
+  yyDo(G, yySet, -5, 0, "yySet");
+  if (!yy_WS(G))  goto l560;
+  if (!yy_IDENT(G))  goto l560;
+  yyDo(G, yySet, -3, 0, "yySet");
+  yyDo(G, yy_4_ConventionalVarDecl, G->begin, G->end, "yy_4_ConventionalVarDecl");
 
   {  int yypos561= G->pos, yythunkpos561= G->thunkpos;  if (!yy__(G))  goto l561;
   if (!yy_ASS(G))  goto l561;
   if (!yy__(G))  goto l561;
   if (!yy_Expr(G))  goto l561;
-  yyDo(G, yy_3_ConventionalVarDecl, G->begin, G->end, "yy_3_ConventionalVarDecl");
+  yyDo(G, yy_5_ConventionalVarDecl, G->begin, G->end, "yy_5_ConventionalVarDecl");
   goto l562;
   l561:;	  G->pos= yypos561; G->thunkpos= yythunkpos561;
   }
-  l562:;	
+  l562:;	  if (!yy__(G))  goto l560;
+  goto l559;
+  l560:;	  G->pos= yypos560; G->thunkpos= yythunkpos560;
+  }  if (!yy_WS(G))  goto l556;
+  if (!yy_COLON(G))  goto l556;
+  if (!yy_WS(G))  goto l556;
+
   l563:;	
   {  int yypos564= G->pos, yythunkpos564= G->thunkpos;  if (!yy__(G))  goto l564;
-  if (!yymatchChar(G, ',')) goto l564;
-  if (!yy_OocDoc(G))  goto l564;
-  yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_WS(G))  goto l564;
-  if (!yy_IDENT(G))  goto l564;
-  yyDo(G, yySet, -3, 0, "yySet");
-  yyDo(G, yy_4_ConventionalVarDecl, G->begin, G->end, "yy_4_ConventionalVarDecl");
 
-  {  int yypos565= G->pos, yythunkpos565= G->thunkpos;  if (!yy__(G))  goto l565;
-  if (!yy_ASS(G))  goto l565;
-  if (!yy__(G))  goto l565;
-  if (!yy_Expr(G))  goto l565;
-  yyDo(G, yy_5_ConventionalVarDecl, G->begin, G->end, "yy_5_ConventionalVarDecl");
-  goto l566;
-  l565:;	  G->pos= yypos565; G->thunkpos= yythunkpos565;
-  }
-  l566:;	  if (!yy__(G))  goto l564;
-  goto l563;
-  l564:;	  G->pos= yypos564; G->thunkpos= yythunkpos564;
-  }  if (!yy_WS(G))  goto l560;
-  if (!yy_COLON(G))  goto l560;
-  if (!yy_WS(G))  goto l560;
-
-  l567:;	
-  {  int yypos568= G->pos, yythunkpos568= G->thunkpos;  if (!yy__(G))  goto l568;
-
-  {  int yypos569= G->pos, yythunkpos569= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l570;
+  {  int yypos565= G->pos, yythunkpos565= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l566;
   yyDo(G, yy_6_ConventionalVarDecl, G->begin, G->end, "yy_6_ConventionalVarDecl");
-  goto l569;
-  l570:;	  G->pos= yypos569; G->thunkpos= yythunkpos569;  if (!yy_CONST_KW(G))  goto l571;
+  goto l565;
+  l566:;	  G->pos= yypos565; G->thunkpos= yythunkpos565;  if (!yy_CONST_KW(G))  goto l567;
   yyDo(G, yy_7_ConventionalVarDecl, G->begin, G->end, "yy_7_ConventionalVarDecl");
-  goto l569;
-  l571:;	  G->pos= yypos569; G->thunkpos= yythunkpos569;  if (!yy_PROTO_KW(G))  goto l572;
+  goto l565;
+  l567:;	  G->pos= yypos565; G->thunkpos= yythunkpos565;  if (!yy_PROTO_KW(G))  goto l568;
   yyDo(G, yy_8_ConventionalVarDecl, G->begin, G->end, "yy_8_ConventionalVarDecl");
-  goto l569;
-  l572:;	  G->pos= yypos569; G->thunkpos= yythunkpos569;  if (!yy_ExternName(G))  goto l573;
+  goto l565;
+  l568:;	  G->pos= yypos565; G->thunkpos= yythunkpos565;  if (!yy_ExternName(G))  goto l569;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_9_ConventionalVarDecl, G->begin, G->end, "yy_9_ConventionalVarDecl");
-  goto l569;
-  l573:;	  G->pos= yypos569; G->thunkpos= yythunkpos569;  if (!yy_UnmangledName(G))  goto l574;
+  goto l565;
+  l569:;	  G->pos= yypos565; G->thunkpos= yythunkpos565;  if (!yy_UnmangledName(G))  goto l570;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_ConventionalVarDecl, G->begin, G->end, "yy_10_ConventionalVarDecl");
-  goto l569;
-  l574:;	  G->pos= yypos569; G->thunkpos= yythunkpos569;  if (!yy_FORCEDMALLOC_KW(G))  goto l568;
+  goto l565;
+  l570:;	  G->pos= yypos565; G->thunkpos= yythunkpos565;  if (!yy_FORCEDMALLOC_KW(G))  goto l564;
   yyDo(G, yy_11_ConventionalVarDecl, G->begin, G->end, "yy_11_ConventionalVarDecl");
 
   }
-  l569:;	  goto l567;
-  l568:;	  G->pos= yypos568; G->thunkpos= yythunkpos568;
-  }  if (!yy_WS(G))  goto l560;
-  if (!yy_Type(G))  goto l560;
+  l565:;	  goto l563;
+  l564:;	  G->pos= yypos564; G->thunkpos= yythunkpos564;
+  }  if (!yy_WS(G))  goto l556;
+  if (!yy_Type(G))  goto l556;
   yyDo(G, yy_12_ConventionalVarDecl, G->begin, G->end, "yy_12_ConventionalVarDecl");
 
-  {  int yypos575= G->pos, yythunkpos575= G->thunkpos;  if (!yy__(G))  goto l575;
-  if (!yy_ASS(G))  goto l575;
-  if (!yy__(G))  goto l575;
-  if (!yy_Expr(G))  goto l575;
+  {  int yypos571= G->pos, yythunkpos571= G->thunkpos;  if (!yy__(G))  goto l571;
+  if (!yy_ASS(G))  goto l571;
+  if (!yy__(G))  goto l571;
+  if (!yy_Expr(G))  goto l571;
   yyDo(G, yy_13_ConventionalVarDecl, G->begin, G->end, "yy_13_ConventionalVarDecl");
-  goto l576;
-  l575:;	  G->pos= yypos575; G->thunkpos= yythunkpos575;
+  goto l572;
+  l571:;	  G->pos= yypos571; G->thunkpos= yythunkpos571;
   }
-  l576:;	  yyDo(G, yy_14_ConventionalVarDecl, G->begin, G->end, "yy_14_ConventionalVarDecl");
+  l572:;	  yyDo(G, yy_14_ConventionalVarDecl, G->begin, G->end, "yy_14_ConventionalVarDecl");
   yyprintf((stderr, "  ok   ConventionalVarDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l560:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalVarDecl"));
+  l556:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalVarDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10836,13 +10834,13 @@ YY_RULE(int) yy_ConventionalVarDecl(GREG *G)
 }
 YY_RULE(int) yy_FORCEDMALLOC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FORCEDMALLOC_KW"));
-  if (!yymatchString(G, "__onheap__")) goto l577;
+  if (!yymatchString(G, "__onheap__")) goto l573;
   yyprintf((stderr, "  ok   FORCEDMALLOC_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l577:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FORCEDMALLOC_KW"));
+  l573:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FORCEDMALLOC_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10850,13 +10848,13 @@ YY_RULE(int) yy_FORCEDMALLOC_KW(GREG *G)
 }
 YY_RULE(int) yy_CONST_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CONST_KW"));
-  if (!yymatchString(G, "const")) goto l578;
+  if (!yymatchString(G, "const")) goto l574;
   yyprintf((stderr, "  ok   CONST_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l578:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONST_KW"));
+  l574:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONST_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10864,14 +10862,14 @@ YY_RULE(int) yy_CONST_KW(GREG *G)
 }
 YY_RULE(int) yy_ASS_DECL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_DECL"));
-  if (!yymatchString(G, ":=")) goto l579;
-  if (!yy__(G))  goto l579;
+  if (!yymatchString(G, ":=")) goto l575;
+  if (!yy__(G))  goto l575;
   yyprintf((stderr, "  ok   ASS_DECL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l579:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DECL"));
+  l575:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DECL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10880,41 +10878,41 @@ YY_RULE(int) yy_ASS_DECL(GREG *G)
 YY_RULE(int) yy_Tuple(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Tuple"));
-  if (!yymatchChar(G, '(')) goto l580;
+  if (!yymatchChar(G, '(')) goto l576;
   yyDo(G, yy_1_Tuple, G->begin, G->end, "yy_1_Tuple");
-  if (!yy_WS(G))  goto l580;
+  if (!yy_WS(G))  goto l576;
   yyDo(G, yy_2_Tuple, G->begin, G->end, "yy_2_Tuple");
 
-  {  int yypos581= G->pos, yythunkpos581= G->thunkpos;  if (!yy_Expr(G))  goto l581;
+  {  int yypos577= G->pos, yythunkpos577= G->thunkpos;  if (!yy_Expr(G))  goto l577;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_Tuple, G->begin, G->end, "yy_3_Tuple");
 
-  l583:;	
-  {  int yypos584= G->pos, yythunkpos584= G->thunkpos;
-  {  int yypos585= G->pos, yythunkpos585= G->thunkpos;  if (!yy_WS(G))  goto l586;
-  if (!yymatchChar(G, ',')) goto l586;
-  goto l585;
-  l586:;	  G->pos= yypos585; G->thunkpos= yythunkpos585;  if (!yy_EOL(G))  goto l584;
+  l579:;	
+  {  int yypos580= G->pos, yythunkpos580= G->thunkpos;
+  {  int yypos581= G->pos, yythunkpos581= G->thunkpos;  if (!yy_WS(G))  goto l582;
+  if (!yymatchChar(G, ',')) goto l582;
+  goto l581;
+  l582:;	  G->pos= yypos581; G->thunkpos= yythunkpos581;  if (!yy_EOL(G))  goto l580;
 
   }
-  l585:;	  if (!yy_WS(G))  goto l584;
-  if (!yy_Expr(G))  goto l584;
+  l581:;	  if (!yy_WS(G))  goto l580;
+  if (!yy_Expr(G))  goto l580;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Tuple, G->begin, G->end, "yy_4_Tuple");
-  goto l583;
-  l584:;	  G->pos= yypos584; G->thunkpos= yythunkpos584;
-  }  goto l582;
-  l581:;	  G->pos= yypos581; G->thunkpos= yythunkpos581;
+  goto l579;
+  l580:;	  G->pos= yypos580; G->thunkpos= yythunkpos580;
+  }  goto l578;
+  l577:;	  G->pos= yypos577; G->thunkpos= yythunkpos577;
   }
-  l582:;	  if (!yy_WS(G))  goto l580;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed tuple! Expected ')' to close.\n"); ; } goto l580; }
+  l578:;	  if (!yy_WS(G))  goto l576;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed tuple! Expected ')' to close.\n"); ; } goto l576; }
   yyDo(G, yy_5_Tuple, G->begin, G->end, "yy_5_Tuple");
   yyprintf((stderr, "  ok   Tuple"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l580:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Tuple"));
+  l576:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Tuple"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10923,54 +10921,54 @@ YY_RULE(int) yy_Tuple(GREG *G)
 YY_RULE(int) yy_VarDeclFromExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VarDeclFromExpr"));
-  if (!yy_OocDoc(G))  goto l587;
+  if (!yy_OocDoc(G))  goto l583;
   yyDo(G, yySet, -4, 0, "yySet");
 
-  {  int yypos588= G->pos, yythunkpos588= G->thunkpos;  if (!yy_IDENT(G))  goto l589;
+  {  int yypos584= G->pos, yythunkpos584= G->thunkpos;  if (!yy_IDENT(G))  goto l585;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_VarDeclFromExpr, G->begin, G->end, "yy_1_VarDeclFromExpr");
-  goto l588;
-  l589:;	  G->pos= yypos588; G->thunkpos= yythunkpos588;  if (!yy_Tuple(G))  goto l587;
+  goto l584;
+  l585:;	  G->pos= yypos584; G->thunkpos= yythunkpos584;  if (!yy_Tuple(G))  goto l583;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_VarDeclFromExpr, G->begin, G->end, "yy_2_VarDeclFromExpr");
 
   }
-  l588:;	  if (!yy__(G))  goto l587;
-  if (!yy_ASS_DECL(G))  goto l587;
+  l584:;	  if (!yy__(G))  goto l583;
+  if (!yy_ASS_DECL(G))  goto l583;
 
-  l590:;	
-  {  int yypos591= G->pos, yythunkpos591= G->thunkpos;  if (!yy__(G))  goto l591;
+  l586:;	
+  {  int yypos587= G->pos, yythunkpos587= G->thunkpos;  if (!yy__(G))  goto l587;
 
-  {  int yypos592= G->pos, yythunkpos592= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l593;
+  {  int yypos588= G->pos, yythunkpos588= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l589;
   yyDo(G, yy_3_VarDeclFromExpr, G->begin, G->end, "yy_3_VarDeclFromExpr");
-  goto l592;
-  l593:;	  G->pos= yypos592; G->thunkpos= yythunkpos592;  if (!yy_CONST_KW(G))  goto l594;
+  goto l588;
+  l589:;	  G->pos= yypos588; G->thunkpos= yythunkpos588;  if (!yy_CONST_KW(G))  goto l590;
   yyDo(G, yy_4_VarDeclFromExpr, G->begin, G->end, "yy_4_VarDeclFromExpr");
-  goto l592;
-  l594:;	  G->pos= yypos592; G->thunkpos= yythunkpos592;  if (!yy_PROTO_KW(G))  goto l595;
+  goto l588;
+  l590:;	  G->pos= yypos588; G->thunkpos= yythunkpos588;  if (!yy_PROTO_KW(G))  goto l591;
   yyDo(G, yy_5_VarDeclFromExpr, G->begin, G->end, "yy_5_VarDeclFromExpr");
-  goto l592;
-  l595:;	  G->pos= yypos592; G->thunkpos= yythunkpos592;  if (!yy_FORCEDMALLOC_KW(G))  goto l591;
+  goto l588;
+  l591:;	  G->pos= yypos588; G->thunkpos= yythunkpos588;  if (!yy_FORCEDMALLOC_KW(G))  goto l587;
   yyDo(G, yy_6_VarDeclFromExpr, G->begin, G->end, "yy_6_VarDeclFromExpr");
 
   }
-  l592:;	
-  {  int yypos596= G->pos, yythunkpos596= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l591;
-  G->pos= yypos596; G->thunkpos= yythunkpos596;
-  }  goto l590;
-  l591:;	  G->pos= yypos591; G->thunkpos= yythunkpos591;
-  }  if (!yy__(G))  goto l587;
-  if (!yy_Expr(G))  goto l587;
+  l588:;	
+  {  int yypos592= G->pos, yythunkpos592= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l587;
+  G->pos= yypos592; G->thunkpos= yythunkpos592;
+  }  goto l586;
+  l587:;	  G->pos= yypos587; G->thunkpos= yythunkpos587;
+  }  if (!yy__(G))  goto l583;
+  if (!yy_Expr(G))  goto l583;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_7_VarDeclFromExpr, G->begin, G->end, "yy_7_VarDeclFromExpr");
-  if (!yy__(G))  goto l587;
+  if (!yy__(G))  goto l583;
   yyDo(G, yy_8_VarDeclFromExpr, G->begin, G->end, "yy_8_VarDeclFromExpr");
   yyprintf((stderr, "  ok   VarDeclFromExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l587:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VarDeclFromExpr"));
+  l583:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VarDeclFromExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10978,13 +10976,13 @@ YY_RULE(int) yy_VarDeclFromExpr(GREG *G)
 }
 YY_RULE(int) yy_UNMANGLED_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "UNMANGLED_KW"));
-  if (!yymatchString(G, "unmangled")) goto l597;
+  if (!yymatchString(G, "unmangled")) goto l593;
   yyprintf((stderr, "  ok   UNMANGLED_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l597:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UNMANGLED_KW"));
+  l593:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UNMANGLED_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10992,13 +10990,13 @@ YY_RULE(int) yy_UNMANGLED_KW(GREG *G)
 }
 YY_RULE(int) yy_EXTERN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXTERN_KW"));
-  if (!yymatchString(G, "extern")) goto l598;
+  if (!yymatchString(G, "extern")) goto l594;
   yyprintf((stderr, "  ok   EXTERN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l598:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTERN_KW"));
+  l594:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTERN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11006,13 +11004,13 @@ YY_RULE(int) yy_EXTERN_KW(GREG *G)
 }
 YY_RULE(int) yy_INTERFACE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INTERFACE_KW"));
-  if (!yymatchString(G, "interface")) goto l599;
+  if (!yymatchString(G, "interface")) goto l595;
   yyprintf((stderr, "  ok   INTERFACE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l599:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTERFACE_KW"));
+  l595:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTERFACE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11020,13 +11018,13 @@ YY_RULE(int) yy_INTERFACE_KW(GREG *G)
 }
 YY_RULE(int) yy_COVER_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "COVER_KW"));
-  if (!yymatchString(G, "cover")) goto l600;
+  if (!yymatchString(G, "cover")) goto l596;
   yyprintf((stderr, "  ok   COVER_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l600:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COVER_KW"));
+  l596:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COVER_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11034,18 +11032,18 @@ YY_RULE(int) yy_COVER_KW(GREG *G)
 }
 YY_RULE(int) yy_PLUS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PLUS"));
-  if (!yymatchChar(G, '+')) goto l601;
+  if (!yymatchChar(G, '+')) goto l597;
 
-  {  int yypos602= G->pos, yythunkpos602= G->thunkpos;  if (!yymatchChar(G, '=')) goto l602;
-  goto l601;
-  l602:;	  G->pos= yypos602; G->thunkpos= yythunkpos602;
-  }  if (!yy__(G))  goto l601;
+  {  int yypos598= G->pos, yythunkpos598= G->thunkpos;  if (!yymatchChar(G, '=')) goto l598;
+  goto l597;
+  l598:;	  G->pos= yypos598; G->thunkpos= yythunkpos598;
+  }  if (!yy__(G))  goto l597;
   yyprintf((stderr, "  ok   PLUS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l601:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PLUS"));
+  l597:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PLUS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11053,18 +11051,18 @@ YY_RULE(int) yy_PLUS(GREG *G)
 }
 YY_RULE(int) yy_STAR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "STAR"));
-  if (!yymatchChar(G, '*')) goto l603;
+  if (!yymatchChar(G, '*')) goto l599;
 
-  {  int yypos604= G->pos, yythunkpos604= G->thunkpos;  if (!yymatchChar(G, '=')) goto l604;
-  goto l603;
-  l604:;	  G->pos= yypos604; G->thunkpos= yythunkpos604;
-  }  if (!yy__(G))  goto l603;
+  {  int yypos600= G->pos, yythunkpos600= G->thunkpos;  if (!yymatchChar(G, '=')) goto l600;
+  goto l599;
+  l600:;	  G->pos= yypos600; G->thunkpos= yythunkpos600;
+  }  if (!yy__(G))  goto l599;
   yyprintf((stderr, "  ok   STAR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l603:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STAR"));
+  l599:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STAR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11074,38 +11072,38 @@ YY_RULE(int) yy_Expr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Expr"));
 
-  {  int yypos606= G->pos, yythunkpos606= G->thunkpos;  if (!yy_VariableDecl(G))  goto l607;
+  {  int yypos602= G->pos, yythunkpos602= G->thunkpos;  if (!yy_VariableDecl(G))  goto l603;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy__(G))  goto l607;
-  goto l606;
-  l607:;	  G->pos= yypos606; G->thunkpos= yythunkpos606;  if (!yy_DoubleArrow(G))  goto l608;
+  if (!yy__(G))  goto l603;
+  goto l602;
+  l603:;	  G->pos= yypos602; G->thunkpos= yythunkpos602;  if (!yy_DoubleArrow(G))  goto l604;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l608;
-  goto l606;
-  l608:;	  G->pos= yypos606; G->thunkpos= yythunkpos606;  if (!yy_BinaryOperation(G))  goto l609;
+  if (!yy__(G))  goto l604;
+  goto l602;
+  l604:;	  G->pos= yypos602; G->thunkpos= yythunkpos602;  if (!yy_BinaryOperation(G))  goto l605;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l609;
+  if (!yy__(G))  goto l605;
 
-  l610:;	
-  {  int yypos611= G->pos, yythunkpos611= G->thunkpos;  if (!yy__(G))  goto l611;
-  if (!yymatchChar(G, '.')) goto l611;
+  l606:;	
+  {  int yypos607= G->pos, yythunkpos607= G->thunkpos;  if (!yy__(G))  goto l607;
+  if (!yymatchChar(G, '.')) goto l607;
   yyDo(G, yy_1_Expr, G->begin, G->end, "yy_1_Expr");
-  if (!yy_WS(G))  goto l611;
-  if (!yy_FunctionCall(G))  goto l611;
+  if (!yy_WS(G))  goto l607;
+  if (!yy_FunctionCall(G))  goto l607;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Expr, G->begin, G->end, "yy_2_Expr");
-  goto l610;
-  l611:;	  G->pos= yypos611; G->thunkpos= yythunkpos611;
-  }  goto l606;
-  l609:;	  G->pos= yypos606; G->thunkpos= yythunkpos606;  if (!yy_AnonymousFunctionDecl(G))  goto l605;
+  goto l606;
+  l607:;	  G->pos= yypos607; G->thunkpos= yythunkpos607;
+  }  goto l602;
+  l605:;	  G->pos= yypos602; G->thunkpos= yythunkpos602;  if (!yy_AnonymousFunctionDecl(G))  goto l601;
 
   }
-  l606:;	  yyprintf((stderr, "  ok   Expr"));
+  l602:;	  yyprintf((stderr, "  ok   Expr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l605:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Expr"));
+  l601:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Expr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11114,36 +11112,36 @@ YY_RULE(int) yy_Expr(GREG *G)
 YY_RULE(int) yy_EnumElement(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "EnumElement"));
-  if (!yy_OocDoc(G))  goto l612;
+  if (!yy_OocDoc(G))  goto l608;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l612;
+  if (!yy_IDENT(G))  goto l608;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_EnumElement, G->begin, G->end, "yy_1_EnumElement");
-  if (!yy__(G))  goto l612;
+  if (!yy__(G))  goto l608;
 
-  {  int yypos613= G->pos, yythunkpos613= G->thunkpos;
-  {  int yypos615= G->pos, yythunkpos615= G->thunkpos;  if (!yy_ASS(G))  goto l616;
-  if (!yy_Expr(G))  goto l616;
+  {  int yypos609= G->pos, yythunkpos609= G->thunkpos;
+  {  int yypos611= G->pos, yythunkpos611= G->thunkpos;  if (!yy_ASS(G))  goto l612;
+  if (!yy_Expr(G))  goto l612;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_EnumElement, G->begin, G->end, "yy_2_EnumElement");
-  goto l615;
-  l616:;	  G->pos= yypos615; G->thunkpos= yythunkpos615;  if (!yy_COLON(G))  goto l613;
-  if (!yy__(G))  goto l613;
-  if (!yy_ExternName(G))  goto l613;
+  goto l611;
+  l612:;	  G->pos= yypos611; G->thunkpos= yythunkpos611;  if (!yy_COLON(G))  goto l609;
+  if (!yy__(G))  goto l609;
+  if (!yy_ExternName(G))  goto l609;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_EnumElement, G->begin, G->end, "yy_3_EnumElement");
 
   }
-  l615:;	  goto l614;
-  l613:;	  G->pos= yypos613; G->thunkpos= yythunkpos613;
+  l611:;	  goto l610;
+  l609:;	  G->pos= yypos609; G->thunkpos= yythunkpos609;
   }
-  l614:;	  yyDo(G, yy_4_EnumElement, G->begin, G->end, "yy_4_EnumElement");
+  l610:;	  yyDo(G, yy_4_EnumElement, G->begin, G->end, "yy_4_EnumElement");
   yyprintf((stderr, "  ok   EnumElement"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l612:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumElement"));
+  l608:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumElement"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11153,28 +11151,28 @@ YY_RULE(int) yy_IntLiteral(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IntLiteral"));
 
-  {  int yypos618= G->pos, yythunkpos618= G->thunkpos;  if (!yy_OCT_LIT(G))  goto l619;
+  {  int yypos614= G->pos, yythunkpos614= G->thunkpos;  if (!yy_OCT_LIT(G))  goto l615;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l619;
+  if (!yy__(G))  goto l615;
   yyDo(G, yy_1_IntLiteral, G->begin, G->end, "yy_1_IntLiteral");
-  goto l618;
-  l619:;	  G->pos= yypos618; G->thunkpos= yythunkpos618;  if (!yy_HEX_LIT(G))  goto l620;
+  goto l614;
+  l615:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_HEX_LIT(G))  goto l616;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l620;
+  if (!yy__(G))  goto l616;
   yyDo(G, yy_2_IntLiteral, G->begin, G->end, "yy_2_IntLiteral");
-  goto l618;
-  l620:;	  G->pos= yypos618; G->thunkpos= yythunkpos618;  if (!yy_DEC_LIT(G))  goto l617;
+  goto l614;
+  l616:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_DEC_LIT(G))  goto l613;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l617;
+  if (!yy__(G))  goto l613;
   yyDo(G, yy_3_IntLiteral, G->begin, G->end, "yy_3_IntLiteral");
 
   }
-  l618:;	  yyprintf((stderr, "  ok   IntLiteral"));
+  l614:;	  yyprintf((stderr, "  ok   IntLiteral"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l617:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IntLiteral"));
+  l613:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IntLiteral"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11183,19 +11181,19 @@ YY_RULE(int) yy_IntLiteral(GREG *G)
 YY_RULE(int) yy_EnumIncrementOper(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EnumIncrementOper"));
 
-  {  int yypos622= G->pos, yythunkpos622= G->thunkpos;  if (!yy_STAR(G))  goto l623;
+  {  int yypos618= G->pos, yythunkpos618= G->thunkpos;  if (!yy_STAR(G))  goto l619;
   yyDo(G, yy_1_EnumIncrementOper, G->begin, G->end, "yy_1_EnumIncrementOper");
-  goto l622;
-  l623:;	  G->pos= yypos622; G->thunkpos= yythunkpos622;  if (!yy_PLUS(G))  goto l621;
+  goto l618;
+  l619:;	  G->pos= yypos618; G->thunkpos= yythunkpos618;  if (!yy_PLUS(G))  goto l617;
   yyDo(G, yy_2_EnumIncrementOper, G->begin, G->end, "yy_2_EnumIncrementOper");
 
   }
-  l622:;	  yyprintf((stderr, "  ok   EnumIncrementOper"));
+  l618:;	  yyprintf((stderr, "  ok   EnumIncrementOper"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l621:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumIncrementOper"));
+  l617:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumIncrementOper"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11203,13 +11201,13 @@ YY_RULE(int) yy_EnumIncrementOper(GREG *G)
 }
 YY_RULE(int) yy_FROM_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FROM_KW"));
-  if (!yymatchString(G, "from")) goto l624;
+  if (!yymatchString(G, "from")) goto l620;
   yyprintf((stderr, "  ok   FROM_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l624:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FROM_KW"));
+  l620:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FROM_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11217,13 +11215,13 @@ YY_RULE(int) yy_FROM_KW(GREG *G)
 }
 YY_RULE(int) yy_ENUM_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ENUM_KW"));
-  if (!yymatchString(G, "enum")) goto l625;
+  if (!yymatchString(G, "enum")) goto l621;
   yyprintf((stderr, "  ok   ENUM_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l625:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ENUM_KW"));
+  l621:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ENUM_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11231,13 +11229,13 @@ YY_RULE(int) yy_ENUM_KW(GREG *G)
 }
 YY_RULE(int) yy_IMPLEMENTS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IMPLEMENTS_KW"));
-  if (!yymatchString(G, "implements")) goto l626;
+  if (!yymatchString(G, "implements")) goto l622;
   yyprintf((stderr, "  ok   IMPLEMENTS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l626:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPLEMENTS_KW"));
+  l622:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPLEMENTS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11245,13 +11243,13 @@ YY_RULE(int) yy_IMPLEMENTS_KW(GREG *G)
 }
 YY_RULE(int) yy_EXTENDS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXTENDS_KW"));
-  if (!yymatchString(G, "extends")) goto l627;
+  if (!yymatchString(G, "extends")) goto l623;
   yyprintf((stderr, "  ok   EXTENDS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l627:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTENDS_KW"));
+  l623:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTENDS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11259,13 +11257,13 @@ YY_RULE(int) yy_EXTENDS_KW(GREG *G)
 }
 YY_RULE(int) yy_CLASS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLASS_KW"));
-  if (!yymatchString(G, "class")) goto l628;
+  if (!yymatchString(G, "class")) goto l624;
   yyprintf((stderr, "  ok   CLASS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l628:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLASS_KW"));
+  l624:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLASS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11274,17 +11272,17 @@ YY_RULE(int) yy_CLASS_KW(GREG *G)
 YY_RULE(int) yy_ASS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS"));
 
-  {  int yypos630= G->pos, yythunkpos630= G->thunkpos;  if (!yy_DOUBLE_ARROW(G))  goto l630;
-  goto l629;
-  l630:;	  G->pos= yypos630; G->thunkpos= yythunkpos630;
-  }  if (!yymatchChar(G, '=')) goto l629;
-  if (!yy__(G))  goto l629;
+  {  int yypos626= G->pos, yythunkpos626= G->thunkpos;  if (!yy_DOUBLE_ARROW(G))  goto l626;
+  goto l625;
+  l626:;	  G->pos= yypos626; G->thunkpos= yythunkpos626;
+  }  if (!yymatchChar(G, '=')) goto l625;
+  if (!yy__(G))  goto l625;
   yyprintf((stderr, "  ok   ASS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l629:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS"));
+  l625:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11293,16 +11291,16 @@ YY_RULE(int) yy_ASS(GREG *G)
 YY_RULE(int) yy_DOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOT"));
 
-  {  int yypos632= G->pos, yythunkpos632= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l632;
-  goto l631;
-  l632:;	  G->pos= yypos632; G->thunkpos= yythunkpos632;
-  }  if (!yymatchChar(G, '.')) goto l631;
+  {  int yypos628= G->pos, yythunkpos628= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l628;
+  goto l627;
+  l628:;	  G->pos= yypos628; G->thunkpos= yythunkpos628;
+  }  if (!yymatchChar(G, '.')) goto l627;
   yyprintf((stderr, "  ok   DOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l631:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOT"));
+  l627:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11312,137 +11310,137 @@ YY_RULE(int) yy_Type(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 6, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Type"));
 
-  {  int yypos634= G->pos, yythunkpos634= G->thunkpos;  if (!yy_TypeList(G))  goto l635;
+  {  int yypos630= G->pos, yythunkpos630= G->thunkpos;  if (!yy_TypeList(G))  goto l631;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_1_Type, G->begin, G->end, "yy_1_Type");
-  goto l634;
-  l635:;	  G->pos= yypos634; G->thunkpos= yythunkpos634;  if (!yy_TypeBase(G))  goto l636;
+  goto l630;
+  l631:;	  G->pos= yypos630; G->thunkpos= yythunkpos630;  if (!yy_TypeBase(G))  goto l632;
   yyDo(G, yySet, -5, 0, "yySet");
 
-  {  int yypos637= G->pos, yythunkpos637= G->thunkpos;  if (!yy__(G))  goto l637;
-  if (!yymatchChar(G, '<')) goto l637;
-  if (!yy__(G))  goto l637;
-  if (!yy_Type(G))  goto l637;
+  {  int yypos633= G->pos, yythunkpos633= G->thunkpos;  if (!yy__(G))  goto l633;
+  if (!yymatchChar(G, '<')) goto l633;
+  if (!yy__(G))  goto l633;
+  if (!yy_Type(G))  goto l633;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_Type, G->begin, G->end, "yy_2_Type");
 
-  l639:;	
-  {  int yypos640= G->pos, yythunkpos640= G->thunkpos;  if (!yy__(G))  goto l640;
-  if (!yymatchChar(G, ',')) goto l640;
-  if (!yy__(G))  goto l640;
-  if (!yy_Type(G))  goto l640;
+  l635:;	
+  {  int yypos636= G->pos, yythunkpos636= G->thunkpos;  if (!yy__(G))  goto l636;
+  if (!yymatchChar(G, ',')) goto l636;
+  if (!yy__(G))  goto l636;
+  if (!yy_Type(G))  goto l636;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_3_Type, G->begin, G->end, "yy_3_Type");
-  goto l639;
-  l640:;	  G->pos= yypos640; G->thunkpos= yythunkpos640;
-  }  if (!yy__(G))  goto l637;
-  if (!yymatchChar(G, '>')) goto l637;
-  goto l638;
-  l637:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;
+  goto l635;
+  l636:;	  G->pos= yypos636; G->thunkpos= yythunkpos636;
+  }  if (!yy__(G))  goto l633;
+  if (!yymatchChar(G, '>')) goto l633;
+  goto l634;
+  l633:;	  G->pos= yypos633; G->thunkpos= yythunkpos633;
   }
-  l638:;	  if (!yy__(G))  goto l636;
+  l634:;	  if (!yy__(G))  goto l632;
 
-  l641:;	
-  {  int yypos642= G->pos, yythunkpos642= G->thunkpos;
-  {  int yypos643= G->pos, yythunkpos643= G->thunkpos;  if (!yy_STAR(G))  goto l644;
+  l637:;	
+  {  int yypos638= G->pos, yythunkpos638= G->thunkpos;
+  {  int yypos639= G->pos, yythunkpos639= G->thunkpos;  if (!yy_STAR(G))  goto l640;
   yyDo(G, yy_4_Type, G->begin, G->end, "yy_4_Type");
-  goto l643;
-  l644:;	  G->pos= yypos643; G->thunkpos= yythunkpos643;  if (!yymatchChar(G, '@')) goto l645;
+  goto l639;
+  l640:;	  G->pos= yypos639; G->thunkpos= yythunkpos639;  if (!yymatchChar(G, '@')) goto l641;
   yyDo(G, yy_5_Type, G->begin, G->end, "yy_5_Type");
-  goto l643;
-  l645:;	  G->pos= yypos643; G->thunkpos= yythunkpos643;  if (!yymatchChar(G, '[')) goto l642;
-  if (!yy_WS(G))  goto l642;
+  goto l639;
+  l641:;	  G->pos= yypos639; G->thunkpos= yythunkpos639;  if (!yymatchChar(G, '[')) goto l638;
+  if (!yy_WS(G))  goto l638;
   yyDo(G, yy_6_Type, G->begin, G->end, "yy_6_Type");
-  if (!yy__(G))  goto l642;
+  if (!yy__(G))  goto l638;
 
-  {  int yypos646= G->pos, yythunkpos646= G->thunkpos;  if (!yy_Expr(G))  goto l646;
+  {  int yypos642= G->pos, yythunkpos642= G->thunkpos;  if (!yy_Expr(G))  goto l642;
   yyDo(G, yySet, -3, 0, "yySet");
-  goto l647;
-  l646:;	  G->pos= yypos646; G->thunkpos= yythunkpos646;
+  goto l643;
+  l642:;	  G->pos= yypos642; G->thunkpos= yythunkpos642;
   }
-  l647:;	  if (!yymatchChar(G, ']')) goto l642;
+  l643:;	  if (!yymatchChar(G, ']')) goto l638;
   yyDo(G, yy_7_Type, G->begin, G->end, "yy_7_Type");
 
   }
-  l643:;	  goto l641;
-  l642:;	  G->pos= yypos642; G->thunkpos= yythunkpos642;
-  }  if (!yy__(G))  goto l636;
+  l639:;	  goto l637;
+  l638:;	  G->pos= yypos638; G->thunkpos= yythunkpos638;
+  }  if (!yy__(G))  goto l632;
   yyDo(G, yy_8_Type, G->begin, G->end, "yy_8_Type");
-  goto l634;
-  l636:;	  G->pos= yypos634; G->thunkpos= yythunkpos634;  if (!yymatchChar(G, '(')) goto l633;
-  if (!yy_Old(G))  goto l633;
+  goto l630;
+  l632:;	  G->pos= yypos630; G->thunkpos= yythunkpos630;  if (!yymatchChar(G, '(')) goto l629;
+  if (!yy_Old(G))  goto l629;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l633;
-  if (!yy_IDENT(G))  goto l633;
+  if (!yy__(G))  goto l629;
+  if (!yy_IDENT(G))  goto l629;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_9_Type, G->begin, G->end, "yy_9_Type");
-  if (!yy__(G))  goto l633;
-  if (!yy_TypeBase(G))  goto l633;
+  if (!yy__(G))  goto l629;
+  if (!yy_TypeBase(G))  goto l629;
   yyDo(G, yySet, -5, 0, "yySet");
 
-  {  int yypos648= G->pos, yythunkpos648= G->thunkpos;  if (!yy_FuncType(G))  goto l648;
-  goto l633;
-  l648:;	  G->pos= yypos648; G->thunkpos= yythunkpos648;
+  {  int yypos644= G->pos, yythunkpos644= G->thunkpos;  if (!yy_FuncType(G))  goto l644;
+  goto l629;
+  l644:;	  G->pos= yypos644; G->thunkpos= yythunkpos644;
   }  yyDo(G, yy_10_Type, G->begin, G->end, "yy_10_Type");
 
-  {  int yypos649= G->pos, yythunkpos649= G->thunkpos;  if (!yy__(G))  goto l649;
-  if (!yymatchChar(G, '<')) goto l649;
-  if (!yy__(G))  goto l649;
-  if (!yy_Type(G))  goto l649;
+  {  int yypos645= G->pos, yythunkpos645= G->thunkpos;  if (!yy__(G))  goto l645;
+  if (!yymatchChar(G, '<')) goto l645;
+  if (!yy__(G))  goto l645;
+  if (!yy_Type(G))  goto l645;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_11_Type, G->begin, G->end, "yy_11_Type");
 
-  l651:;	
-  {  int yypos652= G->pos, yythunkpos652= G->thunkpos;  if (!yy__(G))  goto l652;
-  if (!yymatchChar(G, ',')) goto l652;
-  if (!yy__(G))  goto l652;
-  if (!yy_Type(G))  goto l652;
+  l647:;	
+  {  int yypos648= G->pos, yythunkpos648= G->thunkpos;  if (!yy__(G))  goto l648;
+  if (!yymatchChar(G, ',')) goto l648;
+  if (!yy__(G))  goto l648;
+  if (!yy_Type(G))  goto l648;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_12_Type, G->begin, G->end, "yy_12_Type");
-  goto l651;
-  l652:;	  G->pos= yypos652; G->thunkpos= yythunkpos652;
-  }  if (!yy__(G))  goto l649;
-  if (!yymatchChar(G, '>')) goto l649;
-  goto l650;
-  l649:;	  G->pos= yypos649; G->thunkpos= yythunkpos649;
+  goto l647;
+  l648:;	  G->pos= yypos648; G->thunkpos= yythunkpos648;
+  }  if (!yy__(G))  goto l645;
+  if (!yymatchChar(G, '>')) goto l645;
+  goto l646;
+  l645:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;
   }
-  l650:;	  if (!yy__(G))  goto l633;
+  l646:;	  if (!yy__(G))  goto l629;
 
-  l653:;	
-  {  int yypos654= G->pos, yythunkpos654= G->thunkpos;
-  {  int yypos655= G->pos, yythunkpos655= G->thunkpos;  if (!yy_STAR(G))  goto l656;
+  l649:;	
+  {  int yypos650= G->pos, yythunkpos650= G->thunkpos;
+  {  int yypos651= G->pos, yythunkpos651= G->thunkpos;  if (!yy_STAR(G))  goto l652;
   yyDo(G, yy_13_Type, G->begin, G->end, "yy_13_Type");
-  goto l655;
-  l656:;	  G->pos= yypos655; G->thunkpos= yythunkpos655;  if (!yymatchChar(G, '@')) goto l657;
+  goto l651;
+  l652:;	  G->pos= yypos651; G->thunkpos= yythunkpos651;  if (!yymatchChar(G, '@')) goto l653;
   yyDo(G, yy_14_Type, G->begin, G->end, "yy_14_Type");
-  goto l655;
-  l657:;	  G->pos= yypos655; G->thunkpos= yythunkpos655;  if (!yymatchChar(G, '[')) goto l654;
-  if (!yy_WS(G))  goto l654;
+  goto l651;
+  l653:;	  G->pos= yypos651; G->thunkpos= yythunkpos651;  if (!yymatchChar(G, '[')) goto l650;
+  if (!yy_WS(G))  goto l650;
   yyDo(G, yy_15_Type, G->begin, G->end, "yy_15_Type");
-  if (!yy__(G))  goto l654;
+  if (!yy__(G))  goto l650;
 
-  {  int yypos658= G->pos, yythunkpos658= G->thunkpos;  if (!yy_Expr(G))  goto l658;
+  {  int yypos654= G->pos, yythunkpos654= G->thunkpos;  if (!yy_Expr(G))  goto l654;
   yyDo(G, yySet, -3, 0, "yySet");
-  goto l659;
-  l658:;	  G->pos= yypos658; G->thunkpos= yythunkpos658;
+  goto l655;
+  l654:;	  G->pos= yypos654; G->thunkpos= yythunkpos654;
   }
-  l659:;	  if (!yymatchChar(G, ']')) goto l654;
+  l655:;	  if (!yymatchChar(G, ']')) goto l650;
   yyDo(G, yy_16_Type, G->begin, G->end, "yy_16_Type");
 
   }
-  l655:;	  goto l653;
-  l654:;	  G->pos= yypos654; G->thunkpos= yythunkpos654;
-  }  if (!yy__(G))  goto l633;
+  l651:;	  goto l649;
+  l650:;	  G->pos= yypos650; G->thunkpos= yythunkpos650;
+  }  if (!yy__(G))  goto l629;
   yyDo(G, yy_17_Type, G->begin, G->end, "yy_17_Type");
-  if (!yymatchChar(G, ')')) goto l633;
+  if (!yymatchChar(G, ')')) goto l629;
 
   }
-  l634:;	  yyprintf((stderr, "  ok   Type"));
+  l630:;	  yyprintf((stderr, "  ok   Type"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 6, 0, "yyPop");
   return 1;
-  l633:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Type"));
+  l629:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Type"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11450,13 +11448,13 @@ YY_RULE(int) yy_Type(GREG *G)
 }
 YY_RULE(int) yy_R_ARROW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "R_ARROW"));
-  if (!yymatchString(G, "->")) goto l660;
+  if (!yymatchString(G, "->")) goto l656;
   yyprintf((stderr, "  ok   R_ARROW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l660:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "R_ARROW"));
+  l656:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "R_ARROW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11466,45 +11464,45 @@ YY_RULE(int) yy_Argument(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Argument"));
 
-  {  int yypos662= G->pos, yythunkpos662= G->thunkpos;  if (!yy_DOT(G))  goto l663;
-  if (!yy_IDENT(G))  goto l663;
+  {  int yypos658= G->pos, yythunkpos658= G->thunkpos;  if (!yy_DOT(G))  goto l659;
+  if (!yy_IDENT(G))  goto l659;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy__(G))  goto l663;
+  if (!yy__(G))  goto l659;
   yyDo(G, yy_1_Argument, G->begin, G->end, "yy_1_Argument");
-  goto l662;
-  l663:;	  G->pos= yypos662; G->thunkpos= yythunkpos662;  if (!yy_ASS(G))  goto l664;
-  if (!yy_IDENT(G))  goto l664;
+  goto l658;
+  l659:;	  G->pos= yypos658; G->thunkpos= yythunkpos658;  if (!yy_ASS(G))  goto l660;
+  if (!yy_IDENT(G))  goto l660;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy__(G))  goto l664;
+  if (!yy__(G))  goto l660;
   yyDo(G, yy_2_Argument, G->begin, G->end, "yy_2_Argument");
-  goto l662;
-  l664:;	  G->pos= yypos662; G->thunkpos= yythunkpos662;  if (!yy_VariableDecl(G))  goto l665;
+  goto l658;
+  l660:;	  G->pos= yypos658; G->thunkpos= yythunkpos658;  if (!yy_VariableDecl(G))  goto l661;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_3_Argument, G->begin, G->end, "yy_3_Argument");
-  goto l662;
-  l665:;	  G->pos= yypos662; G->thunkpos= yythunkpos662;  if (!yy_IDENT(G))  goto l666;
+  goto l658;
+  l661:;	  G->pos= yypos658; G->thunkpos= yythunkpos658;  if (!yy_IDENT(G))  goto l662;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l666;
-  if (!yymatchChar(G, ':')) goto l666;
-  if (!yy__(G))  goto l666;
-  if (!yymatchString(G, "...")) goto l666;
-  if (!yy__(G))  goto l666;
+  if (!yy__(G))  goto l662;
+  if (!yymatchChar(G, ':')) goto l662;
+  if (!yy__(G))  goto l662;
+  if (!yymatchString(G, "...")) goto l662;
+  if (!yy__(G))  goto l662;
   yyDo(G, yy_4_Argument, G->begin, G->end, "yy_4_Argument");
-  goto l662;
-  l666:;	  G->pos= yypos662; G->thunkpos= yythunkpos662;  if (!yy_Type(G))  goto l667;
+  goto l658;
+  l662:;	  G->pos= yypos658; G->thunkpos= yythunkpos658;  if (!yy_Type(G))  goto l663;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_5_Argument, G->begin, G->end, "yy_5_Argument");
-  goto l662;
-  l667:;	  G->pos= yypos662; G->thunkpos= yythunkpos662;  if (!yymatchString(G, "...")) goto l661;
+  goto l658;
+  l663:;	  G->pos= yypos658; G->thunkpos= yythunkpos658;  if (!yymatchString(G, "...")) goto l657;
   yyDo(G, yy_6_Argument, G->begin, G->end, "yy_6_Argument");
 
   }
-  l662:;	  yyprintf((stderr, "  ok   Argument"));
+  l658:;	  yyprintf((stderr, "  ok   Argument"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l661:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Argument"));
+  l657:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Argument"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11513,13 +11511,13 @@ YY_RULE(int) yy_Argument(GREG *G)
 YY_RULE(int) yy_AnonymousFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "AnonymousFunctionDecl"));
   yyDo(G, yy_1_AnonymousFunctionDecl, G->begin, G->end, "yy_1_AnonymousFunctionDecl");
-  if (!yy_FunctionDeclCore(G))  goto l668;
+  if (!yy_FunctionDeclCore(G))  goto l664;
   yyprintf((stderr, "  ok   AnonymousFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l668:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "AnonymousFunctionDecl"));
+  l664:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "AnonymousFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11528,30 +11526,30 @@ YY_RULE(int) yy_AnonymousFunctionDecl(GREG *G)
 YY_RULE(int) yy_FunctionDeclCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionDeclCore"));
-  if (!yy__(G))  goto l669;
-  if (!yy_FUNC_KW(G))  goto l669;
+  if (!yy__(G))  goto l665;
+  if (!yy_FUNC_KW(G))  goto l665;
 
-  {  int yypos670= G->pos, yythunkpos670= G->thunkpos;  if (!yymatchChar(G, '@')) goto l670;
+  {  int yypos666= G->pos, yythunkpos666= G->thunkpos;  if (!yymatchChar(G, '@')) goto l666;
   yyDo(G, yy_1_FunctionDeclCore, G->begin, G->end, "yy_1_FunctionDeclCore");
-  goto l671;
-  l670:;	  G->pos= yypos670; G->thunkpos= yythunkpos670;
+  goto l667;
+  l666:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;
   }
-  l671:;	
-  {  int yypos672= G->pos, yythunkpos672= G->thunkpos;  if (!yy__(G))  goto l672;
-  if (!yymatchChar(G, '~')) goto l672;
-  if (!yy_IDENT(G))  goto l672;
+  l667:;	
+  {  int yypos668= G->pos, yythunkpos668= G->thunkpos;  if (!yy__(G))  goto l668;
+  if (!yymatchChar(G, '~')) goto l668;
+  if (!yy_IDENT(G))  goto l668;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_FunctionDeclCore, G->begin, G->end, "yy_2_FunctionDeclCore");
-  goto l673;
-  l672:;	  G->pos= yypos672; G->thunkpos= yythunkpos672;
+  goto l669;
+  l668:;	  G->pos= yypos668; G->thunkpos= yythunkpos668;
   }
-  l673:;	  if (!yy_FunctionDeclBody(G))  goto l669;
+  l669:;	  if (!yy_FunctionDeclBody(G))  goto l665;
   yyprintf((stderr, "  ok   FunctionDeclCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l669:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclCore"));
+  l665:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11559,13 +11557,13 @@ YY_RULE(int) yy_FunctionDeclCore(GREG *G)
 }
 YY_RULE(int) yy_OVERRIDE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OVERRIDE_KW"));
-  if (!yymatchString(G, "override")) goto l674;
+  if (!yymatchString(G, "override")) goto l670;
   yyprintf((stderr, "  ok   OVERRIDE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l674:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OVERRIDE_KW"));
+  l670:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OVERRIDE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11573,13 +11571,13 @@ YY_RULE(int) yy_OVERRIDE_KW(GREG *G)
 }
 YY_RULE(int) yy_VIRTUAL_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "VIRTUAL_KW"));
-  if (!yymatchString(G, "virtual")) goto l675;
+  if (!yymatchString(G, "virtual")) goto l671;
   yyprintf((stderr, "  ok   VIRTUAL_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l675:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VIRTUAL_KW"));
+  l671:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VIRTUAL_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11587,13 +11585,13 @@ YY_RULE(int) yy_VIRTUAL_KW(GREG *G)
 }
 YY_RULE(int) yy_PROTO_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PROTO_KW"));
-  if (!yymatchString(G, "proto")) goto l676;
+  if (!yymatchString(G, "proto")) goto l672;
   yyprintf((stderr, "  ok   PROTO_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l676:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROTO_KW"));
+  l672:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROTO_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11601,13 +11599,13 @@ YY_RULE(int) yy_PROTO_KW(GREG *G)
 }
 YY_RULE(int) yy_FINAL_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FINAL_KW"));
-  if (!yymatchString(G, "final")) goto l677;
+  if (!yymatchString(G, "final")) goto l673;
   yyprintf((stderr, "  ok   FINAL_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l677:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FINAL_KW"));
+  l673:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FINAL_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11615,13 +11613,13 @@ YY_RULE(int) yy_FINAL_KW(GREG *G)
 }
 YY_RULE(int) yy_INLINE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INLINE_KW"));
-  if (!yymatchString(G, "inline")) goto l678;
+  if (!yymatchString(G, "inline")) goto l674;
   yyprintf((stderr, "  ok   INLINE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l678:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INLINE_KW"));
+  l674:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INLINE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11629,13 +11627,13 @@ YY_RULE(int) yy_INLINE_KW(GREG *G)
 }
 YY_RULE(int) yy_STATIC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "STATIC_KW"));
-  if (!yymatchString(G, "static")) goto l679;
+  if (!yymatchString(G, "static")) goto l675;
   yyprintf((stderr, "  ok   STATIC_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l679:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STATIC_KW"));
+  l675:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STATIC_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11644,26 +11642,26 @@ YY_RULE(int) yy_STATIC_KW(GREG *G)
 YY_RULE(int) yy_UnmangledName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "UnmangledName"));
-  if (!yy_UNMANGLED_KW(G))  goto l680;
+  if (!yy_UNMANGLED_KW(G))  goto l676;
   yyDo(G, yy_1_UnmangledName, G->begin, G->end, "yy_1_UnmangledName");
 
-  {  int yypos681= G->pos, yythunkpos681= G->thunkpos;  if (!yy__(G))  goto l681;
-  if (!yymatchChar(G, '(')) goto l681;
-  if (!yy__(G))  goto l681;
-  if (!yy_IDENT(G))  goto l681;
+  {  int yypos677= G->pos, yythunkpos677= G->thunkpos;  if (!yy__(G))  goto l677;
+  if (!yymatchChar(G, '(')) goto l677;
+  if (!yy__(G))  goto l677;
+  if (!yy_IDENT(G))  goto l677;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_UnmangledName, G->begin, G->end, "yy_2_UnmangledName");
-  if (!yy__(G))  goto l681;
-  if (!yymatchChar(G, ')')) goto l681;
-  goto l682;
-  l681:;	  G->pos= yypos681; G->thunkpos= yythunkpos681;
+  if (!yy__(G))  goto l677;
+  if (!yymatchChar(G, ')')) goto l677;
+  goto l678;
+  l677:;	  G->pos= yypos677; G->thunkpos= yythunkpos677;
   }
-  l682:;	  yyprintf((stderr, "  ok   UnmangledName"));
+  l678:;	  yyprintf((stderr, "  ok   UnmangledName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l680:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UnmangledName"));
+  l676:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UnmangledName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11671,30 +11669,30 @@ YY_RULE(int) yy_UnmangledName(GREG *G)
 }
 YY_RULE(int) yy_ExternName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ExternName"));
-  if (!yy_EXTERN_KW(G))  goto l683;
+  if (!yy_EXTERN_KW(G))  goto l679;
   yyDo(G, yy_1_ExternName, G->begin, G->end, "yy_1_ExternName");
 
-  {  int yypos684= G->pos, yythunkpos684= G->thunkpos;  if (!yy__(G))  goto l684;
-  if (!yymatchChar(G, '(')) goto l684;
-  if (!yy__(G))  goto l684;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l684;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_")) goto l684;
+  {  int yypos680= G->pos, yythunkpos680= G->thunkpos;  if (!yy__(G))  goto l680;
+  if (!yymatchChar(G, '(')) goto l680;
+  if (!yy__(G))  goto l680;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l680;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_")) goto l680;
 
-  l686:;	
-  {  int yypos687= G->pos, yythunkpos687= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_")) goto l687;
-  goto l686;
-  l687:;	  G->pos= yypos687; G->thunkpos= yythunkpos687;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l684;  yyDo(G, yy_2_ExternName, G->begin, G->end, "yy_2_ExternName");
-  if (!yy__(G))  goto l684;
-  if (!yymatchChar(G, ')')) goto l684;
-  goto l685;
-  l684:;	  G->pos= yypos684; G->thunkpos= yythunkpos684;
+  l682:;	
+  {  int yypos683= G->pos, yythunkpos683= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_")) goto l683;
+  goto l682;
+  l683:;	  G->pos= yypos683; G->thunkpos= yythunkpos683;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l680;  yyDo(G, yy_2_ExternName, G->begin, G->end, "yy_2_ExternName");
+  if (!yy__(G))  goto l680;
+  if (!yymatchChar(G, ')')) goto l680;
+  goto l681;
+  l680:;	  G->pos= yypos680; G->thunkpos= yythunkpos680;
   }
-  l685:;	  yyprintf((stderr, "  ok   ExternName"));
+  l681:;	  yyprintf((stderr, "  ok   ExternName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l683:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExternName"));
+  l679:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExternName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11703,17 +11701,17 @@ YY_RULE(int) yy_ExternName(GREG *G)
 YY_RULE(int) yy_OocDoc(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OocDoc"));
 
-  {  int yypos689= G->pos, yythunkpos689= G->thunkpos;  if (!yy_OocDocCore(G))  goto l690;
-  goto l689;
-  l690:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;  yyDo(G, yy_1_OocDoc, G->begin, G->end, "yy_1_OocDoc");
+  {  int yypos685= G->pos, yythunkpos685= G->thunkpos;  if (!yy_OocDocCore(G))  goto l686;
+  goto l685;
+  l686:;	  G->pos= yypos685; G->thunkpos= yythunkpos685;  yyDo(G, yy_1_OocDoc, G->begin, G->end, "yy_1_OocDoc");
 
   }
-  l689:;	  yyprintf((stderr, "  ok   OocDoc"));
+  l685:;	  yyprintf((stderr, "  ok   OocDoc"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l688:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDoc"));
+  l684:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDoc"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11721,13 +11719,13 @@ YY_RULE(int) yy_OocDoc(GREG *G)
 }
 YY_RULE(int) yy_FUNC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FUNC_KW"));
-  if (!yymatchString(G, "func")) goto l691;
+  if (!yymatchString(G, "func")) goto l687;
   yyprintf((stderr, "  ok   FUNC_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l691:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FUNC_KW"));
+  l687:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FUNC_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11736,20 +11734,20 @@ YY_RULE(int) yy_FUNC_KW(GREG *G)
 YY_RULE(int) yy_COLON(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "COLON"));
 
-  {  int yypos693= G->pos, yythunkpos693= G->thunkpos;  if (!yy_ASS_DECL(G))  goto l693;
-  goto l692;
-  l693:;	  G->pos= yypos693; G->thunkpos= yythunkpos693;
+  {  int yypos689= G->pos, yythunkpos689= G->thunkpos;  if (!yy_ASS_DECL(G))  goto l689;
+  goto l688;
+  l689:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;
   }
-  {  int yypos694= G->pos, yythunkpos694= G->thunkpos;  if (!yy_PROPASS_DECL(G))  goto l694;
-  goto l692;
-  l694:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;
-  }  if (!yymatchChar(G, ':')) goto l692;
+  {  int yypos690= G->pos, yythunkpos690= G->thunkpos;  if (!yy_PROPASS_DECL(G))  goto l690;
+  goto l688;
+  l690:;	  G->pos= yypos690; G->thunkpos= yythunkpos690;
+  }  if (!yymatchChar(G, ':')) goto l688;
   yyprintf((stderr, "  ok   COLON"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l692:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COLON"));
+  l688:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COLON"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11758,56 +11756,56 @@ YY_RULE(int) yy_COLON(GREG *G)
 YY_RULE(int) yy_RegularFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "RegularFunctionDecl"));
-  if (!yy_OocDoc(G))  goto l695;
+  if (!yy_OocDoc(G))  goto l691;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l695;
+  if (!yy_IDENT(G))  goto l691;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_RegularFunctionDecl, G->begin, G->end, "yy_1_RegularFunctionDecl");
-  if (!yy__(G))  goto l695;
-  if (!yy_COLON(G))  goto l695;
+  if (!yy__(G))  goto l691;
+  if (!yy_COLON(G))  goto l691;
 
-  l696:;	
-  {  int yypos697= G->pos, yythunkpos697= G->thunkpos;  if (!yy__(G))  goto l697;
+  l692:;	
+  {  int yypos693= G->pos, yythunkpos693= G->thunkpos;  if (!yy__(G))  goto l693;
 
-  {  int yypos698= G->pos, yythunkpos698= G->thunkpos;  if (!yy_ExternName(G))  goto l699;
+  {  int yypos694= G->pos, yythunkpos694= G->thunkpos;  if (!yy_ExternName(G))  goto l695;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_RegularFunctionDecl, G->begin, G->end, "yy_2_RegularFunctionDecl");
-  goto l698;
-  l699:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;  if (!yy_UnmangledName(G))  goto l700;
+  goto l694;
+  l695:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;  if (!yy_UnmangledName(G))  goto l696;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_RegularFunctionDecl, G->begin, G->end, "yy_3_RegularFunctionDecl");
-  goto l698;
-  l700:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;  if (!yy_ABSTRACT_KW(G))  goto l701;
+  goto l694;
+  l696:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;  if (!yy_ABSTRACT_KW(G))  goto l697;
   yyDo(G, yy_4_RegularFunctionDecl, G->begin, G->end, "yy_4_RegularFunctionDecl");
-  goto l698;
-  l701:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;  if (!yy_STATIC_KW(G))  goto l702;
+  goto l694;
+  l697:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;  if (!yy_STATIC_KW(G))  goto l698;
   yyDo(G, yy_5_RegularFunctionDecl, G->begin, G->end, "yy_5_RegularFunctionDecl");
-  goto l698;
-  l702:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;  if (!yy_INLINE_KW(G))  goto l703;
+  goto l694;
+  l698:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;  if (!yy_INLINE_KW(G))  goto l699;
   yyDo(G, yy_6_RegularFunctionDecl, G->begin, G->end, "yy_6_RegularFunctionDecl");
-  goto l698;
-  l703:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;  if (!yy_FINAL_KW(G))  goto l704;
+  goto l694;
+  l699:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;  if (!yy_FINAL_KW(G))  goto l700;
   yyDo(G, yy_7_RegularFunctionDecl, G->begin, G->end, "yy_7_RegularFunctionDecl");
-  goto l698;
-  l704:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;  if (!yy_PROTO_KW(G))  goto l705;
+  goto l694;
+  l700:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;  if (!yy_PROTO_KW(G))  goto l701;
   yyDo(G, yy_8_RegularFunctionDecl, G->begin, G->end, "yy_8_RegularFunctionDecl");
-  goto l698;
-  l705:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;  if (!yy_VIRTUAL_KW(G))  goto l706;
+  goto l694;
+  l701:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;  if (!yy_VIRTUAL_KW(G))  goto l702;
   yyDo(G, yy_9_RegularFunctionDecl, G->begin, G->end, "yy_9_RegularFunctionDecl");
-  goto l698;
-  l706:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;  if (!yy_OVERRIDE_KW(G))  goto l697;
+  goto l694;
+  l702:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;  if (!yy_OVERRIDE_KW(G))  goto l693;
   yyDo(G, yy_10_RegularFunctionDecl, G->begin, G->end, "yy_10_RegularFunctionDecl");
 
   }
-  l698:;	  goto l696;
-  l697:;	  G->pos= yypos697; G->thunkpos= yythunkpos697;
-  }  if (!yy_FunctionDeclCore(G))  goto l695;
+  l694:;	  goto l692;
+  l693:;	  G->pos= yypos693; G->thunkpos= yythunkpos693;
+  }  if (!yy_FunctionDeclCore(G))  goto l691;
   yyprintf((stderr, "  ok   RegularFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l695:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RegularFunctionDecl"));
+  l691:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RegularFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11816,32 +11814,32 @@ YY_RULE(int) yy_RegularFunctionDecl(GREG *G)
 YY_RULE(int) yy_SuperFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "SuperFunctionDecl"));
-  if (!yy_IDENT(G))  goto l707;
+  if (!yy_IDENT(G))  goto l703;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l707;
-  if (!yy_COLON(G))  goto l707;
-  if (!yy__(G))  goto l707;
-  if (!yymatchString(G, "super")) goto l707;
-  if (!yy__(G))  goto l707;
-  if (!yy_FUNC_KW(G))  goto l707;
-  if (!yy__(G))  goto l707;
+  if (!yy__(G))  goto l703;
+  if (!yy_COLON(G))  goto l703;
+  if (!yy__(G))  goto l703;
+  if (!yymatchString(G, "super")) goto l703;
+  if (!yy__(G))  goto l703;
+  if (!yy_FUNC_KW(G))  goto l703;
+  if (!yy__(G))  goto l703;
   yyDo(G, yy_1_SuperFunctionDecl, G->begin, G->end, "yy_1_SuperFunctionDecl");
 
-  {  int yypos708= G->pos, yythunkpos708= G->thunkpos;  if (!yy__(G))  goto l708;
-  if (!yymatchChar(G, '~')) goto l708;
-  if (!yy_IDENT(G))  goto l708;
+  {  int yypos704= G->pos, yythunkpos704= G->thunkpos;  if (!yy__(G))  goto l704;
+  if (!yymatchChar(G, '~')) goto l704;
+  if (!yy_IDENT(G))  goto l704;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_SuperFunctionDecl, G->begin, G->end, "yy_2_SuperFunctionDecl");
-  goto l709;
-  l708:;	  G->pos= yypos708; G->thunkpos= yythunkpos708;
+  goto l705;
+  l704:;	  G->pos= yypos704; G->thunkpos= yythunkpos704;
   }
-  l709:;	  yyDo(G, yy_3_SuperFunctionDecl, G->begin, G->end, "yy_3_SuperFunctionDecl");
+  l705:;	  yyDo(G, yy_3_SuperFunctionDecl, G->begin, G->end, "yy_3_SuperFunctionDecl");
   yyprintf((stderr, "  ok   SuperFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l707:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SuperFunctionDecl"));
+  l703:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SuperFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11851,87 +11849,87 @@ YY_RULE(int) yy_FunctionDeclBody(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionDeclBody"));
 
-  {  int yypos711= G->pos, yythunkpos711= G->thunkpos;  if (!yy_GenericArguments(G))  goto l711;
-  goto l712;
-  l711:;	  G->pos= yypos711; G->thunkpos= yythunkpos711;
+  {  int yypos707= G->pos, yythunkpos707= G->thunkpos;  if (!yy_GenericArguments(G))  goto l707;
+  goto l708;
+  l707:;	  G->pos= yypos707; G->thunkpos= yythunkpos707;
   }
-  l712:;	
-  {  int yypos713= G->pos, yythunkpos713= G->thunkpos;  if (!yy_WS(G))  goto l713;
-  if (!yymatchChar(G, '(')) goto l713;
+  l708:;	
+  {  int yypos709= G->pos, yythunkpos709= G->thunkpos;  if (!yy_WS(G))  goto l709;
+  if (!yymatchChar(G, '(')) goto l709;
   yyDo(G, yy_1_FunctionDeclBody, G->begin, G->end, "yy_1_FunctionDeclBody");
 
-  {  int yypos715= G->pos, yythunkpos715= G->thunkpos;  if (!yy_WS(G))  goto l715;
-  if (!yy_Argument(G))  goto l715;
-  if (!yy_WS(G))  goto l715;
+  {  int yypos711= G->pos, yythunkpos711= G->thunkpos;  if (!yy_WS(G))  goto l711;
+  if (!yy_Argument(G))  goto l711;
+  if (!yy_WS(G))  goto l711;
 
-  l717:;	
-  {  int yypos718= G->pos, yythunkpos718= G->thunkpos;  if (!yymatchChar(G, ',')) goto l718;
-  if (!yy_WS(G))  goto l718;
-  if (!yy_Argument(G))  goto l718;
-  if (!yy_WS(G))  goto l718;
-  goto l717;
-  l718:;	  G->pos= yypos718; G->thunkpos= yythunkpos718;
-  }  goto l716;
-  l715:;	  G->pos= yypos715; G->thunkpos= yythunkpos715;
+  l713:;	
+  {  int yypos714= G->pos, yythunkpos714= G->thunkpos;  if (!yymatchChar(G, ',')) goto l714;
+  if (!yy_WS(G))  goto l714;
+  if (!yy_Argument(G))  goto l714;
+  if (!yy_WS(G))  goto l714;
+  goto l713;
+  l714:;	  G->pos= yypos714; G->thunkpos= yythunkpos714;
+  }  goto l712;
+  l711:;	  G->pos= yypos711; G->thunkpos= yythunkpos711;
   }
-  l716:;	  if (!yy_WS(G))  goto l713;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ARG, "Malformed function argument (remember, it's `name: Type` in ooc, not `Type name`)\n") ; } goto l713; }
+  l712:;	  if (!yy_WS(G))  goto l709;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ARG, "Malformed function argument (remember, it's `name: Type` in ooc, not `Type name`)\n") ; } goto l709; }
   yyDo(G, yy_2_FunctionDeclBody, G->begin, G->end, "yy_2_FunctionDeclBody");
-  goto l714;
-  l713:;	  G->pos= yypos713; G->thunkpos= yythunkpos713;
+  goto l710;
+  l709:;	  G->pos= yypos709; G->thunkpos= yythunkpos709;
   }
-  l714:;	
-  {  int yypos719= G->pos, yythunkpos719= G->thunkpos;  if (!yy__(G))  goto l719;
-  if (!yymatchChar(G, '~')) goto l719;
-  if (!yy_IDENT(G))  goto l719;
+  l710:;	
+  {  int yypos715= G->pos, yythunkpos715= G->thunkpos;  if (!yy__(G))  goto l715;
+  if (!yymatchChar(G, '~')) goto l715;
+  if (!yy_IDENT(G))  goto l715;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_3_FunctionDeclBody, G->begin, G->end, "yy_3_FunctionDeclBody");
-  goto l720;
-  l719:;	  G->pos= yypos719; G->thunkpos= yythunkpos719;
+  goto l716;
+  l715:;	  G->pos= yypos715; G->thunkpos= yythunkpos715;
   }
-  l720:;	
-  {  int yypos721= G->pos, yythunkpos721= G->thunkpos;  if (!yy__(G))  goto l721;
-  if (!yy_R_ARROW(G))  goto l721;
-  if (!yy__(G))  goto l721;
-  if (!yy_Type(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_RET_TYPE, "Missing return type.\n") ; } goto l721; }
+  l716:;	
+  {  int yypos717= G->pos, yythunkpos717= G->thunkpos;  if (!yy__(G))  goto l717;
+  if (!yy_R_ARROW(G))  goto l717;
+  if (!yy__(G))  goto l717;
+  if (!yy_Type(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_RET_TYPE, "Missing return type.\n") ; } goto l717; }
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_FunctionDeclBody, G->begin, G->end, "yy_4_FunctionDeclBody");
-  goto l722;
-  l721:;	  G->pos= yypos721; G->thunkpos= yythunkpos721;
+  goto l718;
+  l717:;	  G->pos= yypos717; G->thunkpos= yythunkpos717;
   }
-  l722:;	
-  {  int yypos723= G->pos, yythunkpos723= G->thunkpos;  yyDo(G, yy_5_FunctionDeclBody, G->begin, G->end, "yy_5_FunctionDeclBody");
-  if (!yy_WS(G))  goto l723;
-  if (!yymatchChar(G, '{')) goto l723;
-  if (!yy_WS(G))  goto l723;
+  l718:;	
+  {  int yypos719= G->pos, yythunkpos719= G->thunkpos;  yyDo(G, yy_5_FunctionDeclBody, G->begin, G->end, "yy_5_FunctionDeclBody");
+  if (!yy_WS(G))  goto l719;
+  if (!yymatchChar(G, '{')) goto l719;
+  if (!yy_WS(G))  goto l719;
 
-  l725:;	
-  {  int yypos726= G->pos, yythunkpos726= G->thunkpos;  if (!yy_WS(G))  goto l726;
+  l721:;	
+  {  int yypos722= G->pos, yythunkpos722= G->thunkpos;  if (!yy_WS(G))  goto l722;
 
-  {  int yypos727= G->pos, yythunkpos727= G->thunkpos;  if (!yy_Stmt(G))  goto l728;
+  {  int yypos723= G->pos, yythunkpos723= G->thunkpos;  if (!yy_Stmt(G))  goto l724;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_FunctionDeclBody, G->begin, G->end, "yy_6_FunctionDeclBody");
-  goto l727;
-  l728:;	  G->pos= yypos727; G->thunkpos= yythunkpos727;  yyDo(G, yy_7_FunctionDeclBody, G->begin, G->end, "yy_7_FunctionDeclBody");
-  if (!yy_OocDocCore(G))  goto l726;
+  goto l723;
+  l724:;	  G->pos= yypos723; G->thunkpos= yythunkpos723;  yyDo(G, yy_7_FunctionDeclBody, G->begin, G->end, "yy_7_FunctionDeclBody");
+  if (!yy_OocDocCore(G))  goto l722;
   yyDo(G, yy_8_FunctionDeclBody, G->begin, G->end, "yy_8_FunctionDeclBody");
 
   }
-  l727:;	  if (!yy_WS(G))  goto l726;
-  goto l725;
-  l726:;	  G->pos= yypos726; G->thunkpos= yythunkpos726;
-  }  if (!yy_WS(G))  goto l723;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or closing bracket missing\n") ; } goto l723; }
-  goto l724;
-  l723:;	  G->pos= yypos723; G->thunkpos= yythunkpos723;
+  l723:;	  if (!yy_WS(G))  goto l722;
+  goto l721;
+  l722:;	  G->pos= yypos722; G->thunkpos= yythunkpos722;
+  }  if (!yy_WS(G))  goto l719;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or closing bracket missing\n") ; } goto l719; }
+  goto l720;
+  l719:;	  G->pos= yypos719; G->thunkpos= yythunkpos719;
   }
-  l724:;	  yyDo(G, yy_9_FunctionDeclBody, G->begin, G->end, "yy_9_FunctionDeclBody");
+  l720:;	  yyDo(G, yy_9_FunctionDeclBody, G->begin, G->end, "yy_9_FunctionDeclBody");
   yyprintf((stderr, "  ok   FunctionDeclBody"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l710:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclBody"));
+  l706:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclBody"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11939,13 +11937,13 @@ YY_RULE(int) yy_FunctionDeclBody(GREG *G)
 }
 YY_RULE(int) yy_ABSTRACT_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ABSTRACT_KW"));
-  if (!yymatchString(G, "abstract")) goto l729;
+  if (!yymatchString(G, "abstract")) goto l725;
   yyprintf((stderr, "  ok   ABSTRACT_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l729:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ABSTRACT_KW"));
+  l725:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ABSTRACT_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11953,13 +11951,13 @@ YY_RULE(int) yy_ABSTRACT_KW(GREG *G)
 }
 YY_RULE(int) yy_OPERATOR_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OPERATOR_KW"));
-  if (!yymatchString(G, "operator")) goto l730;
+  if (!yymatchString(G, "operator")) goto l726;
   yyprintf((stderr, "  ok   OPERATOR_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l730:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OPERATOR_KW"));
+  l726:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OPERATOR_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11967,18 +11965,18 @@ YY_RULE(int) yy_OPERATOR_KW(GREG *G)
 }
 YY_RULE(int) yy_TemplateDef(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "TemplateDef"));
-  if (!yy_WS(G))  goto l731;
-  if (!yymatchString(G, "template")) goto l731;
-  if (!yy_WS(G))  goto l731;
+  if (!yy_WS(G))  goto l727;
+  if (!yymatchString(G, "template")) goto l727;
+  if (!yy_WS(G))  goto l727;
   yyDo(G, yy_1_TemplateDef, G->begin, G->end, "yy_1_TemplateDef");
-  if (!yy_GenericArguments(G))  goto l731;
+  if (!yy_GenericArguments(G))  goto l727;
   yyDo(G, yy_2_TemplateDef, G->begin, G->end, "yy_2_TemplateDef");
   yyprintf((stderr, "  ok   TemplateDef"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l731:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TemplateDef"));
+  l727:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TemplateDef"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11986,23 +11984,23 @@ YY_RULE(int) yy_TemplateDef(GREG *G)
 }
 YY_RULE(int) yy_MORETHAN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MORETHAN"));
-  if (!yymatchChar(G, '>')) goto l732;
+  if (!yymatchChar(G, '>')) goto l728;
 
-  {  int yypos733= G->pos, yythunkpos733= G->thunkpos;
-  {  int yypos734= G->pos, yythunkpos734= G->thunkpos;  if (!yymatchChar(G, '=')) goto l735;
-  goto l734;
-  l735:;	  G->pos= yypos734; G->thunkpos= yythunkpos734;  if (!yymatchChar(G, '>')) goto l733;
+  {  int yypos729= G->pos, yythunkpos729= G->thunkpos;
+  {  int yypos730= G->pos, yythunkpos730= G->thunkpos;  if (!yymatchChar(G, '=')) goto l731;
+  goto l730;
+  l731:;	  G->pos= yypos730; G->thunkpos= yythunkpos730;  if (!yymatchChar(G, '>')) goto l729;
 
   }
-  l734:;	  goto l732;
-  l733:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;
-  }  if (!yy__(G))  goto l732;
+  l730:;	  goto l728;
+  l729:;	  G->pos= yypos729; G->thunkpos= yythunkpos729;
+  }  if (!yy__(G))  goto l728;
   yyprintf((stderr, "  ok   MORETHAN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l732:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN"));
+  l728:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12010,23 +12008,23 @@ YY_RULE(int) yy_MORETHAN(GREG *G)
 }
 YY_RULE(int) yy_LESSTHAN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "LESSTHAN"));
-  if (!yymatchChar(G, '<')) goto l736;
+  if (!yymatchChar(G, '<')) goto l732;
 
-  {  int yypos737= G->pos, yythunkpos737= G->thunkpos;
-  {  int yypos738= G->pos, yythunkpos738= G->thunkpos;  if (!yymatchChar(G, '=')) goto l739;
-  goto l738;
-  l739:;	  G->pos= yypos738; G->thunkpos= yythunkpos738;  if (!yymatchChar(G, '<')) goto l737;
+  {  int yypos733= G->pos, yythunkpos733= G->thunkpos;
+  {  int yypos734= G->pos, yythunkpos734= G->thunkpos;  if (!yymatchChar(G, '=')) goto l735;
+  goto l734;
+  l735:;	  G->pos= yypos734; G->thunkpos= yythunkpos734;  if (!yymatchChar(G, '<')) goto l733;
 
   }
-  l738:;	  goto l736;
-  l737:;	  G->pos= yypos737; G->thunkpos= yythunkpos737;
-  }  if (!yy__(G))  goto l736;
+  l734:;	  goto l732;
+  l733:;	  G->pos= yypos733; G->thunkpos= yythunkpos733;
+  }  if (!yy__(G))  goto l732;
   yyprintf((stderr, "  ok   LESSTHAN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l736:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN"));
+  l732:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12035,30 +12033,30 @@ YY_RULE(int) yy_LESSTHAN(GREG *G)
 YY_RULE(int) yy_GenericArguments(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "GenericArguments"));
-  if (!yy__(G))  goto l740;
-  if (!yy_LESSTHAN(G))  goto l740;
-  if (!yy__(G))  goto l740;
-  if (!yy_IDENT(G))  goto l740;
+  if (!yy__(G))  goto l736;
+  if (!yy_LESSTHAN(G))  goto l736;
+  if (!yy__(G))  goto l736;
+  if (!yy_IDENT(G))  goto l736;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_GenericArguments, G->begin, G->end, "yy_1_GenericArguments");
 
-  l741:;	
-  {  int yypos742= G->pos, yythunkpos742= G->thunkpos;  if (!yy__(G))  goto l742;
-  if (!yymatchChar(G, ',')) goto l742;
-  if (!yy__(G))  goto l742;
-  if (!yy_IDENT(G))  goto l742;
+  l737:;	
+  {  int yypos738= G->pos, yythunkpos738= G->thunkpos;  if (!yy__(G))  goto l738;
+  if (!yymatchChar(G, ',')) goto l738;
+  if (!yy__(G))  goto l738;
+  if (!yy_IDENT(G))  goto l738;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_GenericArguments, G->begin, G->end, "yy_2_GenericArguments");
-  goto l741;
-  l742:;	  G->pos= yypos742; G->thunkpos= yythunkpos742;
-  }  if (!yy_MORETHAN(G))  goto l740;
-  if (!yy__(G))  goto l740;
+  goto l737;
+  l738:;	  G->pos= yypos738; G->thunkpos= yythunkpos738;
+  }  if (!yy_MORETHAN(G))  goto l736;
+  if (!yy__(G))  goto l736;
   yyprintf((stderr, "  ok   GenericArguments"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l740:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericArguments"));
+  l736:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericArguments"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12067,27 +12065,27 @@ YY_RULE(int) yy_GenericArguments(GREG *G)
 YY_RULE(int) yy_Terminator(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Terminator"));
 
-  {  int yypos744= G->pos, yythunkpos744= G->thunkpos;  if (!yy_CommentLine(G))  goto l745;
-  goto l744;
-  l745:;	  G->pos= yypos744; G->thunkpos= yythunkpos744;
-  {  int yypos746= G->pos, yythunkpos746= G->thunkpos;  if (!yy_CommentMultiLine(G))  goto l746;
-  goto l747;
-  l746:;	  G->pos= yypos746; G->thunkpos= yythunkpos746;
+  {  int yypos740= G->pos, yythunkpos740= G->thunkpos;  if (!yy_CommentLine(G))  goto l741;
+  goto l740;
+  l741:;	  G->pos= yypos740; G->thunkpos= yythunkpos740;
+  {  int yypos742= G->pos, yythunkpos742= G->thunkpos;  if (!yy_CommentMultiLine(G))  goto l742;
+  goto l743;
+  l742:;	  G->pos= yypos742; G->thunkpos= yythunkpos742;
   }
-  l747:;	
-  {  int yypos748= G->pos, yythunkpos748= G->thunkpos;  if (!yy_EOL(G))  goto l749;
-  goto l748;
-  l749:;	  G->pos= yypos748; G->thunkpos= yythunkpos748;  if (!yymatchChar(G, ';')) goto l743;
+  l743:;	
+  {  int yypos744= G->pos, yythunkpos744= G->thunkpos;  if (!yy_EOL(G))  goto l745;
+  goto l744;
+  l745:;	  G->pos= yypos744; G->thunkpos= yythunkpos744;  if (!yymatchChar(G, ';')) goto l739;
 
   }
-  l748:;	
+  l744:;	
   }
-  l744:;	  yyprintf((stderr, "  ok   Terminator"));
+  l740:;	  yyprintf((stderr, "  ok   Terminator"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l743:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Terminator"));
+  l739:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Terminator"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12097,21 +12095,21 @@ YY_RULE(int) yy_VariableDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VariableDecl"));
 
-  {  int yypos751= G->pos, yythunkpos751= G->thunkpos;  if (!yy_VarDeclFromExpr(G))  goto l752;
+  {  int yypos747= G->pos, yythunkpos747= G->thunkpos;  if (!yy_VarDeclFromExpr(G))  goto l748;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_VariableDecl, G->begin, G->end, "yy_1_VariableDecl");
-  goto l751;
-  l752:;	  G->pos= yypos751; G->thunkpos= yythunkpos751;  if (!yy_ConventionalVarDecl(G))  goto l750;
+  goto l747;
+  l748:;	  G->pos= yypos747; G->thunkpos= yythunkpos747;  if (!yy_ConventionalVarDecl(G))  goto l746;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VariableDecl, G->begin, G->end, "yy_2_VariableDecl");
 
   }
-  l751:;	  yyprintf((stderr, "  ok   VariableDecl"));
+  l747:;	  yyprintf((stderr, "  ok   VariableDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l750:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VariableDecl"));
+  l746:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VariableDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12121,21 +12119,21 @@ YY_RULE(int) yy_PropertyDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDecl"));
 
-  {  int yypos754= G->pos, yythunkpos754= G->thunkpos;  if (!yy_PropertyDeclFromExpr(G))  goto l755;
+  {  int yypos750= G->pos, yythunkpos750= G->thunkpos;  if (!yy_PropertyDeclFromExpr(G))  goto l751;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_PropertyDecl, G->begin, G->end, "yy_1_PropertyDecl");
-  goto l754;
-  l755:;	  G->pos= yypos754; G->thunkpos= yythunkpos754;  if (!yy_ConventionalPropertyDecl(G))  goto l753;
+  goto l750;
+  l751:;	  G->pos= yypos750; G->thunkpos= yythunkpos750;  if (!yy_ConventionalPropertyDecl(G))  goto l749;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_PropertyDecl, G->begin, G->end, "yy_2_PropertyDecl");
 
   }
-  l754:;	  yyprintf((stderr, "  ok   PropertyDecl"));
+  l750:;	  yyprintf((stderr, "  ok   PropertyDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l753:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDecl"));
+  l749:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12144,17 +12142,17 @@ YY_RULE(int) yy_PropertyDecl(GREG *G)
 YY_RULE(int) yy_FunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FunctionDecl"));
 
-  {  int yypos757= G->pos, yythunkpos757= G->thunkpos;  if (!yy_SuperFunctionDecl(G))  goto l758;
-  goto l757;
-  l758:;	  G->pos= yypos757; G->thunkpos= yythunkpos757;  if (!yy_RegularFunctionDecl(G))  goto l756;
+  {  int yypos753= G->pos, yythunkpos753= G->thunkpos;  if (!yy_SuperFunctionDecl(G))  goto l754;
+  goto l753;
+  l754:;	  G->pos= yypos753; G->thunkpos= yythunkpos753;  if (!yy_RegularFunctionDecl(G))  goto l752;
 
   }
-  l757:;	  yyprintf((stderr, "  ok   FunctionDecl"));
+  l753:;	  yyprintf((stderr, "  ok   FunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l756:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDecl"));
+  l752:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12163,115 +12161,115 @@ YY_RULE(int) yy_FunctionDecl(GREG *G)
 YY_RULE(int) yy_OperatorDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OperatorDecl"));
 
-  {  int yypos760= G->pos, yythunkpos760= G->thunkpos;  if (!yy_OPERATOR_KW(G))  goto l761;
+  {  int yypos756= G->pos, yythunkpos756= G->thunkpos;  if (!yy_OPERATOR_KW(G))  goto l757;
   yyDo(G, yy_1_OperatorDecl, G->begin, G->end, "yy_1_OperatorDecl");
-  goto l760;
-  l761:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yy_ABSTRACT_KW(G))  goto l759;
-  if (!yy__(G))  goto l759;
-  if (!yy_OPERATOR_KW(G))  goto l759;
+  goto l756;
+  l757:;	  G->pos= yypos756; G->thunkpos= yythunkpos756;  if (!yy_ABSTRACT_KW(G))  goto l755;
+  if (!yy__(G))  goto l755;
+  if (!yy_OPERATOR_KW(G))  goto l755;
   yyDo(G, yy_2_OperatorDecl, G->begin, G->end, "yy_2_OperatorDecl");
 
   }
-  l760:;	  if (!yy__(G))  goto l759;
+  l756:;	  if (!yy__(G))  goto l755;
 
-  {  int yypos762= G->pos, yythunkpos762= G->thunkpos;  if (!yymatchChar(G, '@')) goto l762;
+  {  int yypos758= G->pos, yythunkpos758= G->thunkpos;  if (!yymatchChar(G, '@')) goto l758;
   yyDo(G, yy_3_OperatorDecl, G->begin, G->end, "yy_3_OperatorDecl");
-  goto l763;
-  l762:;	  G->pos= yypos762; G->thunkpos= yythunkpos762;
+  goto l759;
+  l758:;	  G->pos= yypos758; G->thunkpos= yythunkpos758;
   }
-  l763:;	  if (!yy__(G))  goto l759;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l759;
-  {  int yypos764= G->pos, yythunkpos764= G->thunkpos;  if (!yymatchString(G, "=>")) goto l765;
-  goto l764;
-  l765:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "<=>")) goto l766;
-  goto l764;
-  l766:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, ">>=")) goto l767;
-  goto l764;
-  l767:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "<<=")) goto l768;
-  goto l764;
-  l768:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, ">>")) goto l769;
-  goto l764;
-  l769:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "<<")) goto l770;
-  goto l764;
-  l770:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, ">=")) goto l771;
-  goto l764;
-  l771:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "<=")) goto l772;
-  goto l764;
-  l772:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "!=")) goto l773;
-  goto l764;
-  l773:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "==")) goto l774;
-  goto l764;
-  l774:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '>')) goto l775;
-  goto l764;
-  l775:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '<')) goto l776;
-  goto l764;
-  l776:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '!')) goto l777;
-  goto l764;
-  l777:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "??")) goto l778;
-  goto l764;
-  l778:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "+=")) goto l779;
-  goto l764;
-  l779:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "-=")) goto l780;
-  goto l764;
-  l780:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "*=")) goto l781;
-  goto l764;
-  l781:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "**=")) goto l782;
-  goto l764;
-  l782:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "/=")) goto l783;
-  goto l764;
-  l783:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "%=")) goto l784;
-  goto l764;
-  l784:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '+')) goto l785;
-  goto l764;
-  l785:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '-')) goto l786;
-  goto l764;
-  l786:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "**")) goto l787;
-  goto l764;
-  l787:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '/')) goto l788;
-  goto l764;
-  l788:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '*')) goto l789;
-  goto l764;
-  l789:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '=')) goto l790;
-  goto l764;
-  l790:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "[]=")) goto l791;
-  goto l764;
-  l791:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "[]")) goto l792;
-  goto l764;
-  l792:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "&&")) goto l793;
-  goto l764;
-  l793:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "||")) goto l794;
-  goto l764;
-  l794:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '%')) goto l795;
-  goto l764;
-  l795:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "as")) goto l796;
-  goto l764;
-  l796:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "implicit as")) goto l797;
-  goto l764;
-  l797:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "&=")) goto l798;
-  goto l764;
-  l798:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "|=")) goto l799;
-  goto l764;
-  l799:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchString(G, "^=")) goto l800;
-  goto l764;
-  l800:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '&')) goto l801;
-  goto l764;
-  l801:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '|')) goto l802;
-  goto l764;
-  l802:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '^')) goto l803;
-  goto l764;
-  l803:;	  G->pos= yypos764; G->thunkpos= yythunkpos764;  if (!yymatchChar(G, '~')) goto l759;
+  l759:;	  if (!yy__(G))  goto l755;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l755;
+  {  int yypos760= G->pos, yythunkpos760= G->thunkpos;  if (!yymatchString(G, "=>")) goto l761;
+  goto l760;
+  l761:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "<=>")) goto l762;
+  goto l760;
+  l762:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, ">>=")) goto l763;
+  goto l760;
+  l763:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "<<=")) goto l764;
+  goto l760;
+  l764:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, ">>")) goto l765;
+  goto l760;
+  l765:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "<<")) goto l766;
+  goto l760;
+  l766:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, ">=")) goto l767;
+  goto l760;
+  l767:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "<=")) goto l768;
+  goto l760;
+  l768:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "!=")) goto l769;
+  goto l760;
+  l769:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "==")) goto l770;
+  goto l760;
+  l770:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '>')) goto l771;
+  goto l760;
+  l771:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '<')) goto l772;
+  goto l760;
+  l772:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '!')) goto l773;
+  goto l760;
+  l773:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "??")) goto l774;
+  goto l760;
+  l774:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "+=")) goto l775;
+  goto l760;
+  l775:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "-=")) goto l776;
+  goto l760;
+  l776:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "*=")) goto l777;
+  goto l760;
+  l777:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "**=")) goto l778;
+  goto l760;
+  l778:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "/=")) goto l779;
+  goto l760;
+  l779:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "%=")) goto l780;
+  goto l760;
+  l780:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '+')) goto l781;
+  goto l760;
+  l781:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '-')) goto l782;
+  goto l760;
+  l782:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "**")) goto l783;
+  goto l760;
+  l783:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '/')) goto l784;
+  goto l760;
+  l784:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '*')) goto l785;
+  goto l760;
+  l785:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '=')) goto l786;
+  goto l760;
+  l786:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "[]=")) goto l787;
+  goto l760;
+  l787:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "[]")) goto l788;
+  goto l760;
+  l788:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "&&")) goto l789;
+  goto l760;
+  l789:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "||")) goto l790;
+  goto l760;
+  l790:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '%')) goto l791;
+  goto l760;
+  l791:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "as")) goto l792;
+  goto l760;
+  l792:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "implicit as")) goto l793;
+  goto l760;
+  l793:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "&=")) goto l794;
+  goto l760;
+  l794:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "|=")) goto l795;
+  goto l760;
+  l795:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchString(G, "^=")) goto l796;
+  goto l760;
+  l796:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '&')) goto l797;
+  goto l760;
+  l797:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '|')) goto l798;
+  goto l760;
+  l798:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '^')) goto l799;
+  goto l760;
+  l799:;	  G->pos= yypos760; G->thunkpos= yythunkpos760;  if (!yymatchChar(G, '~')) goto l755;
 
   }
-  l764:;	  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l759;  yyDo(G, yy_4_OperatorDecl, G->begin, G->end, "yy_4_OperatorDecl");
-  if (!yy__(G))  goto l759;
-  if (!yy_FunctionDeclBody(G))  goto l759;
+  l760:;	  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l755;  yyDo(G, yy_4_OperatorDecl, G->begin, G->end, "yy_4_OperatorDecl");
+  if (!yy__(G))  goto l755;
+  if (!yy_FunctionDeclBody(G))  goto l755;
   yyDo(G, yy_5_OperatorDecl, G->begin, G->end, "yy_5_OperatorDecl");
   yyprintf((stderr, "  ok   OperatorDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l759:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OperatorDecl"));
+  l755:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OperatorDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12280,70 +12278,70 @@ YY_RULE(int) yy_OperatorDecl(GREG *G)
 YY_RULE(int) yy_InterfaceDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "InterfaceDecl"));
-  if (!yy_OocDoc(G))  goto l804;
+  if (!yy_OocDoc(G))  goto l800;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l804;
+  if (!yy_IDENT(G))  goto l800;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_InterfaceDecl, G->begin, G->end, "yy_1_InterfaceDecl");
-  if (!yy__(G))  goto l804;
-  if (!yy_COLON(G))  goto l804;
-  if (!yy__(G))  goto l804;
-  if (!yy_INTERFACE_KW(G))  goto l804;
+  if (!yy__(G))  goto l800;
+  if (!yy_COLON(G))  goto l800;
+  if (!yy__(G))  goto l800;
+  if (!yy_INTERFACE_KW(G))  goto l800;
 
-  {  int yypos805= G->pos, yythunkpos805= G->thunkpos;  if (!yy_GenericArguments(G))  goto l805;
-  goto l806;
-  l805:;	  G->pos= yypos805; G->thunkpos= yythunkpos805;
+  {  int yypos801= G->pos, yythunkpos801= G->thunkpos;  if (!yy_GenericArguments(G))  goto l801;
+  goto l802;
+  l801:;	  G->pos= yypos801; G->thunkpos= yythunkpos801;
   }
-  l806:;	
-  {  int yypos807= G->pos, yythunkpos807= G->thunkpos;  if (!yy__(G))  goto l807;
-  if (!yy_EXTENDS_KW(G))  goto l807;
-  if (!yy__(G))  goto l807;
-  if (!yy_Type(G))  goto l807;
+  l802:;	
+  {  int yypos803= G->pos, yythunkpos803= G->thunkpos;  if (!yy__(G))  goto l803;
+  if (!yy_EXTENDS_KW(G))  goto l803;
+  if (!yy__(G))  goto l803;
+  if (!yy_Type(G))  goto l803;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_InterfaceDecl, G->begin, G->end, "yy_2_InterfaceDecl");
-  goto l808;
-  l807:;	  G->pos= yypos807; G->thunkpos= yythunkpos807;
+  goto l804;
+  l803:;	  G->pos= yypos803; G->thunkpos= yythunkpos803;
   }
-  l808:;	
-  {  int yypos809= G->pos, yythunkpos809= G->thunkpos;  if (!yy__(G))  goto l809;
-  if (!yy_IMPLEMENTS_KW(G))  goto l809;
-  if (!yy__(G))  goto l809;
-  if (!yy_Type(G))  goto l809;
+  l804:;	
+  {  int yypos805= G->pos, yythunkpos805= G->thunkpos;  if (!yy__(G))  goto l805;
+  if (!yy_IMPLEMENTS_KW(G))  goto l805;
+  if (!yy__(G))  goto l805;
+  if (!yy_Type(G))  goto l805;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_InterfaceDecl, G->begin, G->end, "yy_3_InterfaceDecl");
 
-  l811:;	
-  {  int yypos812= G->pos, yythunkpos812= G->thunkpos;  if (!yy__(G))  goto l812;
-  if (!yymatchChar(G, ',')) goto l812;
-  if (!yy__(G))  goto l812;
-  if (!yy_Type(G))  goto l812;
+  l807:;	
+  {  int yypos808= G->pos, yythunkpos808= G->thunkpos;  if (!yy__(G))  goto l808;
+  if (!yymatchChar(G, ',')) goto l808;
+  if (!yy__(G))  goto l808;
+  if (!yy_Type(G))  goto l808;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_InterfaceDecl, G->begin, G->end, "yy_4_InterfaceDecl");
-  goto l811;
-  l812:;	  G->pos= yypos812; G->thunkpos= yythunkpos812;
-  }  goto l810;
-  l809:;	  G->pos= yypos809; G->thunkpos= yythunkpos809;
+  goto l807;
+  l808:;	  G->pos= yypos808; G->thunkpos= yythunkpos808;
+  }  goto l806;
+  l805:;	  G->pos= yypos805; G->thunkpos= yythunkpos805;
   }
-  l810:;	  if (!yy_WS(G))  goto l804;
-  if (!yymatchChar(G, '{')) goto l804;
-  if (!yy_WS(G))  goto l804;
+  l806:;	  if (!yy_WS(G))  goto l800;
+  if (!yymatchChar(G, '{')) goto l800;
+  if (!yy_WS(G))  goto l800;
 
-  l813:;	
-  {  int yypos814= G->pos, yythunkpos814= G->thunkpos;  if (!yy_WS(G))  goto l814;
-  if (!yy_FunctionDecl(G))  goto l814;
+  l809:;	
+  {  int yypos810= G->pos, yythunkpos810= G->thunkpos;  if (!yy_WS(G))  goto l810;
+  if (!yy_FunctionDecl(G))  goto l810;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l814;
-  goto l813;
-  l814:;	  G->pos= yypos814; G->thunkpos= yythunkpos814;
-  }  if (!yy_WS(G))  goto l804;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected method or '"_CSBRACK"' to close interface.\n"); ; } goto l804; }
+  if (!yy_WS(G))  goto l810;
+  goto l809;
+  l810:;	  G->pos= yypos810; G->thunkpos= yythunkpos810;
+  }  if (!yy_WS(G))  goto l800;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected method or '"_CSBRACK"' to close interface.\n"); ; } goto l800; }
   yyDo(G, yy_5_InterfaceDecl, G->begin, G->end, "yy_5_InterfaceDecl");
   yyprintf((stderr, "  ok   InterfaceDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l804:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "InterfaceDecl"));
+  l800:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "InterfaceDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12352,86 +12350,86 @@ YY_RULE(int) yy_InterfaceDecl(GREG *G)
 YY_RULE(int) yy_EnumDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "EnumDecl"));
-  if (!yy_OocDoc(G))  goto l815;
+  if (!yy_OocDoc(G))  goto l811;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_IDENT(G))  goto l815;
+  if (!yy_IDENT(G))  goto l811;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_1_EnumDecl, G->begin, G->end, "yy_1_EnumDecl");
-  if (!yy__(G))  goto l815;
-  if (!yy_COLON(G))  goto l815;
-  if (!yy__(G))  goto l815;
-  if (!yy_ENUM_KW(G))  goto l815;
+  if (!yy__(G))  goto l811;
+  if (!yy_COLON(G))  goto l811;
+  if (!yy__(G))  goto l811;
+  if (!yy_ENUM_KW(G))  goto l811;
 
-  {  int yypos816= G->pos, yythunkpos816= G->thunkpos;  if (!yy__(G))  goto l816;
-  if (!yy_FROM_KW(G))  goto l816;
-  if (!yy__(G))  goto l816;
-  if (!yy_Type(G))  goto l816;
+  {  int yypos812= G->pos, yythunkpos812= G->thunkpos;  if (!yy__(G))  goto l812;
+  if (!yy_FROM_KW(G))  goto l812;
+  if (!yy__(G))  goto l812;
+  if (!yy_Type(G))  goto l812;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_2_EnumDecl, G->begin, G->end, "yy_2_EnumDecl");
-  goto l817;
-  l816:;	  G->pos= yypos816; G->thunkpos= yythunkpos816;
+  goto l813;
+  l812:;	  G->pos= yypos812; G->thunkpos= yythunkpos812;
   }
-  l817:;	
-  {  int yypos818= G->pos, yythunkpos818= G->thunkpos;  if (!yy__(G))  goto l818;
-  if (!yymatchChar(G, '(')) goto l818;
-  if (!yy__(G))  goto l818;
-  if (!yy_EnumIncrementOper(G))  goto l818;
+  l813:;	
+  {  int yypos814= G->pos, yythunkpos814= G->thunkpos;  if (!yy__(G))  goto l814;
+  if (!yymatchChar(G, '(')) goto l814;
+  if (!yy__(G))  goto l814;
+  if (!yy_EnumIncrementOper(G))  goto l814;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l818;
-  if (!yy_IntLiteral(G))  goto l818;
+  if (!yy_WS(G))  goto l814;
+  if (!yy_IntLiteral(G))  goto l814;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_EnumDecl, G->begin, G->end, "yy_3_EnumDecl");
-  if (!yy__(G))  goto l818;
-  if (!yymatchChar(G, ')')) goto l818;
-  goto l819;
-  l818:;	  G->pos= yypos818; G->thunkpos= yythunkpos818;
+  if (!yy__(G))  goto l814;
+  if (!yymatchChar(G, ')')) goto l814;
+  goto l815;
+  l814:;	  G->pos= yypos814; G->thunkpos= yythunkpos814;
   }
-  l819:;	  if (!yy_WS(G))  goto l815;
-  if (!yymatchChar(G, '{')) goto l815;
-  if (!yy_WS(G))  goto l815;
+  l815:;	  if (!yy_WS(G))  goto l811;
+  if (!yymatchChar(G, '{')) goto l811;
+  if (!yy_WS(G))  goto l811;
 
-  {  int yypos820= G->pos, yythunkpos820= G->thunkpos;  if (!yy_EnumElement(G))  goto l820;
+  {  int yypos816= G->pos, yythunkpos816= G->thunkpos;  if (!yy_EnumElement(G))  goto l816;
+
+  l818:;	
+  {  int yypos819= G->pos, yythunkpos819= G->thunkpos;
+  {  int yypos820= G->pos, yythunkpos820= G->thunkpos;  if (!yy_Terminator(G))  goto l821;
 
   l822:;	
-  {  int yypos823= G->pos, yythunkpos823= G->thunkpos;
-  {  int yypos824= G->pos, yythunkpos824= G->thunkpos;  if (!yy_Terminator(G))  goto l825;
+  {  int yypos823= G->pos, yythunkpos823= G->thunkpos;  if (!yy_Terminator(G))  goto l823;
+  goto l822;
+  l823:;	  G->pos= yypos823; G->thunkpos= yythunkpos823;
+  }  if (!yy_WS(G))  goto l821;
+  if (!yy_FunctionDecl(G))  goto l821;
+  goto l820;
+  l821:;	  G->pos= yypos820; G->thunkpos= yythunkpos820;
+  {  int yypos824= G->pos, yythunkpos824= G->thunkpos;  if (!yymatchChar(G, ',')) goto l825;
+  goto l824;
+  l825:;	  G->pos= yypos824; G->thunkpos= yythunkpos824;  if (!yy_Terminator(G))  goto l819;
 
   l826:;	
   {  int yypos827= G->pos, yythunkpos827= G->thunkpos;  if (!yy_Terminator(G))  goto l827;
   goto l826;
   l827:;	  G->pos= yypos827; G->thunkpos= yythunkpos827;
-  }  if (!yy_WS(G))  goto l825;
-  if (!yy_FunctionDecl(G))  goto l825;
-  goto l824;
-  l825:;	  G->pos= yypos824; G->thunkpos= yythunkpos824;
-  {  int yypos828= G->pos, yythunkpos828= G->thunkpos;  if (!yymatchChar(G, ',')) goto l829;
-  goto l828;
-  l829:;	  G->pos= yypos828; G->thunkpos= yythunkpos828;  if (!yy_Terminator(G))  goto l823;
-
-  l830:;	
-  {  int yypos831= G->pos, yythunkpos831= G->thunkpos;  if (!yy_Terminator(G))  goto l831;
-  goto l830;
-  l831:;	  G->pos= yypos831; G->thunkpos= yythunkpos831;
   }
   }
-  l828:;	  if (!yy_WS(G))  goto l823;
-  if (!yy_EnumElement(G))  goto l823;
+  l824:;	  if (!yy_WS(G))  goto l819;
+  if (!yy_EnumElement(G))  goto l819;
 
   }
-  l824:;	  goto l822;
-  l823:;	  G->pos= yypos823; G->thunkpos= yythunkpos823;
-  }  goto l821;
-  l820:;	  G->pos= yypos820; G->thunkpos= yythunkpos820;
+  l820:;	  goto l818;
+  l819:;	  G->pos= yypos819; G->thunkpos= yythunkpos819;
+  }  goto l817;
+  l816:;	  G->pos= yypos816; G->thunkpos= yythunkpos816;
   }
-  l821:;	  if (!yy_WS(G))  goto l815;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ENUM_ELEMENT, "Expected enum element!\n"); ; } goto l815; }
+  l817:;	  if (!yy_WS(G))  goto l811;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ENUM_ELEMENT, "Expected enum element!\n"); ; } goto l811; }
   yyDo(G, yy_4_EnumDecl, G->begin, G->end, "yy_4_EnumDecl");
   yyprintf((stderr, "  ok   EnumDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l815:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumDecl"));
+  l811:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12440,40 +12438,40 @@ YY_RULE(int) yy_EnumDecl(GREG *G)
 YY_RULE(int) yy_ExtendDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ExtendDecl"));
-  if (!yy_OocDoc(G))  goto l832;
+  if (!yy_OocDoc(G))  goto l828;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yymatchString(G, "extend")) goto l832;
-  if (!yy_WS(G))  goto l832;
-  if (!yy_Type(G))  goto l832;
+  if (!yymatchString(G, "extend")) goto l828;
+  if (!yy_WS(G))  goto l828;
+  if (!yy_Type(G))  goto l828;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_ExtendDecl, G->begin, G->end, "yy_1_ExtendDecl");
-  if (!yy_WS(G))  goto l832;
-  if (!yymatchChar(G, '{')) goto l832;
-  if (!yy_WS(G))  goto l832;
+  if (!yy_WS(G))  goto l828;
+  if (!yymatchChar(G, '{')) goto l828;
+  if (!yy_WS(G))  goto l828;
 
-  l833:;	
-  {  int yypos834= G->pos, yythunkpos834= G->thunkpos;  if (!yy_WS(G))  goto l834;
+  l829:;	
+  {  int yypos830= G->pos, yythunkpos830= G->thunkpos;  if (!yy_WS(G))  goto l830;
 
-  {  int yypos835= G->pos, yythunkpos835= G->thunkpos;  if (!yy_FunctionDecl(G))  goto l836;
+  {  int yypos831= G->pos, yythunkpos831= G->thunkpos;  if (!yy_FunctionDecl(G))  goto l832;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l835;
-  l836:;	  G->pos= yypos835; G->thunkpos= yythunkpos835;  if (!yy_PropertyDecl(G))  goto l834;
+  goto l831;
+  l832:;	  G->pos= yypos831; G->thunkpos= yythunkpos831;  if (!yy_PropertyDecl(G))  goto l830;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_ExtendDecl, G->begin, G->end, "yy_2_ExtendDecl");
 
   }
-  l835:;	  if (!yy_WS(G))  goto l834;
-  goto l833;
-  l834:;	  G->pos= yypos834; G->thunkpos= yythunkpos834;
-  }  if (!yy_WS(G))  goto l832;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected or function declaration\n"); ; } goto l832; }
+  l831:;	  if (!yy_WS(G))  goto l830;
+  goto l829;
+  l830:;	  G->pos= yypos830; G->thunkpos= yythunkpos830;
+  }  if (!yy_WS(G))  goto l828;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected or function declaration\n"); ; } goto l828; }
   yyDo(G, yy_3_ExtendDecl, G->begin, G->end, "yy_3_ExtendDecl");
   yyprintf((stderr, "  ok   ExtendDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l832:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExtendDecl"));
+  l828:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExtendDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12482,124 +12480,124 @@ YY_RULE(int) yy_ExtendDecl(GREG *G)
 YY_RULE(int) yy_CoverDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 8, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "CoverDecl"));
-  if (!yy_OocDoc(G))  goto l837;
+  if (!yy_OocDoc(G))  goto l833;
   yyDo(G, yySet, -8, 0, "yySet");
-  if (!yy_IDENT(G))  goto l837;
+  if (!yy_IDENT(G))  goto l833;
   yyDo(G, yySet, -7, 0, "yySet");
   yyDo(G, yy_1_CoverDecl, G->begin, G->end, "yy_1_CoverDecl");
-  if (!yy__(G))  goto l837;
-  if (!yy_COLON(G))  goto l837;
+  if (!yy__(G))  goto l833;
+  if (!yy_COLON(G))  goto l833;
 
-  {  int yypos838= G->pos, yythunkpos838= G->thunkpos;  if (!yy__(G))  goto l838;
-  if (!yy_ExternName(G))  goto l838;
+  {  int yypos834= G->pos, yythunkpos834= G->thunkpos;  if (!yy__(G))  goto l834;
+  if (!yy_ExternName(G))  goto l834;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_2_CoverDecl, G->begin, G->end, "yy_2_CoverDecl");
+  goto l835;
+  l834:;	  G->pos= yypos834; G->thunkpos= yythunkpos834;
+  }
+  l835:;	
+  {  int yypos836= G->pos, yythunkpos836= G->thunkpos;  if (!yy__(G))  goto l836;
+  if (!yy_PROTO_KW(G))  goto l836;
+  yyDo(G, yy_3_CoverDecl, G->begin, G->end, "yy_3_CoverDecl");
+  goto l837;
+  l836:;	  G->pos= yypos836; G->thunkpos= yythunkpos836;
+  }
+  l837:;	  if (!yy__(G))  goto l833;
+  if (!yy_COVER_KW(G))  goto l833;
+
+  {  int yypos838= G->pos, yythunkpos838= G->thunkpos;  if (!yy_GenericArguments(G))  goto l838;
   goto l839;
   l838:;	  G->pos= yypos838; G->thunkpos= yythunkpos838;
   }
   l839:;	
-  {  int yypos840= G->pos, yythunkpos840= G->thunkpos;  if (!yy__(G))  goto l840;
-  if (!yy_PROTO_KW(G))  goto l840;
-  yyDo(G, yy_3_CoverDecl, G->begin, G->end, "yy_3_CoverDecl");
+  {  int yypos840= G->pos, yythunkpos840= G->thunkpos;  if (!yy_TemplateDef(G))  goto l840;
   goto l841;
   l840:;	  G->pos= yypos840; G->thunkpos= yythunkpos840;
   }
-  l841:;	  if (!yy__(G))  goto l837;
-  if (!yy_COVER_KW(G))  goto l837;
-
-  {  int yypos842= G->pos, yythunkpos842= G->thunkpos;  if (!yy_GenericArguments(G))  goto l842;
+  l841:;	
+  {  int yypos842= G->pos, yythunkpos842= G->thunkpos;  if (!yy__(G))  goto l842;
+  if (!yy_FROM_KW(G))  goto l842;
+  if (!yy__(G))  goto l842;
+  if (!yy_Type(G))  goto l842;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_4_CoverDecl, G->begin, G->end, "yy_4_CoverDecl");
   goto l843;
   l842:;	  G->pos= yypos842; G->thunkpos= yythunkpos842;
   }
   l843:;	
-  {  int yypos844= G->pos, yythunkpos844= G->thunkpos;  if (!yy_TemplateDef(G))  goto l844;
+  {  int yypos844= G->pos, yythunkpos844= G->thunkpos;  if (!yy__(G))  goto l844;
+  if (!yy_EXTENDS_KW(G))  goto l844;
+  if (!yy__(G))  goto l844;
+  if (!yy_Type(G))  goto l844;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_5_CoverDecl, G->begin, G->end, "yy_5_CoverDecl");
   goto l845;
   l844:;	  G->pos= yypos844; G->thunkpos= yythunkpos844;
   }
   l845:;	
   {  int yypos846= G->pos, yythunkpos846= G->thunkpos;  if (!yy__(G))  goto l846;
-  if (!yy_FROM_KW(G))  goto l846;
+  if (!yy_IMPLEMENTS_KW(G))  goto l846;
   if (!yy__(G))  goto l846;
   if (!yy_Type(G))  goto l846;
   yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_4_CoverDecl, G->begin, G->end, "yy_4_CoverDecl");
-  goto l847;
+  yyDo(G, yy_6_CoverDecl, G->begin, G->end, "yy_6_CoverDecl");
+
+  l848:;	
+  {  int yypos849= G->pos, yythunkpos849= G->thunkpos;  if (!yy__(G))  goto l849;
+  if (!yymatchChar(G, ',')) goto l849;
+  if (!yy__(G))  goto l849;
+  if (!yy_Type(G))  goto l849;
+  yyDo(G, yySet, -5, 0, "yySet");
+  yyDo(G, yy_7_CoverDecl, G->begin, G->end, "yy_7_CoverDecl");
+  goto l848;
+  l849:;	  G->pos= yypos849; G->thunkpos= yythunkpos849;
+  }  goto l847;
   l846:;	  G->pos= yypos846; G->thunkpos= yythunkpos846;
   }
   l847:;	
-  {  int yypos848= G->pos, yythunkpos848= G->thunkpos;  if (!yy__(G))  goto l848;
-  if (!yy_EXTENDS_KW(G))  goto l848;
-  if (!yy__(G))  goto l848;
-  if (!yy_Type(G))  goto l848;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_5_CoverDecl, G->begin, G->end, "yy_5_CoverDecl");
-  goto l849;
-  l848:;	  G->pos= yypos848; G->thunkpos= yythunkpos848;
-  }
-  l849:;	
-  {  int yypos850= G->pos, yythunkpos850= G->thunkpos;  if (!yy__(G))  goto l850;
-  if (!yy_IMPLEMENTS_KW(G))  goto l850;
-  if (!yy__(G))  goto l850;
-  if (!yy_Type(G))  goto l850;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_6_CoverDecl, G->begin, G->end, "yy_6_CoverDecl");
+  {  int yypos850= G->pos, yythunkpos850= G->thunkpos;  if (!yy_WS(G))  goto l850;
+  if (!yymatchChar(G, '{')) goto l850;
+  if (!yy_WS(G))  goto l850;
 
   l852:;	
-  {  int yypos853= G->pos, yythunkpos853= G->thunkpos;  if (!yy__(G))  goto l853;
-  if (!yymatchChar(G, ',')) goto l853;
-  if (!yy__(G))  goto l853;
-  if (!yy_Type(G))  goto l853;
-  yyDo(G, yySet, -5, 0, "yySet");
-  yyDo(G, yy_7_CoverDecl, G->begin, G->end, "yy_7_CoverDecl");
-  goto l852;
-  l853:;	  G->pos= yypos853; G->thunkpos= yythunkpos853;
-  }  goto l851;
-  l850:;	  G->pos= yypos850; G->thunkpos= yythunkpos850;
-  }
-  l851:;	
-  {  int yypos854= G->pos, yythunkpos854= G->thunkpos;  if (!yy_WS(G))  goto l854;
-  if (!yymatchChar(G, '{')) goto l854;
-  if (!yy_WS(G))  goto l854;
+  {  int yypos853= G->pos, yythunkpos853= G->thunkpos;  if (!yy_WS(G))  goto l853;
 
-  l856:;	
-  {  int yypos857= G->pos, yythunkpos857= G->thunkpos;  if (!yy_WS(G))  goto l857;
-
-  {  int yypos858= G->pos, yythunkpos858= G->thunkpos;  if (!yy_VariableDecl(G))  goto l859;
+  {  int yypos854= G->pos, yythunkpos854= G->thunkpos;  if (!yy_VariableDecl(G))  goto l855;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_8_CoverDecl, G->begin, G->end, "yy_8_CoverDecl");
-  if (!yy_Terminator(G))  goto l859;
+  if (!yy_Terminator(G))  goto l855;
 
-  l860:;	
-  {  int yypos861= G->pos, yythunkpos861= G->thunkpos;  if (!yy_Terminator(G))  goto l861;
-  goto l860;
-  l861:;	  G->pos= yypos861; G->thunkpos= yythunkpos861;
-  }  goto l858;
-  l859:;	  G->pos= yypos858; G->thunkpos= yythunkpos858;  if (!yy_PropertyDecl(G))  goto l862;
+  l856:;	
+  {  int yypos857= G->pos, yythunkpos857= G->thunkpos;  if (!yy_Terminator(G))  goto l857;
+  goto l856;
+  l857:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;
+  }  goto l854;
+  l855:;	  G->pos= yypos854; G->thunkpos= yythunkpos854;  if (!yy_PropertyDecl(G))  goto l858;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_9_CoverDecl, G->begin, G->end, "yy_9_CoverDecl");
-  goto l858;
-  l862:;	  G->pos= yypos858; G->thunkpos= yythunkpos858;  if (!yy_OperatorDecl(G))  goto l863;
+  goto l854;
+  l858:;	  G->pos= yypos854; G->thunkpos= yythunkpos854;  if (!yy_OperatorDecl(G))  goto l859;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l858;
-  l863:;	  G->pos= yypos858; G->thunkpos= yythunkpos858;  if (!yy_FunctionDecl(G))  goto l857;
+  goto l854;
+  l859:;	  G->pos= yypos854; G->thunkpos= yythunkpos854;  if (!yy_FunctionDecl(G))  goto l853;
   yyDo(G, yySet, -1, 0, "yySet");
 
   }
-  l858:;	  if (!yy_WS(G))  goto l857;
-  goto l856;
-  l857:;	  G->pos= yypos857; G->thunkpos= yythunkpos857;
-  }  if (!yy_WS(G))  goto l854;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n"); ; } goto l854; }
-  goto l855;
-  l854:;	  G->pos= yypos854; G->thunkpos= yythunkpos854;
+  l854:;	  if (!yy_WS(G))  goto l853;
+  goto l852;
+  l853:;	  G->pos= yypos853; G->thunkpos= yythunkpos853;
+  }  if (!yy_WS(G))  goto l850;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n"); ; } goto l850; }
+  goto l851;
+  l850:;	  G->pos= yypos850; G->thunkpos= yythunkpos850;
   }
-  l855:;	  yyDo(G, yy_10_CoverDecl, G->begin, G->end, "yy_10_CoverDecl");
+  l851:;	  yyDo(G, yy_10_CoverDecl, G->begin, G->end, "yy_10_CoverDecl");
   yyprintf((stderr, "  ok   CoverDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 8, 0, "yyPop");
   return 1;
-  l837:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CoverDecl"));
+  l833:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CoverDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12608,115 +12606,110 @@ YY_RULE(int) yy_CoverDecl(GREG *G)
 YY_RULE(int) yy_ClassDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 8, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ClassDecl"));
-  if (!yy_OocDoc(G))  goto l864;
+  if (!yy_OocDoc(G))  goto l860;
   yyDo(G, yySet, -8, 0, "yySet");
-  if (!yy_IDENT(G))  goto l864;
+  if (!yy_IDENT(G))  goto l860;
   yyDo(G, yySet, -7, 0, "yySet");
   yyDo(G, yy_1_ClassDecl, G->begin, G->end, "yy_1_ClassDecl");
-  if (!yy__(G))  goto l864;
-  if (!yy_COLON(G))  goto l864;
+  if (!yy__(G))  goto l860;
+  if (!yy_COLON(G))  goto l860;
 
-  l865:;	
-  {  int yypos866= G->pos, yythunkpos866= G->thunkpos;  if (!yy__(G))  goto l866;
+  l861:;	
+  {  int yypos862= G->pos, yythunkpos862= G->thunkpos;  if (!yy__(G))  goto l862;
 
-  {  int yypos867= G->pos, yythunkpos867= G->thunkpos;  if (!yy_ExternName(G))  goto l868;
-  goto l867;
-  l868:;	  G->pos= yypos867; G->thunkpos= yythunkpos867;  if (!yy_ABSTRACT_KW(G))  goto l869;
+  {  int yypos863= G->pos, yythunkpos863= G->thunkpos;  if (!yy_ExternName(G))  goto l864;
+  goto l863;
+  l864:;	  G->pos= yypos863; G->thunkpos= yythunkpos863;  if (!yy_ABSTRACT_KW(G))  goto l865;
   yyDo(G, yy_2_ClassDecl, G->begin, G->end, "yy_2_ClassDecl");
-  goto l867;
-  l869:;	  G->pos= yypos867; G->thunkpos= yythunkpos867;  if (!yy_FINAL_KW(G))  goto l866;
+  goto l863;
+  l865:;	  G->pos= yypos863; G->thunkpos= yythunkpos863;  if (!yy_FINAL_KW(G))  goto l862;
   yyDo(G, yy_3_ClassDecl, G->begin, G->end, "yy_3_ClassDecl");
 
   }
-  l867:;	  goto l865;
-  l866:;	  G->pos= yypos866; G->thunkpos= yythunkpos866;
-  }  if (!yy__(G))  goto l864;
-  if (!yy_CLASS_KW(G))  goto l864;
+  l863:;	  goto l861;
+  l862:;	  G->pos= yypos862; G->thunkpos= yythunkpos862;
+  }  if (!yy__(G))  goto l860;
+  if (!yy_CLASS_KW(G))  goto l860;
 
-  {  int yypos870= G->pos, yythunkpos870= G->thunkpos;  if (!yy_GenericArguments(G))  goto l870;
-  goto l871;
-  l870:;	  G->pos= yypos870; G->thunkpos= yythunkpos870;
+  {  int yypos866= G->pos, yythunkpos866= G->thunkpos;  if (!yy_GenericArguments(G))  goto l866;
+  goto l867;
+  l866:;	  G->pos= yypos866; G->thunkpos= yythunkpos866;
   }
-  l871:;	
-  {  int yypos872= G->pos, yythunkpos872= G->thunkpos;  if (!yy_TemplateDef(G))  goto l872;
-  goto l873;
-  l872:;	  G->pos= yypos872; G->thunkpos= yythunkpos872;
-  }
-  l873:;	
-  {  int yypos874= G->pos, yythunkpos874= G->thunkpos;  if (!yy__(G))  goto l874;
-  if (!yy_EXTENDS_KW(G))  goto l874;
-  if (!yy__(G))  goto l874;
-  if (!yy_Type(G))  goto l874;
+  l867:;	
+  {  int yypos868= G->pos, yythunkpos868= G->thunkpos;  if (!yy__(G))  goto l868;
+  if (!yy_EXTENDS_KW(G))  goto l868;
+  if (!yy__(G))  goto l868;
+  if (!yy_Type(G))  goto l868;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_4_ClassDecl, G->begin, G->end, "yy_4_ClassDecl");
-  goto l875;
-  l874:;	  G->pos= yypos874; G->thunkpos= yythunkpos874;
+  goto l869;
+  l868:;	  G->pos= yypos868; G->thunkpos= yythunkpos868;
   }
-  l875:;	
-  {  int yypos876= G->pos, yythunkpos876= G->thunkpos;  if (!yy__(G))  goto l876;
-  if (!yy_IMPLEMENTS_KW(G))  goto l876;
-  if (!yy__(G))  goto l876;
-  if (!yy_Type(G))  goto l876;
+  l869:;	
+  {  int yypos870= G->pos, yythunkpos870= G->thunkpos;  if (!yy__(G))  goto l870;
+  if (!yy_IMPLEMENTS_KW(G))  goto l870;
+  if (!yy__(G))  goto l870;
+  if (!yy_Type(G))  goto l870;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_5_ClassDecl, G->begin, G->end, "yy_5_ClassDecl");
 
-  l878:;	
-  {  int yypos879= G->pos, yythunkpos879= G->thunkpos;  if (!yy__(G))  goto l879;
-  if (!yymatchChar(G, ',')) goto l879;
-  if (!yy__(G))  goto l879;
-  if (!yy_Type(G))  goto l879;
+  l872:;	
+  {  int yypos873= G->pos, yythunkpos873= G->thunkpos;  if (!yy__(G))  goto l873;
+  if (!yymatchChar(G, ',')) goto l873;
+  if (!yy__(G))  goto l873;
+  if (!yy_Type(G))  goto l873;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_6_ClassDecl, G->begin, G->end, "yy_6_ClassDecl");
-  goto l878;
-  l879:;	  G->pos= yypos879; G->thunkpos= yythunkpos879;
-  }  goto l877;
-  l876:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;
+  goto l872;
+  l873:;	  G->pos= yypos873; G->thunkpos= yythunkpos873;
+  }  goto l871;
+  l870:;	  G->pos= yypos870; G->thunkpos= yythunkpos870;
   }
-  l877:;	  yyDo(G, yy_7_ClassDecl, G->begin, G->end, "yy_7_ClassDecl");
-  if (!yy_WS(G))  goto l864;
-  if (!yymatchChar(G, '{')) goto l864;
-  if (!yy_WS(G))  goto l864;
+  l871:;	  yyDo(G, yy_7_ClassDecl, G->begin, G->end, "yy_7_ClassDecl");
+  if (!yy_WS(G))  goto l860;
+  if (!yymatchChar(G, '{')) goto l860;
+  if (!yy_WS(G))  goto l860;
 
-  l880:;	
-  {  int yypos881= G->pos, yythunkpos881= G->thunkpos;  if (!yy_WS(G))  goto l881;
+  l874:;	
+  {  int yypos875= G->pos, yythunkpos875= G->thunkpos;  if (!yy_WS(G))  goto l875;
 
-  {  int yypos882= G->pos, yythunkpos882= G->thunkpos;  if (!yy_VariableDecl(G))  goto l883;
+  {  int yypos876= G->pos, yythunkpos876= G->thunkpos;  if (!yy_VariableDecl(G))  goto l877;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_8_ClassDecl, G->begin, G->end, "yy_8_ClassDecl");
-  if (!yy_Terminator(G))  goto l883;
+  if (!yy_Terminator(G))  goto l877;
 
-  l884:;	
-  {  int yypos885= G->pos, yythunkpos885= G->thunkpos;  if (!yy_Terminator(G))  goto l885;
-  goto l884;
-  l885:;	  G->pos= yypos885; G->thunkpos= yythunkpos885;
-  }  goto l882;
-  l883:;	  G->pos= yypos882; G->thunkpos= yythunkpos882;  if (!yy_PropertyDecl(G))  goto l886;
+  l878:;	
+  {  int yypos879= G->pos, yythunkpos879= G->thunkpos;  if (!yy_Terminator(G))  goto l879;
+  goto l878;
+  l879:;	  G->pos= yypos879; G->thunkpos= yythunkpos879;
+  }  goto l876;
+  l877:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;  if (!yy_PropertyDecl(G))  goto l880;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_9_ClassDecl, G->begin, G->end, "yy_9_ClassDecl");
-  goto l882;
-  l886:;	  G->pos= yypos882; G->thunkpos= yythunkpos882;  if (!yy_FunctionDecl(G))  goto l887;
+  goto l876;
+  l880:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;  if (!yy_FunctionDecl(G))  goto l881;
   yyDo(G, yySet, -3, 0, "yySet");
-  goto l882;
-  l887:;	  G->pos= yypos882; G->thunkpos= yythunkpos882;  if (!yy_OperatorDecl(G))  goto l888;
+  goto l876;
+  l881:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;  if (!yy_OperatorDecl(G))  goto l882;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l882;
-  l888:;	  G->pos= yypos882; G->thunkpos= yythunkpos882;  if (!yy_Stmt(G))  goto l881;
+  goto l876;
+  l882:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;  if (!yy_Stmt(G))  goto l875;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_ClassDecl, G->begin, G->end, "yy_10_ClassDecl");
 
   }
-  l882:;	  if (!yy_WS(G))  goto l881;
-  goto l880;
-  l881:;	  G->pos= yypos881; G->thunkpos= yythunkpos881;
-  }  if (!yy_WS(G))  goto l864;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected member, method, or '"_CSBRACK"' to close class.\n"); ; } goto l864; }
+  l876:;	  if (!yy_WS(G))  goto l875;
+  goto l874;
+  l875:;	  G->pos= yypos875; G->thunkpos= yythunkpos875;
+  }  if (!yy_WS(G))  goto l860;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected member, method, or '"_CSBRACK"' to close class.\n"); ; } goto l860; }
   yyDo(G, yy_11_ClassDecl, G->begin, G->end, "yy_11_ClassDecl");
   yyprintf((stderr, "  ok   ClassDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 8, 0, "yyPop");
   return 1;
-  l864:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ClassDecl"));
+  l860:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ClassDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12725,15 +12718,15 @@ YY_RULE(int) yy_ClassDecl(GREG *G)
 YY_RULE(int) yy_IDENT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IDENT"));
-  if (!yy_IDENT_CORE(G))  goto l889;
+  if (!yy_IDENT_CORE(G))  goto l883;
   yyDo(G, yySet, 0, 0, "yySet");
-  if (!yy__(G))  goto l889;
+  if (!yy__(G))  goto l883;
   yyprintf((stderr, "  ok   IDENT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l889:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IDENT"));
+  l883:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IDENT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12741,13 +12734,13 @@ YY_RULE(int) yy_IDENT(GREG *G)
 }
 YY_RULE(int) yy_INTO_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INTO_KW"));
-  if (!yymatchString(G, "into")) goto l890;
+  if (!yymatchString(G, "into")) goto l884;
   yyprintf((stderr, "  ok   INTO_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l890:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTO_KW"));
+  l884:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTO_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12755,29 +12748,29 @@ YY_RULE(int) yy_INTO_KW(GREG *G)
 }
 YY_RULE(int) yy_ImportName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ImportName"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l891;
-  {  int yypos894= G->pos, yythunkpos894= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l895;
-  goto l894;
-  l895:;	  G->pos= yypos894; G->thunkpos= yythunkpos894;  if (!yymatchChar(G, '-')) goto l891;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l885;
+  {  int yypos888= G->pos, yythunkpos888= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l889;
+  goto l888;
+  l889:;	  G->pos= yypos888; G->thunkpos= yythunkpos888;  if (!yymatchChar(G, '-')) goto l885;
 
   }
-  l894:;	
-  l892:;	
-  {  int yypos893= G->pos, yythunkpos893= G->thunkpos;
-  {  int yypos896= G->pos, yythunkpos896= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l897;
-  goto l896;
-  l897:;	  G->pos= yypos896; G->thunkpos= yythunkpos896;  if (!yymatchChar(G, '-')) goto l893;
+  l888:;	
+  l886:;	
+  {  int yypos887= G->pos, yythunkpos887= G->thunkpos;
+  {  int yypos890= G->pos, yythunkpos890= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l891;
+  goto l890;
+  l891:;	  G->pos= yypos890; G->thunkpos= yythunkpos890;  if (!yymatchChar(G, '-')) goto l887;
 
   }
-  l896:;	  goto l892;
-  l893:;	  G->pos= yypos893; G->thunkpos= yythunkpos893;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l891;  yyDo(G, yy_1_ImportName, G->begin, G->end, "yy_1_ImportName");
+  l890:;	  goto l886;
+  l887:;	  G->pos= yypos887; G->thunkpos= yythunkpos887;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l885;  yyDo(G, yy_1_ImportName, G->begin, G->end, "yy_1_ImportName");
   yyprintf((stderr, "  ok   ImportName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l891:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportName"));
+  l885:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12785,38 +12778,38 @@ YY_RULE(int) yy_ImportName(GREG *G)
 }
 YY_RULE(int) yy_ImportPath(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ImportPath"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l898;
-  l899:;	
-  {  int yypos900= G->pos, yythunkpos900= G->thunkpos;
-  {  int yypos903= G->pos, yythunkpos903= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l904;
-  goto l903;
-  l904:;	  G->pos= yypos903; G->thunkpos= yythunkpos903;  if (!yymatchChar(G, '.')) goto l905;
-  goto l903;
-  l905:;	  G->pos= yypos903; G->thunkpos= yythunkpos903;  if (!yymatchChar(G, '-')) goto l900;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l892;
+  l893:;	
+  {  int yypos894= G->pos, yythunkpos894= G->thunkpos;
+  {  int yypos897= G->pos, yythunkpos897= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l898;
+  goto l897;
+  l898:;	  G->pos= yypos897; G->thunkpos= yythunkpos897;  if (!yymatchChar(G, '.')) goto l899;
+  goto l897;
+  l899:;	  G->pos= yypos897; G->thunkpos= yythunkpos897;  if (!yymatchChar(G, '-')) goto l894;
 
   }
-  l903:;	
-  l901:;	
-  {  int yypos902= G->pos, yythunkpos902= G->thunkpos;
-  {  int yypos906= G->pos, yythunkpos906= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l907;
-  goto l906;
-  l907:;	  G->pos= yypos906; G->thunkpos= yythunkpos906;  if (!yymatchChar(G, '.')) goto l908;
-  goto l906;
-  l908:;	  G->pos= yypos906; G->thunkpos= yythunkpos906;  if (!yymatchChar(G, '-')) goto l902;
+  l897:;	
+  l895:;	
+  {  int yypos896= G->pos, yythunkpos896= G->thunkpos;
+  {  int yypos900= G->pos, yythunkpos900= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l901;
+  goto l900;
+  l901:;	  G->pos= yypos900; G->thunkpos= yythunkpos900;  if (!yymatchChar(G, '.')) goto l902;
+  goto l900;
+  l902:;	  G->pos= yypos900; G->thunkpos= yythunkpos900;  if (!yymatchChar(G, '-')) goto l896;
 
   }
-  l906:;	  goto l901;
-  l902:;	  G->pos= yypos902; G->thunkpos= yythunkpos902;
-  }  if (!yymatchChar(G, '/')) goto l900;
-  goto l899;
-  l900:;	  G->pos= yypos900; G->thunkpos= yythunkpos900;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l898;  yyDo(G, yy_1_ImportPath, G->begin, G->end, "yy_1_ImportPath");
+  l900:;	  goto l895;
+  l896:;	  G->pos= yypos896; G->thunkpos= yythunkpos896;
+  }  if (!yymatchChar(G, '/')) goto l894;
+  goto l893;
+  l894:;	  G->pos= yypos894; G->thunkpos= yythunkpos894;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l892;  yyDo(G, yy_1_ImportPath, G->begin, G->end, "yy_1_ImportPath");
   yyprintf((stderr, "  ok   ImportPath"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l898:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportPath"));
+  l892:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportPath"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12825,60 +12818,60 @@ YY_RULE(int) yy_ImportPath(GREG *G)
 YY_RULE(int) yy_ImportAtom(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ImportAtom"));
-  if (!yy_ImportPath(G))  goto l909;
+  if (!yy_ImportPath(G))  goto l903;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos910= G->pos, yythunkpos910= G->thunkpos;  if (!yy_ImportName(G))  goto l911;
+  {  int yypos904= G->pos, yythunkpos904= G->thunkpos;  if (!yy_ImportName(G))  goto l905;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_1_ImportAtom, G->begin, G->end, "yy_1_ImportAtom");
   yyDo(G, yy_2_ImportAtom, G->begin, G->end, "yy_2_ImportAtom");
 
-  {  int yypos912= G->pos, yythunkpos912= G->thunkpos;  if (!yy__(G))  goto l912;
-  if (!yy_INTO_KW(G))  goto l912;
-  if (!yy__(G))  goto l912;
-  if (!yy_IDENT(G))  goto l912;
+  {  int yypos906= G->pos, yythunkpos906= G->thunkpos;  if (!yy__(G))  goto l906;
+  if (!yy_INTO_KW(G))  goto l906;
+  if (!yy__(G))  goto l906;
+  if (!yy_IDENT(G))  goto l906;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_ImportAtom, G->begin, G->end, "yy_3_ImportAtom");
-  goto l913;
-  l912:;	  G->pos= yypos912; G->thunkpos= yythunkpos912;
+  goto l907;
+  l906:;	  G->pos= yypos906; G->thunkpos= yythunkpos906;
   }
-  l913:;	  goto l910;
-  l911:;	  G->pos= yypos910; G->thunkpos= yythunkpos910;  if (!yymatchChar(G, '[')) goto l909;
+  l907:;	  goto l904;
+  l905:;	  G->pos= yypos904; G->thunkpos= yythunkpos904;  if (!yymatchChar(G, '[')) goto l903;
   yyDo(G, yy_4_ImportAtom, G->begin, G->end, "yy_4_ImportAtom");
 
-  l914:;	
-  {  int yypos915= G->pos, yythunkpos915= G->thunkpos;  if (!yy_ImportName(G))  goto l915;
+  l908:;	
+  {  int yypos909= G->pos, yythunkpos909= G->thunkpos;  if (!yy_ImportName(G))  goto l909;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_5_ImportAtom, G->begin, G->end, "yy_5_ImportAtom");
-  if (!yy__(G))  goto l915;
-  if (!yymatchChar(G, ',')) goto l915;
-  if (!yy_WS(G))  goto l915;
+  if (!yy__(G))  goto l909;
+  if (!yymatchChar(G, ',')) goto l909;
+  if (!yy_WS(G))  goto l909;
   yyDo(G, yy_6_ImportAtom, G->begin, G->end, "yy_6_ImportAtom");
-  goto l914;
-  l915:;	  G->pos= yypos915; G->thunkpos= yythunkpos915;
-  }  if (!yy_ImportName(G))  goto l909;
+  goto l908;
+  l909:;	  G->pos= yypos909; G->thunkpos= yythunkpos909;
+  }  if (!yy_ImportName(G))  goto l903;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_7_ImportAtom, G->begin, G->end, "yy_7_ImportAtom");
   yyDo(G, yy_8_ImportAtom, G->begin, G->end, "yy_8_ImportAtom");
-  if (!yymatchChar(G, ']')) goto l909;
+  if (!yymatchChar(G, ']')) goto l903;
 
-  {  int yypos916= G->pos, yythunkpos916= G->thunkpos;  if (!yy__(G))  goto l916;
-  if (!yy_INTO_KW(G))  goto l916;
-  if (!yy__(G))  goto l916;
-  if (!yy_IDENT(G))  goto l916;
+  {  int yypos910= G->pos, yythunkpos910= G->thunkpos;  if (!yy__(G))  goto l910;
+  if (!yy_INTO_KW(G))  goto l910;
+  if (!yy__(G))  goto l910;
+  if (!yy_IDENT(G))  goto l910;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_9_ImportAtom, G->begin, G->end, "yy_9_ImportAtom");
-  goto l917;
-  l916:;	  G->pos= yypos916; G->thunkpos= yythunkpos916;
+  goto l911;
+  l910:;	  G->pos= yypos910; G->thunkpos= yythunkpos910;
   }
-  l917:;	
+  l911:;	
   }
-  l910:;	  yyprintf((stderr, "  ok   ImportAtom"));
+  l904:;	  yyprintf((stderr, "  ok   ImportAtom"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l909:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportAtom"));
+  l903:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportAtom"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12886,13 +12879,13 @@ YY_RULE(int) yy_ImportAtom(GREG *G)
 }
 YY_RULE(int) yy_IMPORT_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IMPORT_KW"));
-  if (!yymatchString(G, "import")) goto l918;
+  if (!yymatchString(G, "import")) goto l912;
   yyprintf((stderr, "  ok   IMPORT_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l918:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPORT_KW"));
+  l912:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPORT_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12901,38 +12894,38 @@ YY_RULE(int) yy_IMPORT_KW(GREG *G)
 YY_RULE(int) yy_DefineValue(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DefineValue"));
 
-  {  int yypos920= G->pos, yythunkpos920= G->thunkpos;
-  {  int yypos922= G->pos, yythunkpos922= G->thunkpos;  if (!yymatchChar(G, '=')) goto l922;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l922;
-  {  int yypos926= G->pos, yythunkpos926= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l927;
-  goto l926;
-  l927:;	  G->pos= yypos926; G->thunkpos= yythunkpos926;  if (!yymatchChar(G, '-')) goto l922;
-
-  }
-  l926:;	
-  l924:;	
-  {  int yypos925= G->pos, yythunkpos925= G->thunkpos;
-  {  int yypos928= G->pos, yythunkpos928= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l929;
-  goto l928;
-  l929:;	  G->pos= yypos928; G->thunkpos= yythunkpos928;  if (!yymatchChar(G, '-')) goto l925;
-
-  }
-  l928:;	  goto l924;
-  l925:;	  G->pos= yypos925; G->thunkpos= yythunkpos925;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l922;  goto l923;
-  l922:;	  G->pos= yypos922; G->thunkpos= yythunkpos922;
-  }
-  l923:;	  yyDo(G, yy_1_DefineValue, G->begin, G->end, "yy_1_DefineValue");
+  {  int yypos914= G->pos, yythunkpos914= G->thunkpos;
+  {  int yypos916= G->pos, yythunkpos916= G->thunkpos;  if (!yymatchChar(G, '=')) goto l916;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l916;
+  {  int yypos920= G->pos, yythunkpos920= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l921;
   goto l920;
-  l921:;	  G->pos= yypos920; G->thunkpos= yythunkpos920;  yyDo(G, yy_2_DefineValue, G->begin, G->end, "yy_2_DefineValue");
+  l921:;	  G->pos= yypos920; G->thunkpos= yythunkpos920;  if (!yymatchChar(G, '-')) goto l916;
 
   }
-  l920:;	  yyprintf((stderr, "  ok   DefineValue"));
+  l920:;	
+  l918:;	
+  {  int yypos919= G->pos, yythunkpos919= G->thunkpos;
+  {  int yypos922= G->pos, yythunkpos922= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l923;
+  goto l922;
+  l923:;	  G->pos= yypos922; G->thunkpos= yythunkpos922;  if (!yymatchChar(G, '-')) goto l919;
+
+  }
+  l922:;	  goto l918;
+  l919:;	  G->pos= yypos919; G->thunkpos= yythunkpos919;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l916;  goto l917;
+  l916:;	  G->pos= yypos916; G->thunkpos= yythunkpos916;
+  }
+  l917:;	  yyDo(G, yy_1_DefineValue, G->begin, G->end, "yy_1_DefineValue");
+  goto l914;
+  l915:;	  G->pos= yypos914; G->thunkpos= yythunkpos914;  yyDo(G, yy_2_DefineValue, G->begin, G->end, "yy_2_DefineValue");
+
+  }
+  l914:;	  yyprintf((stderr, "  ok   DefineValue"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l919:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineValue"));
+  l913:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineValue"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12940,29 +12933,29 @@ YY_RULE(int) yy_DefineValue(GREG *G)
 }
 YY_RULE(int) yy_DefineName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DefineName"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l930;
-  {  int yypos933= G->pos, yythunkpos933= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l934;
-  goto l933;
-  l934:;	  G->pos= yypos933; G->thunkpos= yythunkpos933;  if (!yymatchChar(G, '-')) goto l930;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l924;
+  {  int yypos927= G->pos, yythunkpos927= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l928;
+  goto l927;
+  l928:;	  G->pos= yypos927; G->thunkpos= yythunkpos927;  if (!yymatchChar(G, '-')) goto l924;
 
   }
-  l933:;	
-  l931:;	
-  {  int yypos932= G->pos, yythunkpos932= G->thunkpos;
-  {  int yypos935= G->pos, yythunkpos935= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l936;
-  goto l935;
-  l936:;	  G->pos= yypos935; G->thunkpos= yythunkpos935;  if (!yymatchChar(G, '-')) goto l932;
+  l927:;	
+  l925:;	
+  {  int yypos926= G->pos, yythunkpos926= G->thunkpos;
+  {  int yypos929= G->pos, yythunkpos929= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l930;
+  goto l929;
+  l930:;	  G->pos= yypos929; G->thunkpos= yythunkpos929;  if (!yymatchChar(G, '-')) goto l926;
 
   }
-  l935:;	  goto l931;
-  l932:;	  G->pos= yypos932; G->thunkpos= yythunkpos932;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l930;  yyDo(G, yy_1_DefineName, G->begin, G->end, "yy_1_DefineName");
+  l929:;	  goto l925;
+  l926:;	  G->pos= yypos926; G->thunkpos= yythunkpos926;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l924;  yyDo(G, yy_1_DefineName, G->begin, G->end, "yy_1_DefineName");
   yyprintf((stderr, "  ok   DefineName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l930:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineName"));
+  l924:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12971,57 +12964,57 @@ YY_RULE(int) yy_DefineName(GREG *G)
 YY_RULE(int) yy_IncludeCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IncludeCore"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l937;
-  {  int yypos940= G->pos, yythunkpos940= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l941;
-  goto l940;
-  l941:;	  G->pos= yypos940; G->thunkpos= yythunkpos940;  if (!yymatchChar(G, '-')) goto l937;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l931;
+  {  int yypos934= G->pos, yythunkpos934= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l935;
+  goto l934;
+  l935:;	  G->pos= yypos934; G->thunkpos= yythunkpos934;  if (!yymatchChar(G, '-')) goto l931;
 
   }
-  l940:;	
-  l938:;	
-  {  int yypos939= G->pos, yythunkpos939= G->thunkpos;
-  {  int yypos942= G->pos, yythunkpos942= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l943;
-  goto l942;
-  l943:;	  G->pos= yypos942; G->thunkpos= yythunkpos942;  if (!yymatchChar(G, '-')) goto l939;
+  l934:;	
+  l932:;	
+  {  int yypos933= G->pos, yythunkpos933= G->thunkpos;
+  {  int yypos936= G->pos, yythunkpos936= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l937;
+  goto l936;
+  l937:;	  G->pos= yypos936; G->thunkpos= yythunkpos936;  if (!yymatchChar(G, '-')) goto l933;
 
   }
-  l942:;	  goto l938;
-  l939:;	  G->pos= yypos939; G->thunkpos= yythunkpos939;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l937;  yyDo(G, yy_1_IncludeCore, G->begin, G->end, "yy_1_IncludeCore");
+  l936:;	  goto l932;
+  l933:;	  G->pos= yypos933; G->thunkpos= yythunkpos933;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l931;  yyDo(G, yy_1_IncludeCore, G->begin, G->end, "yy_1_IncludeCore");
 
-  {  int yypos944= G->pos, yythunkpos944= G->thunkpos;  if (!yy__(G))  goto l944;
-  if (!yymatchChar(G, '|')) goto l944;
-  if (!yy__(G))  goto l944;
-  if (!yymatchChar(G, '(')) goto l944;
-  if (!yy__(G))  goto l944;
-  if (!yy_DefineName(G))  goto l944;
+  {  int yypos938= G->pos, yythunkpos938= G->thunkpos;  if (!yy__(G))  goto l938;
+  if (!yymatchChar(G, '|')) goto l938;
+  if (!yy__(G))  goto l938;
+  if (!yymatchChar(G, '(')) goto l938;
+  if (!yy__(G))  goto l938;
+  if (!yy_DefineName(G))  goto l938;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DefineValue(G))  goto l944;
+  if (!yy_DefineValue(G))  goto l938;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_IncludeCore, G->begin, G->end, "yy_2_IncludeCore");
 
-  l946:;	
-  {  int yypos947= G->pos, yythunkpos947= G->thunkpos;  if (!yy__(G))  goto l947;
-  if (!yymatchChar(G, ',')) goto l947;
-  if (!yy__(G))  goto l947;
-  if (!yy_DefineName(G))  goto l947;
+  l940:;	
+  {  int yypos941= G->pos, yythunkpos941= G->thunkpos;  if (!yy__(G))  goto l941;
+  if (!yymatchChar(G, ',')) goto l941;
+  if (!yy__(G))  goto l941;
+  if (!yy_DefineName(G))  goto l941;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DefineValue(G))  goto l947;
+  if (!yy_DefineValue(G))  goto l941;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_IncludeCore, G->begin, G->end, "yy_3_IncludeCore");
-  goto l946;
-  l947:;	  G->pos= yypos947; G->thunkpos= yythunkpos947;
-  }  if (!yy__(G))  goto l944;
-  if (!yymatchChar(G, ')')) goto l944;
-  goto l945;
-  l944:;	  G->pos= yypos944; G->thunkpos= yythunkpos944;
+  goto l940;
+  l941:;	  G->pos= yypos941; G->thunkpos= yythunkpos941;
+  }  if (!yy__(G))  goto l938;
+  if (!yymatchChar(G, ')')) goto l938;
+  goto l939;
+  l938:;	  G->pos= yypos938; G->thunkpos= yythunkpos938;
   }
-  l945:;	  yyprintf((stderr, "  ok   IncludeCore"));
+  l939:;	  yyprintf((stderr, "  ok   IncludeCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l937:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IncludeCore"));
+  l931:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IncludeCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13029,13 +13022,13 @@ YY_RULE(int) yy_IncludeCore(GREG *G)
 }
 YY_RULE(int) yy_INCLUDE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INCLUDE_KW"));
-  if (!yymatchString(G, "include")) goto l948;
+  if (!yymatchString(G, "include")) goto l942;
   yyprintf((stderr, "  ok   INCLUDE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l948:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INCLUDE_KW"));
+  l942:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INCLUDE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13043,29 +13036,29 @@ YY_RULE(int) yy_INCLUDE_KW(GREG *G)
 }
 YY_RULE(int) yy_UseCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "UseCore"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l949;
-  {  int yypos952= G->pos, yythunkpos952= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l953;
-  goto l952;
-  l953:;	  G->pos= yypos952; G->thunkpos= yythunkpos952;  if (!yymatchChar(G, '-')) goto l949;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l943;
+  {  int yypos946= G->pos, yythunkpos946= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l947;
+  goto l946;
+  l947:;	  G->pos= yypos946; G->thunkpos= yythunkpos946;  if (!yymatchChar(G, '-')) goto l943;
 
   }
-  l952:;	
-  l950:;	
-  {  int yypos951= G->pos, yythunkpos951= G->thunkpos;
-  {  int yypos954= G->pos, yythunkpos954= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l955;
-  goto l954;
-  l955:;	  G->pos= yypos954; G->thunkpos= yythunkpos954;  if (!yymatchChar(G, '-')) goto l951;
+  l946:;	
+  l944:;	
+  {  int yypos945= G->pos, yythunkpos945= G->thunkpos;
+  {  int yypos948= G->pos, yythunkpos948= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l949;
+  goto l948;
+  l949:;	  G->pos= yypos948; G->thunkpos= yythunkpos948;  if (!yymatchChar(G, '-')) goto l945;
 
   }
-  l954:;	  goto l950;
-  l951:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l949;  yyDo(G, yy_1_UseCore, G->begin, G->end, "yy_1_UseCore");
+  l948:;	  goto l944;
+  l945:;	  G->pos= yypos945; G->thunkpos= yythunkpos945;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l943;  yyDo(G, yy_1_UseCore, G->begin, G->end, "yy_1_UseCore");
   yyprintf((stderr, "  ok   UseCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l949:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UseCore"));
+  l943:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UseCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13073,13 +13066,13 @@ YY_RULE(int) yy_UseCore(GREG *G)
 }
 YY_RULE(int) yy_USE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "USE_KW"));
-  if (!yymatchString(G, "use")) goto l956;
+  if (!yymatchString(G, "use")) goto l950;
   yyprintf((stderr, "  ok   USE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l956:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "USE_KW"));
+  l950:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "USE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13087,20 +13080,20 @@ YY_RULE(int) yy_USE_KW(GREG *G)
 }
 YY_RULE(int) yy_VersionName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "VersionName"));
-  if (!yy__(G))  goto l957;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l957;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l957;
+  if (!yy__(G))  goto l951;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l951;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l951;
 
-  l958:;	
-  {  int yypos959= G->pos, yythunkpos959= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l959;
-  goto l958;
-  l959:;	  G->pos= yypos959; G->thunkpos= yythunkpos959;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l957;  yyDo(G, yy_1_VersionName, G->begin, G->end, "yy_1_VersionName");
+  l952:;	
+  {  int yypos953= G->pos, yythunkpos953= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l953;
+  goto l952;
+  l953:;	  G->pos= yypos953; G->thunkpos= yythunkpos953;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l951;  yyDo(G, yy_1_VersionName, G->begin, G->end, "yy_1_VersionName");
   yyprintf((stderr, "  ok   VersionName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l957:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionName"));
+  l951:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13109,11 +13102,11 @@ YY_RULE(int) yy_VersionName(GREG *G)
 YY_RULE(int) yy_VersionNegation(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VersionNegation"));
-  if (!yy__(G))  goto l960;
-  if (!yymatchChar(G, '!')) goto l960;
+  if (!yy__(G))  goto l954;
+  if (!yymatchChar(G, '!')) goto l954;
   yyDo(G, yy_1_VersionNegation, G->begin, G->end, "yy_1_VersionNegation");
-  if (!yy__(G))  goto l960;
-  if (!yy_VersionSpec(G))  goto l960;
+  if (!yy__(G))  goto l954;
+  if (!yy_VersionSpec(G))  goto l954;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VersionNegation, G->begin, G->end, "yy_2_VersionNegation");
   yyprintf((stderr, "  ok   VersionNegation"));
@@ -13121,7 +13114,7 @@ YY_RULE(int) yy_VersionNegation(GREG *G)
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l960:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionNegation"));
+  l954:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionNegation"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13130,17 +13123,17 @@ YY_RULE(int) yy_VersionNegation(GREG *G)
 YY_RULE(int) yy_VersionCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "VersionCore"));
 
-  {  int yypos962= G->pos, yythunkpos962= G->thunkpos;  if (!yy_VersionNegation(G))  goto l963;
-  goto l962;
-  l963:;	  G->pos= yypos962; G->thunkpos= yythunkpos962;  if (!yy_VersionName(G))  goto l961;
+  {  int yypos956= G->pos, yythunkpos956= G->thunkpos;  if (!yy_VersionNegation(G))  goto l957;
+  goto l956;
+  l957:;	  G->pos= yypos956; G->thunkpos= yythunkpos956;  if (!yy_VersionName(G))  goto l955;
 
   }
-  l962:;	  yyprintf((stderr, "  ok   VersionCore"));
+  l956:;	  yyprintf((stderr, "  ok   VersionCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l961:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionCore"));
+  l955:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13149,52 +13142,52 @@ YY_RULE(int) yy_VersionCore(GREG *G)
 YY_RULE(int) yy_OocDocCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OocDocCore"));
 
-  {  int yypos965= G->pos, yythunkpos965= G->thunkpos;  if (!yymatchString(G, "/**")) goto l966;
+  {  int yypos959= G->pos, yythunkpos959= G->thunkpos;  if (!yymatchString(G, "/**")) goto l960;
 
-  {  int yypos967= G->pos, yythunkpos967= G->thunkpos;  if (!yymatchChar(G, '*')) goto l967;
-  goto l966;
+  {  int yypos961= G->pos, yythunkpos961= G->thunkpos;  if (!yymatchChar(G, '*')) goto l961;
+  goto l960;
+  l961:;	  G->pos= yypos961; G->thunkpos= yythunkpos961;
+  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l960;
+  l962:;	
+  {  int yypos963= G->pos, yythunkpos963= G->thunkpos;
+  {  int yypos964= G->pos, yythunkpos964= G->thunkpos;  if (!yymatchString(G, "*/")) goto l964;
+  goto l963;
+  l964:;	  G->pos= yypos964; G->thunkpos= yythunkpos964;
+  }
+  {  int yypos965= G->pos, yythunkpos965= G->thunkpos;  if (!yy_EOL(G))  goto l966;
+  goto l965;
+  l966:;	  G->pos= yypos965; G->thunkpos= yythunkpos965;  if (!yymatchDot(G)) goto l963;
+  }
+  l965:;	  goto l962;
+  l963:;	  G->pos= yypos963; G->thunkpos= yythunkpos963;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l960;  if (!yymatchString(G, "*/")) goto l960;
+  yyDo(G, yy_1_OocDocCore, G->begin, G->end, "yy_1_OocDocCore");
+  if (!yy_WS(G))  goto l960;
+  goto l959;
+  l960:;	  G->pos= yypos959; G->thunkpos= yythunkpos959;  if (!yymatchString(G, "///")) goto l958;
+
+  {  int yypos967= G->pos, yythunkpos967= G->thunkpos;  if (!yymatchChar(G, '/')) goto l967;
+  goto l958;
   l967:;	  G->pos= yypos967; G->thunkpos= yythunkpos967;
-  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l966;
+  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l958;
   l968:;	
   {  int yypos969= G->pos, yythunkpos969= G->thunkpos;
-  {  int yypos970= G->pos, yythunkpos970= G->thunkpos;  if (!yymatchString(G, "*/")) goto l970;
+  {  int yypos970= G->pos, yythunkpos970= G->thunkpos;  if (!yy_EOL(G))  goto l970;
   goto l969;
   l970:;	  G->pos= yypos970; G->thunkpos= yythunkpos970;
-  }
-  {  int yypos971= G->pos, yythunkpos971= G->thunkpos;  if (!yy_EOL(G))  goto l972;
-  goto l971;
-  l972:;	  G->pos= yypos971; G->thunkpos= yythunkpos971;  if (!yymatchDot(G)) goto l969;
-  }
-  l971:;	  goto l968;
+  }  if (!yymatchDot(G)) goto l969;  goto l968;
   l969:;	  G->pos= yypos969; G->thunkpos= yythunkpos969;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l966;  if (!yymatchString(G, "*/")) goto l966;
-  yyDo(G, yy_1_OocDocCore, G->begin, G->end, "yy_1_OocDocCore");
-  if (!yy_WS(G))  goto l966;
-  goto l965;
-  l966:;	  G->pos= yypos965; G->thunkpos= yythunkpos965;  if (!yymatchString(G, "///")) goto l964;
-
-  {  int yypos973= G->pos, yythunkpos973= G->thunkpos;  if (!yymatchChar(G, '/')) goto l973;
-  goto l964;
-  l973:;	  G->pos= yypos973; G->thunkpos= yythunkpos973;
-  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l964;
-  l974:;	
-  {  int yypos975= G->pos, yythunkpos975= G->thunkpos;
-  {  int yypos976= G->pos, yythunkpos976= G->thunkpos;  if (!yy_EOL(G))  goto l976;
-  goto l975;
-  l976:;	  G->pos= yypos976; G->thunkpos= yythunkpos976;
-  }  if (!yymatchDot(G)) goto l975;  goto l974;
-  l975:;	  G->pos= yypos975; G->thunkpos= yythunkpos975;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l964;  if (!yy_EOL(G))  goto l964;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l958;  if (!yy_EOL(G))  goto l958;
   yyDo(G, yy_2_OocDocCore, G->begin, G->end, "yy_2_OocDocCore");
-  if (!yy_WS(G))  goto l964;
+  if (!yy_WS(G))  goto l958;
 
   }
-  l965:;	  yyprintf((stderr, "  ok   OocDocCore"));
+  l959:;	  yyprintf((stderr, "  ok   OocDocCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l964:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDocCore"));
+  l958:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDocCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13204,39 +13197,39 @@ YY_RULE(int) yy_Decl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Decl"));
 
-  {  int yypos978= G->pos, yythunkpos978= G->thunkpos;  if (!yy_ClassDecl(G))  goto l979;
-  goto l978;
-  l979:;	  G->pos= yypos978; G->thunkpos= yythunkpos978;  if (!yy_CoverDecl(G))  goto l980;
-  goto l978;
-  l980:;	  G->pos= yypos978; G->thunkpos= yythunkpos978;  if (!yy_ExtendDecl(G))  goto l981;
-  goto l978;
-  l981:;	  G->pos= yypos978; G->thunkpos= yythunkpos978;  if (!yy_EnumDecl(G))  goto l982;
-  goto l978;
-  l982:;	  G->pos= yypos978; G->thunkpos= yythunkpos978;  if (!yy_InterfaceDecl(G))  goto l983;
-  goto l978;
-  l983:;	  G->pos= yypos978; G->thunkpos= yythunkpos978;  if (!yy_OperatorDecl(G))  goto l984;
-  goto l978;
-  l984:;	  G->pos= yypos978; G->thunkpos= yythunkpos978;  if (!yy_FunctionDecl(G))  goto l985;
-  goto l978;
-  l985:;	  G->pos= yypos978; G->thunkpos= yythunkpos978;  if (!yy_PropertyDecl(G))  goto l986;
-  goto l978;
-  l986:;	  G->pos= yypos978; G->thunkpos= yythunkpos978;  if (!yy_VariableDecl(G))  goto l977;
+  {  int yypos972= G->pos, yythunkpos972= G->thunkpos;  if (!yy_ClassDecl(G))  goto l973;
+  goto l972;
+  l973:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_CoverDecl(G))  goto l974;
+  goto l972;
+  l974:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_ExtendDecl(G))  goto l975;
+  goto l972;
+  l975:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_EnumDecl(G))  goto l976;
+  goto l972;
+  l976:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_InterfaceDecl(G))  goto l977;
+  goto l972;
+  l977:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_OperatorDecl(G))  goto l978;
+  goto l972;
+  l978:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_FunctionDecl(G))  goto l979;
+  goto l972;
+  l979:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_PropertyDecl(G))  goto l980;
+  goto l972;
+  l980:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_VariableDecl(G))  goto l971;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_Terminator(G))  goto l977;
+  if (!yy_Terminator(G))  goto l971;
 
-  l987:;	
-  {  int yypos988= G->pos, yythunkpos988= G->thunkpos;  if (!yy_Terminator(G))  goto l988;
-  goto l987;
-  l988:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;
+  l981:;	
+  {  int yypos982= G->pos, yythunkpos982= G->thunkpos;  if (!yy_Terminator(G))  goto l982;
+  goto l981;
+  l982:;	  G->pos= yypos982; G->thunkpos= yythunkpos982;
   }  yyDo(G, yy_1_Decl, G->begin, G->end, "yy_1_Decl");
 
   }
-  l978:;	  yyprintf((stderr, "  ok   Decl"));
+  l972:;	  yyprintf((stderr, "  ok   Decl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l977:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Decl"));
+  l971:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Decl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13244,24 +13237,24 @@ YY_RULE(int) yy_Decl(GREG *G)
 }
 YY_RULE(int) yy_Use(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Use"));
-  if (!yy_USE_KW(G))  goto l989;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l989;
-  if (!yy__(G))  goto l989;
-  if (!yy_UseCore(G))  goto l989;
+  if (!yy_USE_KW(G))  goto l983;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l983;
+  if (!yy__(G))  goto l983;
+  if (!yy_UseCore(G))  goto l983;
 
-  l990:;	
-  {  int yypos991= G->pos, yythunkpos991= G->thunkpos;  if (!yy__(G))  goto l991;
-  if (!yymatchChar(G, ',')) goto l991;
-  if (!yy__(G))  goto l991;
-  if (!yy_UseCore(G))  goto l991;
-  goto l990;
-  l991:;	  G->pos= yypos991; G->thunkpos= yythunkpos991;
+  l984:;	
+  {  int yypos985= G->pos, yythunkpos985= G->thunkpos;  if (!yy__(G))  goto l985;
+  if (!yymatchChar(G, ',')) goto l985;
+  if (!yy__(G))  goto l985;
+  if (!yy_UseCore(G))  goto l985;
+  goto l984;
+  l985:;	  G->pos= yypos985; G->thunkpos= yythunkpos985;
   }  yyprintf((stderr, "  ok   Use"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l989:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Use"));
+  l983:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Use"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13269,24 +13262,24 @@ YY_RULE(int) yy_Use(GREG *G)
 }
 YY_RULE(int) yy_Import(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Import"));
-  if (!yy_IMPORT_KW(G))  goto l992;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l992;
-  if (!yy__(G))  goto l992;
-  if (!yy_ImportAtom(G))  goto l992;
+  if (!yy_IMPORT_KW(G))  goto l986;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l986;
+  if (!yy__(G))  goto l986;
+  if (!yy_ImportAtom(G))  goto l986;
 
-  l993:;	
-  {  int yypos994= G->pos, yythunkpos994= G->thunkpos;  if (!yymatchChar(G, ',')) goto l994;
-  if (!yy_WS(G))  goto l994;
-  if (!yy__(G))  goto l994;
-  if (!yy_ImportAtom(G))  goto l994;
-  goto l993;
-  l994:;	  G->pos= yypos994; G->thunkpos= yythunkpos994;
+  l987:;	
+  {  int yypos988= G->pos, yythunkpos988= G->thunkpos;  if (!yymatchChar(G, ',')) goto l988;
+  if (!yy_WS(G))  goto l988;
+  if (!yy__(G))  goto l988;
+  if (!yy_ImportAtom(G))  goto l988;
+  goto l987;
+  l988:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;
   }  yyprintf((stderr, "  ok   Import"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l992:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Import"));
+  l986:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Import"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13294,24 +13287,24 @@ YY_RULE(int) yy_Import(GREG *G)
 }
 YY_RULE(int) yy_Include(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Include"));
-  if (!yy_INCLUDE_KW(G))  goto l995;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l995;
-  if (!yy__(G))  goto l995;
-  if (!yy_IncludeCore(G))  goto l995;
+  if (!yy_INCLUDE_KW(G))  goto l989;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l989;
+  if (!yy__(G))  goto l989;
+  if (!yy_IncludeCore(G))  goto l989;
 
-  l996:;	
-  {  int yypos997= G->pos, yythunkpos997= G->thunkpos;  if (!yy__(G))  goto l997;
-  if (!yymatchChar(G, ',')) goto l997;
-  if (!yy__(G))  goto l997;
-  if (!yy_IncludeCore(G))  goto l997;
-  goto l996;
-  l997:;	  G->pos= yypos997; G->thunkpos= yythunkpos997;
+  l990:;	
+  {  int yypos991= G->pos, yythunkpos991= G->thunkpos;  if (!yy__(G))  goto l991;
+  if (!yymatchChar(G, ',')) goto l991;
+  if (!yy__(G))  goto l991;
+  if (!yy_IncludeCore(G))  goto l991;
+  goto l990;
+  l991:;	  G->pos= yypos991; G->thunkpos= yythunkpos991;
   }  yyprintf((stderr, "  ok   Include"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l995:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Include"));
+  l989:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Include"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13321,120 +13314,120 @@ YY_RULE(int) yy_Stmt(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Stmt"));
 
-  {  int yypos999= G->pos, yythunkpos999= G->thunkpos;  if (!yy_Old(G))  goto l1000;
+  {  int yypos993= G->pos, yythunkpos993= G->thunkpos;  if (!yy_Old(G))  goto l994;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_WS(G))  goto l1000;
-  if (!yymatchString(G, "version")) goto l1000;
+  if (!yy_WS(G))  goto l994;
+  if (!yymatchString(G, "version")) goto l994;
   yyDo(G, yy_1_Stmt, G->begin, G->end, "yy_1_Stmt");
+  if (!yy_WS(G))  goto l994;
+  if (!yymatchChar(G, '(')) goto l994;
+  if (!yy__(G))  goto l994;
+  if (!yy_VersionSpec(G))  goto l994;
+  yyDo(G, yySet, -3, 0, "yySet");
+  if (!yy_WS(G))  goto l994;
+  if (!yymatchChar(G, ')')) goto l994;
+
+  {  int yypos995= G->pos, yythunkpos995= G->thunkpos;  if (!yy__(G))  goto l996;
+  if (!yymatchChar(G, '{')) goto l996;
+  yyDo(G, yy_2_Stmt, G->begin, G->end, "yy_2_Stmt");
+  if (!yy_WS(G))  goto l996;
+
+  l997:;	
+  {  int yypos998= G->pos, yythunkpos998= G->thunkpos;  if (!yy_Stmt(G))  goto l998;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_3_Stmt, G->begin, G->end, "yy_3_Stmt");
+  goto l997;
+  l998:;	  G->pos= yypos998; G->thunkpos= yythunkpos998;
+  }  if (!yy_WS(G))  goto l996;
+  if (!yy__(G))  goto l996;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l996; }
+  yyDo(G, yy_4_Stmt, G->begin, G->end, "yy_4_Stmt");
+  goto l995;
+  l996:;	  G->pos= yypos995; G->thunkpos= yythunkpos995;  if (!yy__(G))  goto l994;
+  if (!yy_Stmt(G))  goto l994;
+  yyDo(G, yySet, -2, 0, "yySet");
+  yyDo(G, yy_5_Stmt, G->begin, G->end, "yy_5_Stmt");
+
+  }
+  l995:;	
+  l999:;	
+  {  int yypos1000= G->pos, yythunkpos1000= G->thunkpos;  if (!yy_WS(G))  goto l1000;
+  if (!yymatchString(G, "else")) goto l1000;
+  if (!yy__(G))  goto l1000;
+  if (!yymatchString(G, "version")) goto l1000;
+  yyDo(G, yy_6_Stmt, G->begin, G->end, "yy_6_Stmt");
   if (!yy_WS(G))  goto l1000;
   if (!yymatchChar(G, '(')) goto l1000;
   if (!yy__(G))  goto l1000;
   if (!yy_VersionSpec(G))  goto l1000;
-  yyDo(G, yySet, -3, 0, "yySet");
+  yyDo(G, yySet, -1, 0, "yySet");
   if (!yy_WS(G))  goto l1000;
   if (!yymatchChar(G, ')')) goto l1000;
 
   {  int yypos1001= G->pos, yythunkpos1001= G->thunkpos;  if (!yy__(G))  goto l1002;
   if (!yymatchChar(G, '{')) goto l1002;
-  yyDo(G, yy_2_Stmt, G->begin, G->end, "yy_2_Stmt");
+  yyDo(G, yy_7_Stmt, G->begin, G->end, "yy_7_Stmt");
   if (!yy_WS(G))  goto l1002;
 
   l1003:;	
   {  int yypos1004= G->pos, yythunkpos1004= G->thunkpos;  if (!yy_Stmt(G))  goto l1004;
   yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_3_Stmt, G->begin, G->end, "yy_3_Stmt");
+  yyDo(G, yy_8_Stmt, G->begin, G->end, "yy_8_Stmt");
   goto l1003;
   l1004:;	  G->pos= yypos1004; G->thunkpos= yythunkpos1004;
   }  if (!yy_WS(G))  goto l1002;
   if (!yy__(G))  goto l1002;
   if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l1002; }
-  yyDo(G, yy_4_Stmt, G->begin, G->end, "yy_4_Stmt");
+  yyDo(G, yy_9_Stmt, G->begin, G->end, "yy_9_Stmt");
   goto l1001;
   l1002:;	  G->pos= yypos1001; G->thunkpos= yythunkpos1001;  if (!yy__(G))  goto l1000;
   if (!yy_Stmt(G))  goto l1000;
   yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_5_Stmt, G->begin, G->end, "yy_5_Stmt");
+  yyDo(G, yy_10_Stmt, G->begin, G->end, "yy_10_Stmt");
 
   }
-  l1001:;	
-  l1005:;	
-  {  int yypos1006= G->pos, yythunkpos1006= G->thunkpos;  if (!yy_WS(G))  goto l1006;
-  if (!yymatchString(G, "else")) goto l1006;
-  if (!yy__(G))  goto l1006;
-  if (!yymatchString(G, "version")) goto l1006;
-  yyDo(G, yy_6_Stmt, G->begin, G->end, "yy_6_Stmt");
-  if (!yy_WS(G))  goto l1006;
-  if (!yymatchChar(G, '(')) goto l1006;
-  if (!yy__(G))  goto l1006;
-  if (!yy_VersionSpec(G))  goto l1006;
-  yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l1006;
-  if (!yymatchChar(G, ')')) goto l1006;
+  l1001:;	  goto l999;
+  l1000:;	  G->pos= yypos1000; G->thunkpos= yythunkpos1000;
+  }
+  {  int yypos1005= G->pos, yythunkpos1005= G->thunkpos;  if (!yy_WS(G))  goto l1005;
+  if (!yymatchString(G, "else")) goto l1005;
+  yyDo(G, yy_11_Stmt, G->begin, G->end, "yy_11_Stmt");
 
   {  int yypos1007= G->pos, yythunkpos1007= G->thunkpos;  if (!yy__(G))  goto l1008;
   if (!yymatchChar(G, '{')) goto l1008;
-  yyDo(G, yy_7_Stmt, G->begin, G->end, "yy_7_Stmt");
+  yyDo(G, yy_12_Stmt, G->begin, G->end, "yy_12_Stmt");
   if (!yy_WS(G))  goto l1008;
 
   l1009:;	
   {  int yypos1010= G->pos, yythunkpos1010= G->thunkpos;  if (!yy_Stmt(G))  goto l1010;
   yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_8_Stmt, G->begin, G->end, "yy_8_Stmt");
+  yyDo(G, yy_13_Stmt, G->begin, G->end, "yy_13_Stmt");
   goto l1009;
   l1010:;	  G->pos= yypos1010; G->thunkpos= yythunkpos1010;
   }  if (!yy_WS(G))  goto l1008;
   if (!yy__(G))  goto l1008;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l1008; }
-  yyDo(G, yy_9_Stmt, G->begin, G->end, "yy_9_Stmt");
-  goto l1007;
-  l1008:;	  G->pos= yypos1007; G->thunkpos= yythunkpos1007;  if (!yy__(G))  goto l1006;
-  if (!yy_Stmt(G))  goto l1006;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_10_Stmt, G->begin, G->end, "yy_10_Stmt");
-
-  }
-  l1007:;	  goto l1005;
-  l1006:;	  G->pos= yypos1006; G->thunkpos= yythunkpos1006;
-  }
-  {  int yypos1011= G->pos, yythunkpos1011= G->thunkpos;  if (!yy_WS(G))  goto l1011;
-  if (!yymatchString(G, "else")) goto l1011;
-  yyDo(G, yy_11_Stmt, G->begin, G->end, "yy_11_Stmt");
-
-  {  int yypos1013= G->pos, yythunkpos1013= G->thunkpos;  if (!yy__(G))  goto l1014;
-  if (!yymatchChar(G, '{')) goto l1014;
-  yyDo(G, yy_12_Stmt, G->begin, G->end, "yy_12_Stmt");
-  if (!yy_WS(G))  goto l1014;
-
-  l1015:;	
-  {  int yypos1016= G->pos, yythunkpos1016= G->thunkpos;  if (!yy_Stmt(G))  goto l1016;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_13_Stmt, G->begin, G->end, "yy_13_Stmt");
-  goto l1015;
-  l1016:;	  G->pos= yypos1016; G->thunkpos= yythunkpos1016;
-  }  if (!yy_WS(G))  goto l1014;
-  if (!yy__(G))  goto l1014;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block\n") ; } goto l1014; }
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block\n") ; } goto l1008; }
   yyDo(G, yy_14_Stmt, G->begin, G->end, "yy_14_Stmt");
-  goto l1013;
-  l1014:;	  G->pos= yypos1013; G->thunkpos= yythunkpos1013;  if (!yy__(G))  goto l1011;
-  if (!yy_Stmt(G))  goto l1011;
+  goto l1007;
+  l1008:;	  G->pos= yypos1007; G->thunkpos= yythunkpos1007;  if (!yy__(G))  goto l1005;
+  if (!yy_Stmt(G))  goto l1005;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_15_Stmt, G->begin, G->end, "yy_15_Stmt");
 
   }
-  l1013:;	  goto l1012;
-  l1011:;	  G->pos= yypos1011; G->thunkpos= yythunkpos1011;
+  l1007:;	  goto l1006;
+  l1005:;	  G->pos= yypos1005; G->thunkpos= yythunkpos1005;
   }
-  l1012:;	  goto l999;
-  l1000:;	  G->pos= yypos999; G->thunkpos= yythunkpos999;  if (!yy_StmtCore(G))  goto l998;
+  l1006:;	  goto l993;
+  l994:;	  G->pos= yypos993; G->thunkpos= yythunkpos993;  if (!yy_StmtCore(G))  goto l992;
 
   }
-  l999:;	  yyprintf((stderr, "  ok   Stmt"));
+  l993:;	  yyprintf((stderr, "  ok   Stmt"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l998:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Stmt"));
+  l992:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Stmt"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13442,13 +13435,13 @@ YY_RULE(int) yy_Stmt(GREG *G)
 }
 YY_RULE(int) yy_CLOS_BRACK(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLOS_BRACK"));
-  if (!yymatchChar(G, '}')) goto l1017;
+  if (!yymatchChar(G, '}')) goto l1011;
   yyprintf((stderr, "  ok   CLOS_BRACK"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1017:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_BRACK"));
+  l1011:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_BRACK"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13456,13 +13449,13 @@ YY_RULE(int) yy_CLOS_BRACK(GREG *G)
 }
 YY_RULE(int) yy_CLOS_PAREN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLOS_PAREN"));
-  if (!yymatchChar(G, ')')) goto l1018;
+  if (!yymatchChar(G, ')')) goto l1012;
   yyprintf((stderr, "  ok   CLOS_PAREN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1018:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_PAREN"));
+  l1012:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_PAREN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13472,46 +13465,46 @@ YY_RULE(int) yy_VersionSpec(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VersionSpec"));
 
-  {  int yypos1020= G->pos, yythunkpos1020= G->thunkpos;  if (!yy__(G))  goto l1021;
-  if (!yymatchChar(G, '(')) goto l1021;
-  if (!yy__(G))  goto l1021;
-  if (!yy_VersionSpec(G))  goto l1021;
+  {  int yypos1014= G->pos, yythunkpos1014= G->thunkpos;  if (!yy__(G))  goto l1015;
+  if (!yymatchChar(G, '(')) goto l1015;
+  if (!yy__(G))  goto l1015;
+  if (!yy_VersionSpec(G))  goto l1015;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l1021;
-  if (!yymatchChar(G, ')')) goto l1021;
-  goto l1020;
-  l1021:;	  G->pos= yypos1020; G->thunkpos= yythunkpos1020;  if (!yy_VersionCore(G))  goto l1019;
+  if (!yy__(G))  goto l1015;
+  if (!yymatchChar(G, ')')) goto l1015;
+  goto l1014;
+  l1015:;	  G->pos= yypos1014; G->thunkpos= yythunkpos1014;  if (!yy_VersionCore(G))  goto l1013;
   yyDo(G, yySet, -2, 0, "yySet");
 
   }
-  l1020:;	
-  l1022:;	
-  {  int yypos1023= G->pos, yythunkpos1023= G->thunkpos;
-  {  int yypos1024= G->pos, yythunkpos1024= G->thunkpos;  if (!yy__(G))  goto l1025;
-  if (!yymatchString(G, "&&")) goto l1025;
+  l1014:;	
+  l1016:;	
+  {  int yypos1017= G->pos, yythunkpos1017= G->thunkpos;
+  {  int yypos1018= G->pos, yythunkpos1018= G->thunkpos;  if (!yy__(G))  goto l1019;
+  if (!yymatchString(G, "&&")) goto l1019;
   yyDo(G, yy_1_VersionSpec, G->begin, G->end, "yy_1_VersionSpec");
-  if (!yy__(G))  goto l1025;
-  if (!yy_VersionSpec(G))  goto l1025;
+  if (!yy__(G))  goto l1019;
+  if (!yy_VersionSpec(G))  goto l1019;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VersionSpec, G->begin, G->end, "yy_2_VersionSpec");
-  goto l1024;
-  l1025:;	  G->pos= yypos1024; G->thunkpos= yythunkpos1024;  if (!yy__(G))  goto l1023;
-  if (!yymatchString(G, "||")) goto l1023;
+  goto l1018;
+  l1019:;	  G->pos= yypos1018; G->thunkpos= yythunkpos1018;  if (!yy__(G))  goto l1017;
+  if (!yymatchString(G, "||")) goto l1017;
   yyDo(G, yy_3_VersionSpec, G->begin, G->end, "yy_3_VersionSpec");
-  if (!yy__(G))  goto l1023;
-  if (!yy_VersionSpec(G))  goto l1023;
+  if (!yy__(G))  goto l1017;
+  if (!yy_VersionSpec(G))  goto l1017;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_VersionSpec, G->begin, G->end, "yy_4_VersionSpec");
 
   }
-  l1024:;	  goto l1022;
-  l1023:;	  G->pos= yypos1023; G->thunkpos= yythunkpos1023;
+  l1018:;	  goto l1016;
+  l1017:;	  G->pos= yypos1017; G->thunkpos= yythunkpos1017;
   }  yyprintf((stderr, "  ok   VersionSpec"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l1019:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionSpec"));
+  l1013:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionSpec"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13520,15 +13513,15 @@ YY_RULE(int) yy_VersionSpec(GREG *G)
 YY_RULE(int) yy__(GREG *G)
 {  yyprintfv((stderr, "%s\n", "_"));
 
-  l1027:;	
-  {  int yypos1028= G->pos, yythunkpos1028= G->thunkpos;
-  {  int yypos1029= G->pos, yythunkpos1029= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1030;
-  goto l1029;
-  l1030:;	  G->pos= yypos1029; G->thunkpos= yythunkpos1029;  if (!yy_CommentMultiLine(G))  goto l1028;
+  l1021:;	
+  {  int yypos1022= G->pos, yythunkpos1022= G->thunkpos;
+  {  int yypos1023= G->pos, yythunkpos1023= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1024;
+  goto l1023;
+  l1024:;	  G->pos= yypos1023; G->thunkpos= yythunkpos1023;  if (!yy_CommentMultiLine(G))  goto l1022;
 
   }
-  l1029:;	  goto l1027;
-  l1028:;	  G->pos= yypos1028; G->thunkpos= yythunkpos1028;
+  l1023:;	  goto l1021;
+  l1022:;	  G->pos= yypos1022; G->thunkpos= yythunkpos1022;
   }  yyprintf((stderr, "  ok   _"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -13538,20 +13531,20 @@ YY_RULE(int) yy__(GREG *G)
 YY_RULE(int) yy_EOL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EOL"));
 
-  {  int yypos1032= G->pos, yythunkpos1032= G->thunkpos;  if (!yymatchChar(G, '\n')) goto l1033;
-  goto l1032;
-  l1033:;	  G->pos= yypos1032; G->thunkpos= yythunkpos1032;  if (!yymatchString(G, "\r\n")) goto l1034;
-  goto l1032;
-  l1034:;	  G->pos= yypos1032; G->thunkpos= yythunkpos1032;  if (!yymatchChar(G, '\r')) goto l1031;
+  {  int yypos1026= G->pos, yythunkpos1026= G->thunkpos;  if (!yymatchChar(G, '\n')) goto l1027;
+  goto l1026;
+  l1027:;	  G->pos= yypos1026; G->thunkpos= yythunkpos1026;  if (!yymatchString(G, "\r\n")) goto l1028;
+  goto l1026;
+  l1028:;	  G->pos= yypos1026; G->thunkpos= yythunkpos1026;  if (!yymatchChar(G, '\r')) goto l1025;
 
   }
-  l1032:;	  yyDo(G, yy_1_EOL, G->begin, G->end, "yy_1_EOL");
+  l1026:;	  yyDo(G, yy_1_EOL, G->begin, G->end, "yy_1_EOL");
   yyprintf((stderr, "  ok   EOL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1031:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EOL"));
+  l1025:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EOL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13560,21 +13553,17 @@ YY_RULE(int) yy_EOL(GREG *G)
 YY_RULE(int) yy_WS(GREG *G)
 {  yyprintfv((stderr, "%s\n", "WS"));
 
-  l1036:;	
-  {  int yypos1037= G->pos, yythunkpos1037= G->thunkpos;
-  {  int yypos1038= G->pos, yythunkpos1038= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1039;
-  goto l1038;
-  l1039:;	  G->pos= yypos1038; G->thunkpos= yythunkpos1038;  if (!yy_Comment(G))  goto l1040;
-  goto l1038;
-  l1040:;	  G->pos= yypos1038; G->thunkpos= yythunkpos1038;  if (!yy_PreprocessorBeginRegion(G))  goto l1041;
-  goto l1038;
-  l1041:;	  G->pos= yypos1038; G->thunkpos= yythunkpos1038;  if (!yy_PreprocessorEndRegion(G))  goto l1042;
-  goto l1038;
-  l1042:;	  G->pos= yypos1038; G->thunkpos= yythunkpos1038;  if (!yy_EOL(G))  goto l1037;
+  l1030:;	
+  {  int yypos1031= G->pos, yythunkpos1031= G->thunkpos;
+  {  int yypos1032= G->pos, yythunkpos1032= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1033;
+  goto l1032;
+  l1033:;	  G->pos= yypos1032; G->thunkpos= yythunkpos1032;  if (!yy_Comment(G))  goto l1034;
+  goto l1032;
+  l1034:;	  G->pos= yypos1032; G->thunkpos= yythunkpos1032;  if (!yy_EOL(G))  goto l1031;
 
   }
-  l1038:;	  goto l1036;
-  l1037:;	  G->pos= yypos1037; G->thunkpos= yythunkpos1037;
+  l1032:;	  goto l1030;
+  l1031:;	  G->pos= yypos1031; G->thunkpos= yythunkpos1031;
   }  yyprintf((stderr, "  ok   WS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -13585,140 +13574,140 @@ YY_RULE(int) yy_ModuleCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ModuleCore"));
 
-  {  int yypos1044= G->pos, yythunkpos1044= G->thunkpos;  if (!yy_WS(G))  goto l1045;
-  if (!yymatchString(G, "version")) goto l1045;
+  {  int yypos1036= G->pos, yythunkpos1036= G->thunkpos;  if (!yy_WS(G))  goto l1037;
+  if (!yymatchString(G, "version")) goto l1037;
   yyDo(G, yy_1_ModuleCore, G->begin, G->end, "yy_1_ModuleCore");
-  if (!yy_WS(G))  goto l1045;
-  if (!yymatchChar(G, '(')) goto l1045;
-  if (!yy__(G))  goto l1045;
-  if (!yy_VersionSpec(G))  goto l1045;
+  if (!yy_WS(G))  goto l1037;
+  if (!yymatchChar(G, '(')) goto l1037;
+  if (!yy__(G))  goto l1037;
+  if (!yy_VersionSpec(G))  goto l1037;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_WS(G))  goto l1045;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed version spec!\n") ; } goto l1045; }
+  if (!yy_WS(G))  goto l1037;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed version spec!\n") ; } goto l1037; }
 
-  {  int yypos1046= G->pos, yythunkpos1046= G->thunkpos;  if (!yy__(G))  goto l1047;
-  if (!yymatchChar(G, '{')) goto l1047;
+  {  int yypos1038= G->pos, yythunkpos1038= G->thunkpos;  if (!yy__(G))  goto l1039;
+  if (!yymatchChar(G, '{')) goto l1039;
   yyDo(G, yy_2_ModuleCore, G->begin, G->end, "yy_2_ModuleCore");
-  if (!yy_WS(G))  goto l1047;
+  if (!yy_WS(G))  goto l1039;
 
-  l1048:;	
-  {  int yypos1049= G->pos, yythunkpos1049= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1049;
-  goto l1048;
-  l1049:;	  G->pos= yypos1049; G->thunkpos= yythunkpos1049;
-  }  if (!yy_WS(G))  goto l1047;
-  if (!yy__(G))  goto l1047;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1047; }
+  l1040:;	
+  {  int yypos1041= G->pos, yythunkpos1041= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1041;
+  goto l1040;
+  l1041:;	  G->pos= yypos1041; G->thunkpos= yythunkpos1041;
+  }  if (!yy_WS(G))  goto l1039;
+  if (!yy__(G))  goto l1039;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1039; }
   yyDo(G, yy_3_ModuleCore, G->begin, G->end, "yy_3_ModuleCore");
-  goto l1046;
-  l1047:;	  G->pos= yypos1046; G->thunkpos= yythunkpos1046;  if (!yy__(G))  goto l1045;
-  if (!yy_Stmt(G))  goto l1045;
+  goto l1038;
+  l1039:;	  G->pos= yypos1038; G->thunkpos= yythunkpos1038;  if (!yy__(G))  goto l1037;
+  if (!yy_Stmt(G))  goto l1037;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_4_ModuleCore, G->begin, G->end, "yy_4_ModuleCore");
 
   }
-  l1046:;	
-  l1050:;	
-  {  int yypos1051= G->pos, yythunkpos1051= G->thunkpos;  if (!yy_WS(G))  goto l1051;
-  if (!yymatchString(G, "else")) goto l1051;
-  if (!yy__(G))  goto l1051;
-  if (!yymatchString(G, "version")) goto l1051;
+  l1038:;	
+  l1042:;	
+  {  int yypos1043= G->pos, yythunkpos1043= G->thunkpos;  if (!yy_WS(G))  goto l1043;
+  if (!yymatchString(G, "else")) goto l1043;
+  if (!yy__(G))  goto l1043;
+  if (!yymatchString(G, "version")) goto l1043;
   yyDo(G, yy_5_ModuleCore, G->begin, G->end, "yy_5_ModuleCore");
-  if (!yy_WS(G))  goto l1051;
-  if (!yymatchChar(G, '(')) goto l1051;
-  if (!yy__(G))  goto l1051;
-  if (!yy_VersionSpec(G))  goto l1051;
+  if (!yy_WS(G))  goto l1043;
+  if (!yymatchChar(G, '(')) goto l1043;
+  if (!yy__(G))  goto l1043;
+  if (!yy_VersionSpec(G))  goto l1043;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l1051;
-  if (!yymatchChar(G, ')')) goto l1051;
+  if (!yy_WS(G))  goto l1043;
+  if (!yymatchChar(G, ')')) goto l1043;
 
-  {  int yypos1052= G->pos, yythunkpos1052= G->thunkpos;  if (!yy__(G))  goto l1053;
-  if (!yymatchChar(G, '{')) goto l1053;
+  {  int yypos1044= G->pos, yythunkpos1044= G->thunkpos;  if (!yy__(G))  goto l1045;
+  if (!yymatchChar(G, '{')) goto l1045;
   yyDo(G, yy_6_ModuleCore, G->begin, G->end, "yy_6_ModuleCore");
-  if (!yy_WS(G))  goto l1053;
+  if (!yy_WS(G))  goto l1045;
 
-  l1054:;	
-  {  int yypos1055= G->pos, yythunkpos1055= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1055;
-  goto l1054;
-  l1055:;	  G->pos= yypos1055; G->thunkpos= yythunkpos1055;
-  }  if (!yy_WS(G))  goto l1053;
-  if (!yy__(G))  goto l1053;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1053; }
+  l1046:;	
+  {  int yypos1047= G->pos, yythunkpos1047= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1047;
+  goto l1046;
+  l1047:;	  G->pos= yypos1047; G->thunkpos= yythunkpos1047;
+  }  if (!yy_WS(G))  goto l1045;
+  if (!yy__(G))  goto l1045;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1045; }
   yyDo(G, yy_7_ModuleCore, G->begin, G->end, "yy_7_ModuleCore");
-  goto l1052;
-  l1053:;	  G->pos= yypos1052; G->thunkpos= yythunkpos1052;  if (!yy__(G))  goto l1051;
-  if (!yy_Stmt(G))  goto l1051;
+  goto l1044;
+  l1045:;	  G->pos= yypos1044; G->thunkpos= yythunkpos1044;  if (!yy__(G))  goto l1043;
+  if (!yy_Stmt(G))  goto l1043;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_8_ModuleCore, G->begin, G->end, "yy_8_ModuleCore");
 
   }
-  l1052:;	  goto l1050;
-  l1051:;	  G->pos= yypos1051; G->thunkpos= yythunkpos1051;
+  l1044:;	  goto l1042;
+  l1043:;	  G->pos= yypos1043; G->thunkpos= yythunkpos1043;
   }
-  {  int yypos1056= G->pos, yythunkpos1056= G->thunkpos;  if (!yy_WS(G))  goto l1056;
-  if (!yymatchString(G, "else")) goto l1056;
+  {  int yypos1048= G->pos, yythunkpos1048= G->thunkpos;  if (!yy_WS(G))  goto l1048;
+  if (!yymatchString(G, "else")) goto l1048;
   yyDo(G, yy_9_ModuleCore, G->begin, G->end, "yy_9_ModuleCore");
 
-  {  int yypos1058= G->pos, yythunkpos1058= G->thunkpos;  if (!yy__(G))  goto l1059;
-  if (!yymatchChar(G, '{')) goto l1059;
+  {  int yypos1050= G->pos, yythunkpos1050= G->thunkpos;  if (!yy__(G))  goto l1051;
+  if (!yymatchChar(G, '{')) goto l1051;
   yyDo(G, yy_10_ModuleCore, G->begin, G->end, "yy_10_ModuleCore");
-  if (!yy_WS(G))  goto l1059;
+  if (!yy_WS(G))  goto l1051;
 
-  l1060:;	
-  {  int yypos1061= G->pos, yythunkpos1061= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1061;
-  goto l1060;
-  l1061:;	  G->pos= yypos1061; G->thunkpos= yythunkpos1061;
-  }  if (!yy_WS(G))  goto l1059;
-  if (!yy__(G))  goto l1059;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1059; }
+  l1052:;	
+  {  int yypos1053= G->pos, yythunkpos1053= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1053;
+  goto l1052;
+  l1053:;	  G->pos= yypos1053; G->thunkpos= yythunkpos1053;
+  }  if (!yy_WS(G))  goto l1051;
+  if (!yy__(G))  goto l1051;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1051; }
   yyDo(G, yy_11_ModuleCore, G->begin, G->end, "yy_11_ModuleCore");
-  goto l1058;
-  l1059:;	  G->pos= yypos1058; G->thunkpos= yythunkpos1058;  if (!yy__(G))  goto l1056;
-  if (!yy_Stmt(G))  goto l1056;
+  goto l1050;
+  l1051:;	  G->pos= yypos1050; G->thunkpos= yythunkpos1050;  if (!yy__(G))  goto l1048;
+  if (!yy_Stmt(G))  goto l1048;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_12_ModuleCore, G->begin, G->end, "yy_12_ModuleCore");
 
   }
-  l1058:;	  goto l1057;
-  l1056:;	  G->pos= yypos1056; G->thunkpos= yythunkpos1056;
+  l1050:;	  goto l1049;
+  l1048:;	  G->pos= yypos1048; G->thunkpos= yythunkpos1048;
   }
-  l1057:;	  goto l1044;
-  l1045:;	  G->pos= yypos1044; G->thunkpos= yythunkpos1044;
-  {  int yypos1062= G->pos, yythunkpos1062= G->thunkpos;  if (!yy_WS(G))  goto l1063;
-  if (!yy_Include(G))  goto l1063;
-  if (!yy_WS(G))  goto l1063;
-  goto l1062;
-  l1063:;	  G->pos= yypos1062; G->thunkpos= yythunkpos1062;  if (!yy_WS(G))  goto l1064;
-  if (!yy_Import(G))  goto l1064;
-  if (!yy_WS(G))  goto l1064;
-  goto l1062;
-  l1064:;	  G->pos= yypos1062; G->thunkpos= yythunkpos1062;  if (!yy_WS(G))  goto l1065;
-  if (!yy_Use(G))  goto l1065;
-  if (!yy_WS(G))  goto l1065;
-  goto l1062;
-  l1065:;	  G->pos= yypos1062; G->thunkpos= yythunkpos1062;  if (!yy_WS(G))  goto l1066;
-  if (!yy_Decl(G))  goto l1066;
-  if (!yy_WS(G))  goto l1066;
-  goto l1062;
-  l1066:;	  G->pos= yypos1062; G->thunkpos= yythunkpos1062;  if (!yy_WS(G))  goto l1067;
-  if (!yy_Stmt(G))  goto l1067;
+  l1049:;	  goto l1036;
+  l1037:;	  G->pos= yypos1036; G->thunkpos= yythunkpos1036;
+  {  int yypos1054= G->pos, yythunkpos1054= G->thunkpos;  if (!yy_WS(G))  goto l1055;
+  if (!yy_Include(G))  goto l1055;
+  if (!yy_WS(G))  goto l1055;
+  goto l1054;
+  l1055:;	  G->pos= yypos1054; G->thunkpos= yythunkpos1054;  if (!yy_WS(G))  goto l1056;
+  if (!yy_Import(G))  goto l1056;
+  if (!yy_WS(G))  goto l1056;
+  goto l1054;
+  l1056:;	  G->pos= yypos1054; G->thunkpos= yythunkpos1054;  if (!yy_WS(G))  goto l1057;
+  if (!yy_Use(G))  goto l1057;
+  if (!yy_WS(G))  goto l1057;
+  goto l1054;
+  l1057:;	  G->pos= yypos1054; G->thunkpos= yythunkpos1054;  if (!yy_WS(G))  goto l1058;
+  if (!yy_Decl(G))  goto l1058;
+  if (!yy_WS(G))  goto l1058;
+  goto l1054;
+  l1058:;	  G->pos= yypos1054; G->thunkpos= yythunkpos1054;  if (!yy_WS(G))  goto l1059;
+  if (!yy_Stmt(G))  goto l1059;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l1067;
+  if (!yy_WS(G))  goto l1059;
   yyDo(G, yy_13_ModuleCore, G->begin, G->end, "yy_13_ModuleCore");
-  goto l1062;
-  l1067:;	  G->pos= yypos1062; G->thunkpos= yythunkpos1062;  if (!yy_WS(G))  goto l1043;
+  goto l1054;
+  l1059:;	  G->pos= yypos1054; G->thunkpos= yythunkpos1054;  if (!yy_WS(G))  goto l1035;
   yyDo(G, yy_14_ModuleCore, G->begin, G->end, "yy_14_ModuleCore");
-  if (!yy_OocDocCore(G))  goto l1043;
+  if (!yy_OocDocCore(G))  goto l1035;
   yyDo(G, yy_15_ModuleCore, G->begin, G->end, "yy_15_ModuleCore");
 
   }
-  l1062:;	
+  l1054:;	
   }
-  l1044:;	  yyprintf((stderr, "  ok   ModuleCore"));
+  l1036:;	  yyprintf((stderr, "  ok   ModuleCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l1043:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ModuleCore"));
+  l1035:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ModuleCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13727,27 +13716,27 @@ YY_RULE(int) yy_ModuleCore(GREG *G)
 YY_RULE(int) yy_Module(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Module"));
 
-  {  int yypos1069= G->pos, yythunkpos1069= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1070;
-  goto l1069;
-  l1070:;	  G->pos= yypos1069; G->thunkpos= yythunkpos1069;  if (!yy_WS(G))  goto l1068;
+  {  int yypos1061= G->pos, yythunkpos1061= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1062;
+  goto l1061;
+  l1062:;	  G->pos= yypos1061; G->thunkpos= yythunkpos1061;  if (!yy_WS(G))  goto l1060;
 
-  l1071:;	
-  {  int yypos1072= G->pos, yythunkpos1072= G->thunkpos;
-  {  int yypos1073= G->pos, yythunkpos1073= G->thunkpos;  if (!yy_EOL(G))  goto l1073;
-  goto l1072;
-  l1073:;	  G->pos= yypos1073; G->thunkpos= yythunkpos1073;
-  }  if (!yymatchDot(G)) goto l1072;  goto l1071;
-  l1072:;	  G->pos= yypos1072; G->thunkpos= yythunkpos1072;
-  }  if (!yy_EOL(G))  goto l1068;
+  l1063:;	
+  {  int yypos1064= G->pos, yythunkpos1064= G->thunkpos;
+  {  int yypos1065= G->pos, yythunkpos1065= G->thunkpos;  if (!yy_EOL(G))  goto l1065;
+  goto l1064;
+  l1065:;	  G->pos= yypos1065; G->thunkpos= yythunkpos1065;
+  }  if (!yymatchDot(G)) goto l1064;  goto l1063;
+  l1064:;	  G->pos= yypos1064; G->thunkpos= yythunkpos1064;
+  }  if (!yy_EOL(G))  goto l1060;
   yyDo(G, yy_1_Module, G->begin, G->end, "yy_1_Module");
 
   }
-  l1069:;	  yyprintf((stderr, "  ok   Module"));
+  l1061:;	  yyprintf((stderr, "  ok   Module"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1068:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Module"));
+  l1060:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Module"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 

--- a/source/rock/middle/SafeNavigation.ooc
+++ b/source/rock/middle/SafeNavigation.ooc
@@ -1,6 +1,6 @@
 import ../frontend/Token
 import [Type, Expression, VariableAccess, Comparison, Ternary, VariableDecl, CommaSequence, BinaryOp,
-        FunctionCall, BinaryOp, Parenthesis, NullLiteral, ClassDecl, Visitor, Node]
+        FunctionCall, BinaryOp, Parenthesis, Cast, NullLiteral, ClassDecl, Visitor, Node]
 import algo/typeAnalysis
 import tinker/[Resolver, Response, Trail, Errors]
 import structs/ArrayList
@@ -240,7 +240,7 @@ SafeNavigation: class extends Expression {
         }
 
         makeTernary := func(cond: Comparison, e: Expression) -> Ternary {
-            Ternary new(cond, e, localNull, token)
+            Ternary new(cond, Cast new(e, type, e token), localNull, token)
         }
 
         // We don't need to generate a ternary for the last access.
@@ -253,8 +253,6 @@ SafeNavigation: class extends Expression {
 
             curr = makeTernary(makeNotEquals(access), curr)
         }
-
-        // TODO: Check 'type' against 'expr getType()', generate a cast of 'vAccess' tp 'type' if they are not the same.
 
         curr = makeTernary(makeNotEquals(vAccess), curr)
 

--- a/source/rock/middle/SafeNavigation.ooc
+++ b/source/rock/middle/SafeNavigation.ooc
@@ -1,6 +1,6 @@
 import ../frontend/Token
 import [Type, Expression, VariableAccess, Comparison, Ternary, VariableDecl, CommaSequence, BinaryOp,
-        FunctionCall, BinaryOp, NullLiteral, Visitor, Node]
+        FunctionCall, BinaryOp, Parenthesis, NullLiteral, Visitor, Node]
 
 import tinker/[Resolver, Response, Trail, Errors]
 import structs/ArrayList
@@ -50,7 +50,7 @@ SafeNavigation: class extends Expression {
             return (null, null)
         }
 
-        bop := BinaryOp new(vacc, e, OpType ass, token)
+        bop := Parenthesis new(BinaryOp new(vacc, e, OpType ass, token), token)
         (bop, vacc)
     }
 

--- a/source/rock/middle/SafeNavigation.ooc
+++ b/source/rock/middle/SafeNavigation.ooc
@@ -137,7 +137,7 @@ SafeNavigation: class extends Expression {
 
             // Check to see if we can safe navigate into the expression.
             // To be able to do it, we need to have a class or pointer type.
-            if (type pointerLevel() == 0 && !type isPointer() && !type instanceOf?(ClassDecl)) {
+            if (type pointerLevel() == 0 && !type isPointer() && !type getRef() instanceOf?(ClassDecl)) {
                 res throwError(InvalidSafeNavigationAccessType new(token, type))
                 return Response OK
             }
@@ -174,7 +174,7 @@ SafeNavigation: class extends Expression {
 
             // We only need to chain the last expression the first time we process this.
             // This check essentially guarantees this, because currentIndex is set after this if statement.
-            if (currentIndex == i) {
+            if (currentIndex != i) {
                 _chain(current, lastExpr)
             }
 

--- a/source/rock/middle/SafeNavigation.ooc
+++ b/source/rock/middle/SafeNavigation.ooc
@@ -1,12 +1,15 @@
 import ../frontend/Token
 import [Type, Expression, VariableAccess, Comparison, Ternary, VariableDecl, CommaSequence, BinaryOp,
-        FunctionCall, BinaryOp, Parenthesis, NullLiteral, Visitor, Node]
-
+        FunctionCall, BinaryOp, Parenthesis, NullLiteral, ClassDecl, Visitor, Node]
+import algo/typeAnalysis
 import tinker/[Resolver, Response, Trail, Errors]
 import structs/ArrayList
 
 SafeNavigation: class extends Expression {
     expr: Expression
+
+    // VariableAcces to the VariableDecl which will hold our base expression
+    vAccess: VariableAccess
 
     // Sections are expressions that are mixes of variable accesses and method calls
     sections := ArrayList<Expression> new()
@@ -22,7 +25,7 @@ SafeNavigation: class extends Expression {
     currentIndex := -1
 
     // Wether our base expression has already been replaced
-    _baseReplaced := false
+    _baseReplaced? := false
     // Final comma sequence
     seq: CommaSequence
 
@@ -143,7 +146,7 @@ SafeNavigation: class extends Expression {
         if (!_baseReplaced?) {
             // We need to avoid multiple evaluation of the expression, so we will use a variable declaration and assign it in a comma list before this
             vDecl := VariableDecl new(expr getType(), generateTempName("safeNavExpr"), token)
-            vAccess := VariableAccess new(vDecl, token)
+            vAccess = VariableAccess new(vDecl, token)
 
             if (!trail addBeforeInScope(this, vDecl)) {
                 res throwError(CouldntAddBeforeInScope new(token, this, vDecl, trail))
@@ -155,6 +158,8 @@ SafeNavigation: class extends Expression {
 
             seq add(assignment)
             lastExpr = vAccess
+
+            _baseReplaced? = true
         }
 
         // So, we need to iterate through the sections and build a single fCall or vAccess that will show up in the ternary operator chain
@@ -167,14 +172,63 @@ SafeNavigation: class extends Expression {
                 continue
             }
 
-            _chain(current, lastExpr)
+            // We only need to chain the last expression the first time we process this.
+            // This check essentially guarantees this, because currentIndex is set after this if statement.
+            if (currentIndex == i) {
+                _chain(current, lastExpr)
+            }
+
+            currentIndex = i
+            currentExpr = current
+
+            // We nnow try to resolve our expression.
+            // Note that if currentExpr is replaced (e.g. because of a property access), the expression in the sections list is also replaced (see resolve)
+            trail push(this)
+            resp := currentExpr resolve(trail, res)
+            if (!resp ok()) {
+                trail pop(this)
+                return resp
+            }
+
+            // We need the expressions type (and it to be resolved)
+            if (!currentExpr getType()) {
+                trail pop(this)
+                res wholeAgain(this, "need safe navigation child type")
+                return Response OK
+            }
+
+            resp = currentExpr getType() resolve(trail, res)
+            if (!resp ok()) {
+                trail pop(this)
+                return resp
+            }
+
+            if (!currentExpr getType() isResolved()) {
+                trail pop(this)
+                res wholeAgain(this, "need safe navigation child type to be resolved")
+                return Response OK
+            }
+            trail pop(this)
+
+            // Try to find a better type!
+            typeCandidate := findCommonRoot(type, currentExpr getType())
+            if (!typeCandidate) {
+                if (res fatal) {
+                    res throwError(InvalidSafeNavigationChildType new(currentExpr token, type, typeCandidate))
+                } else {
+                    res wholeAgain(this, "need resolved ref of child type")
+                }
+                return Response OK
+            }
+
+            type = typeCandidate
 
             if (_hasSideEffects(current)) {
                 (assign, acc) := _makeDecl(current, trail, res)
-                exprs add(assign)
+                concreteExprs add(assign)
                 lastExpr = acc
             } else {
-                exprs add(current)
+                concreteExprs add(current)
                 lastExpr = current
             }
         }
@@ -191,7 +245,7 @@ SafeNavigation: class extends Expression {
 
         // We don't need to generate a ternary for the last access.
         // 'foo != null ? foo : null' is equivalent to 'foo'
-        iterator := exprs backIterator()
+        iterator := concreteExprs backIterator()
         curr : Expression = iterator prev()
 
         while (iterator hasPrev?()) {
@@ -238,6 +292,7 @@ SafeNavigation: class extends Expression {
 
         if (oldie == currentExpr) {
             currentExpr = kiddo as Expression
+            sections[currentIndex] = currentExpr
             return true
         }
 
@@ -254,5 +309,13 @@ InvalidSafeNavigationAccessType: class extends Error {
 
     init: func (.token, =type) {
         super(token, "Cannot use safe navigation access into expression of type '#{type}' since it is not a pointer type.")
+    }
+}
+
+InvalidSafeNavigationChildType: class extends Error {
+    baseType, childType: Type
+
+    init: func (.token, =baseType, =childType) {
+        super(token, "Cannot safely navigate into expression of type '#{childType}' since it is incompatible with inferred type '#{baseType}")
     }
 }

--- a/source/rock/middle/VariableAccess.ooc
+++ b/source/rock/middle/VariableAccess.ooc
@@ -15,6 +15,7 @@ VariableAccess: class extends Expression {
 
     _warned := false
     _staticFunc : FunctionDecl = null
+    _replacedByProperty? := false
 
     expr: Expression {
         get
@@ -170,7 +171,7 @@ VariableAccess: class extends Expression {
             return false
         }
 
-        true
+        !_replacedByProperty?
     }
 
     resolve: func (trail: Trail, res: Resolver) -> Response {
@@ -234,6 +235,8 @@ VariableAccess: class extends Expression {
                 }
 
                 if(shouldReplace) {
+                    _replacedByProperty? = true
+
                     property := ref as PropertyDecl
                     fCall := FunctionCall new(expr, property getGetterName(), token)
                     if (!trail peek() replace(this, fCall)) {


### PR DESCRIPTION
Also contains the property fix introduced in [#38](https://github.com/magic-lang/rock/pull/38)  

For a description of the property fix, please refer to the (closed) PR linked above.  

The way this works is exactly as you would expect:  
Safe navigation sections now accept accesses and function calls.  
To achieve this, each section is a "chain" of accesses and method calls constructed in AstBuilder.  

The base expression as well as sections that contain functions each generate a variable declaration and are replaced with an assignment of that variable to its original expression to avoid double evaluation.  

Each section is chained to the previous one (either to the new generated variable or to the access chain).  
Then, we generate a chain of ternary expressions that check if each section is equal to NULL and return NULL in that case or the next ternary expression if it is not.