### PR TITLE
Fixes rock crashes when implementing interfaces

### DIFF
--- a/source/rock/middle/InterfaceImpl.ooc
+++ b/source/rock/middle/InterfaceImpl.ooc
@@ -50,20 +50,20 @@ InterfaceImpl: class extends ClassDecl {
                 finalScore : Int
                 value := impl getMeta() getFunction(key getName(), key getSuffix(), null, true, finalScore&)
 
-                // Check for the score between declarations
-                finalScore = value getScore(key)
-                if(finalScore == -1) {
+                if (value) {
+                    // Check for the score between declarations
+                    finalScore = value getScore(key)
+                    if(finalScore == -1) {
 
-                    res wholeAgain(this, "Not finished checking every function is implemented")
-                    return Response OK
+                        res wholeAgain(this, "Not finished checking every function is implemented")
+                        return Response OK
 
-                } else if(finalScore < 0) {
-                    res throwError(InterfaceContractNotSatisfied new(value token,
-                        "%s implements function %s, from interface %s, incorrectly\n" format(
-                        impl getName(), key toString(), superType toString())))
-                }
-
-                if(value == null) {
+                    } else if(finalScore < 0) {
+                        res throwError(InterfaceContractNotSatisfied new(value token,
+                            "%s implements function %s, from interface %s, incorrectly\n" format(
+                            impl getName(), key toString(), superType toString())))
+                    }
+                } else {
                     if(impl instanceOf?(ClassDecl) && impl as ClassDecl isAbstract) {
                         // relay unimplemented interface methods into an abstract class...
                         value = FunctionDecl new(key getName(), key token)
@@ -100,6 +100,7 @@ InterfaceImpl: class extends ClassDecl {
                         }
                     }
                 }
+
                 aliases put(hash, FunctionAlias new(key, value))
             }
         }

--- a/test/compiler/interfaces/interface-provided-function.ooc
+++ b/test/compiler/interfaces/interface-provided-function.ooc
@@ -1,0 +1,21 @@
+Printable: interface {
+    toString: func -> String
+
+    print: func {
+        toString() println()
+    }
+}
+
+Foo: class implements Printable {
+    count := static 0
+
+    init: func {
+        count += 1
+    }
+
+    toString: func -> String { "foo##{count}" }
+}
+
+describe("interfaces should be able to provide default implementations without rock crashing", ||
+    expect("foo#1", Foo new() toString())
+)


### PR DESCRIPTION
Specifically, when the implementor did not provide a (correct or incorrect) function of the same name and suffix as asked for or when the interface provides a default function.