### PR TITLE
Remove __onheap__, automatically generate free methods that clean up generics

### DIFF
--- a/source/rock/frontend/AstBuilder.ooc
+++ b/source/rock/frontend/AstBuilder.ooc
@@ -787,9 +787,6 @@ AstBuilder: class {
         }
         return fDecl
     }
-    onVarDeclForcedMalloc: unmangled(nq_onVarDeclForcedMalloc) func {
-        peek(Stack<VariableDecl>) each(|vd| vd setForcedMalloc(true))
-    }
     onFunctionVirtual: unmangled(nq_onFunctionVirtual) func {
       checkModifierValidity("virtual", false)
       peek(FunctionDecl) isVirtual = true

--- a/source/rock/frontend/NagaQueen.c
+++ b/source/rock/frontend/NagaQueen.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 struct _GREG;
-#define YYRULECOUNT 228
+#define YYRULECOUNT 223
 
 #include <stdio.h>
 #include <string.h>
@@ -179,7 +179,6 @@ void yyInput(char *buf, int *result, int max_size, NagaQueenCore *core) {
 
 ///////////////////// callbacks def start, you may want to skip this ////////////////////////
 
-void nq_onVarDeclForcedMalloc(void *this);
 void nq_onFunctionVirtual(void *this);
 void nq_onFunctionOverride(void *this);
 
@@ -405,12 +404,6 @@ void *nq_onLogicalAnd(void *this, void *left, void *right);
 void *nq_onBinaryOr(void *this, void *left, void *right);
 void *nq_onBinaryXor(void *this, void *left, void *right);
 void *nq_onBinaryAnd(void *this, void *left, void *right);
-
-void nq_onSafeNavigationStart(void *this, void *expr);
-void nq_onSafeNavigationSection(void *this);
-void nq_onSafeNavigationIdent(void *this, char *ident);
-void nq_onSafeNavigationMethod(void *this, void *fcall);
-void *nq_onSafeNavigationEnd(void *this);
 
 void *nq_onLogicalNot(void *this, void *inner);
 void *nq_onBinaryNot(void *this, void *inner);
@@ -765,149 +758,144 @@ YY_LOCAL(void) yySet(GREG *G, char *text, int count, yythunk *thunk, YY_XTYPE YY
 
 #define YYACCEPT        yyAccept(G, yythunkpos0)
 
-YY_RULE(int) yy_TextInside(GREG *G); /* 228 */
-YY_RULE(int) yy_TextChunk(GREG *G); /* 227 */
-YY_RULE(int) yy_Interpolation(GREG *G); /* 226 */
-YY_RULE(int) yy_StringChunk(GREG *G); /* 225 */
-YY_RULE(int) yy_DOUBLE_QUOTE(GREG *G); /* 224 */
-YY_RULE(int) yy_SINGLE_QUOTE(GREG *G); /* 223 */
-YY_RULE(int) yy_FP_LIT_SUFFIX(GREG *G); /* 222 */
-YY_RULE(int) yy_INT_LIT_SUFFIX(GREG *G); /* 221 */
-YY_RULE(int) yy_CommentMultiLineWithDocs(GREG *G); /* 220 */
-YY_RULE(int) yy_Comment(GREG *G); /* 219 */
-YY_RULE(int) yy_CommentMultiLine(GREG *G); /* 218 */
-YY_RULE(int) yy_CLOS_COMMENT(GREG *G); /* 217 */
-YY_RULE(int) yy_KW(GREG *G); /* 216 */
-YY_RULE(int) yy_FALSE_KW(GREG *G); /* 215 */
-YY_RULE(int) yy_TRUE_KW(GREG *G); /* 214 */
-YY_RULE(int) yy_NULL_KW(GREG *G); /* 213 */
-YY_RULE(int) yy_BOOL_LIT(GREG *G); /* 212 */
-YY_RULE(int) yy_CHAR_LIT(GREG *G); /* 211 */
-YY_RULE(int) yy_STRING_LIT(GREG *G); /* 210 */
-YY_RULE(int) yy_TEXT_STRING_LIT(GREG *G); /* 209 */
-YY_RULE(int) yy_RAW_STRING_LIT(GREG *G); /* 208 */
-YY_RULE(int) yy_FLOAT_LIT(GREG *G); /* 207 */
-YY_RULE(int) yy_BIN_LIT(GREG *G); /* 206 */
-YY_RULE(int) yy_DEC_LIT(GREG *G); /* 205 */
-YY_RULE(int) yy_HEX_LIT(GREG *G); /* 204 */
-YY_RULE(int) yy_OCT_LIT(GREG *G); /* 203 */
-YY_RULE(int) yy_ArrayLiteral(GREG *G); /* 202 */
-YY_RULE(int) yy_ValueCore(GREG *G); /* 201 */
-YY_RULE(int) yy_VariableAccess(GREG *G); /* 200 */
-YY_RULE(int) yy_ACS(GREG *G); /* 199 */
-YY_RULE(int) yy_FunctionCallCore(GREG *G); /* 198 */
-YY_RULE(int) yy_FunctionCallNoname(GREG *G); /* 197 */
-YY_RULE(int) yy_AS_KW(GREG *G); /* 196 */
-YY_RULE(int) yy_CLOS_SQUAR(GREG *G); /* 195 */
-YY_RULE(int) yy_IDENT_CORE(GREG *G); /* 194 */
-YY_RULE(int) yy_SAFE_NAV(GREG *G); /* 193 */
-YY_RULE(int) yy_Access(GREG *G); /* 192 */
-YY_RULE(int) yy_SLASH(GREG *G); /* 191 */
-YY_RULE(int) yy_EXP(GREG *G); /* 190 */
-YY_RULE(int) yy_SafeNavAccess(GREG *G); /* 189 */
-YY_RULE(int) yy_B_NOT(GREG *G); /* 188 */
-YY_RULE(int) yy_L_NOT(GREG *G); /* 187 */
-YY_RULE(int) yy_ProductCore(GREG *G); /* 186 */
-YY_RULE(int) yy_ProductBinaryNot(GREG *G); /* 185 */
-YY_RULE(int) yy_ProductLogicalNot(GREG *G); /* 184 */
-YY_RULE(int) yy_PERCENT(GREG *G); /* 183 */
-YY_RULE(int) yy_MINUS(GREG *G); /* 182 */
-YY_RULE(int) yy_Product(GREG *G); /* 181 */
-YY_RULE(int) yy_B_RSHIFT(GREG *G); /* 180 */
-YY_RULE(int) yy_B_LSHIFT(GREG *G); /* 179 */
-YY_RULE(int) yy_Sum(GREG *G); /* 178 */
-YY_RULE(int) yy_DOUBLE_DOT(GREG *G); /* 177 */
-YY_RULE(int) yy_Shift(GREG *G); /* 176 */
-YY_RULE(int) yy_MORETHAN_EQ(GREG *G); /* 175 */
-YY_RULE(int) yy_LESSTHAN_EQ(GREG *G); /* 174 */
-YY_RULE(int) yy_CMP(GREG *G); /* 173 */
-YY_RULE(int) yy_Range(GREG *G); /* 172 */
-YY_RULE(int) yy_NOT_EQUALS(GREG *G); /* 171 */
-YY_RULE(int) yy_EQUALS(GREG *G); /* 170 */
-YY_RULE(int) yy_Inequality(GREG *G); /* 169 */
-YY_RULE(int) yy_B_AND(GREG *G); /* 168 */
-YY_RULE(int) yy_Equality(GREG *G); /* 167 */
-YY_RULE(int) yy_B_XOR(GREG *G); /* 166 */
-YY_RULE(int) yy_BinaryAnd(GREG *G); /* 165 */
-YY_RULE(int) yy_B_OR(GREG *G); /* 164 */
-YY_RULE(int) yy_BinaryXor(GREG *G); /* 163 */
-YY_RULE(int) yy_L_AND(GREG *G); /* 162 */
-YY_RULE(int) yy_BinaryOr(GREG *G); /* 161 */
-YY_RULE(int) yy_L_OR(GREG *G); /* 160 */
-YY_RULE(int) yy_LogicalAnd(GREG *G); /* 159 */
-YY_RULE(int) yy_DOUBLE_QUEST(GREG *G); /* 158 */
-YY_RULE(int) yy_LogicalOr(GREG *G); /* 157 */
-YY_RULE(int) yy_QUEST(GREG *G); /* 156 */
-YY_RULE(int) yy_NullCoalescing(GREG *G); /* 155 */
-YY_RULE(int) yy_ASS_B_AND(GREG *G); /* 154 */
-YY_RULE(int) yy_ASS_B_OR(GREG *G); /* 153 */
-YY_RULE(int) yy_ASS_B_XOR(GREG *G); /* 152 */
-YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G); /* 151 */
-YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G); /* 150 */
-YY_RULE(int) yy_ASS_DIV(GREG *G); /* 149 */
-YY_RULE(int) yy_ASS_EXP(GREG *G); /* 148 */
-YY_RULE(int) yy_ASS_MUL(GREG *G); /* 147 */
-YY_RULE(int) yy_ASS_SUB(GREG *G); /* 146 */
-YY_RULE(int) yy_ASS_MOD(GREG *G); /* 145 */
-YY_RULE(int) yy_ASS_ADD(GREG *G); /* 144 */
-YY_RULE(int) yy_Ternary(GREG *G); /* 143 */
-YY_RULE(int) yy_Assignment(GREG *G); /* 142 */
-YY_RULE(int) yy_FunctionCall(GREG *G); /* 141 */
-YY_RULE(int) yy_BinaryOperation(GREG *G); /* 140 */
-YY_RULE(int) yy_DoubleArrow(GREG *G); /* 139 */
-YY_RULE(int) yy_RETURN_KW(GREG *G); /* 138 */
-YY_RULE(int) yy_WHILE_KW(GREG *G); /* 137 */
-YY_RULE(int) yy_IN_KW(GREG *G); /* 136 */
-YY_RULE(int) yy_FOR_KW(GREG *G); /* 135 */
-YY_RULE(int) yy_ImplicitDecl(GREG *G); /* 134 */
-YY_RULE(int) yy_CONTINUE_KW(GREG *G); /* 133 */
-YY_RULE(int) yy_BREAK_KW(GREG *G); /* 132 */
-YY_RULE(int) yy_Continue(GREG *G); /* 131 */
-YY_RULE(int) yy_Break(GREG *G); /* 130 */
-YY_RULE(int) yy_While(GREG *G); /* 129 */
-YY_RULE(int) yy_Foreach(GREG *G); /* 128 */
-YY_RULE(int) yy_CATCH_KW(GREG *G); /* 127 */
-YY_RULE(int) yy_Catch(GREG *G); /* 126 */
-YY_RULE(int) yy_TRY_KW(GREG *G); /* 125 */
-YY_RULE(int) yy_Value(GREG *G); /* 124 */
-YY_RULE(int) yy_MATCH_KW(GREG *G); /* 123 */
-YY_RULE(int) yy_DOUBLE_ARROW(GREG *G); /* 122 */
-YY_RULE(int) yy_CaseExpr(GREG *G); /* 121 */
-YY_RULE(int) yy_CASE_KW(GREG *G); /* 120 */
-YY_RULE(int) yy_Case(GREG *G); /* 119 */
-YY_RULE(int) yy_ELSE_KW(GREG *G); /* 118 */
-YY_RULE(int) yy_Body(GREG *G); /* 117 */
-YY_RULE(int) yy_IF_KW(GREG *G); /* 116 */
-YY_RULE(int) yy_Else(GREG *G); /* 115 */
-YY_RULE(int) yy_If(GREG *G); /* 114 */
-YY_RULE(int) yy_Return(GREG *G); /* 113 */
-YY_RULE(int) yy_Try(GREG *G); /* 112 */
-YY_RULE(int) yy_Match(GREG *G); /* 111 */
-YY_RULE(int) yy_FlowControl(GREG *G); /* 110 */
-YY_RULE(int) yy_Block(GREG *G); /* 109 */
-YY_RULE(int) yy_Conditional(GREG *G); /* 108 */
-YY_RULE(int) yy_PreprocessorEndRegion(GREG *G); /* 107 */
-YY_RULE(int) yy_PreprocessorBeginRegion(GREG *G); /* 106 */
-YY_RULE(int) yy_CommentLine(GREG *G); /* 105 */
-YY_RULE(int) yy_EoledStatement(GREG *G); /* 104 */
-YY_RULE(int) yy_StmtCore(GREG *G); /* 103 */
-YY_RULE(int) yy_FuncTypeCore(GREG *G); /* 102 */
-YY_RULE(int) yy_TypeListCore(GREG *G); /* 101 */
-YY_RULE(int) yy_TypeList(GREG *G); /* 100 */
-YY_RULE(int) yy_Old(GREG *G); /* 99 */
-YY_RULE(int) yy_GenericType(GREG *G); /* 98 */
-YY_RULE(int) yy_FuncType(GREG *G); /* 97 */
-YY_RULE(int) yy_TypeBase(GREG *G); /* 96 */
-YY_RULE(int) yy_SET_KW(GREG *G); /* 95 */
-YY_RULE(int) yy_GET_KW(GREG *G); /* 94 */
-YY_RULE(int) yy_PropertyDeclSetter(GREG *G); /* 93 */
-YY_RULE(int) yy_PropertyDeclGetter(GREG *G); /* 92 */
-YY_RULE(int) yy_PROPASS_DECL(GREG *G); /* 91 */
-YY_RULE(int) yy_PropertyDeclCore(GREG *G); /* 90 */
-YY_RULE(int) yy_ConventionalPropertyDecl(GREG *G); /* 89 */
-YY_RULE(int) yy_PropertyDeclFromExpr(GREG *G); /* 88 */
-YY_RULE(int) yy_ConventionalVarDecl(GREG *G); /* 87 */
-YY_RULE(int) yy_FORCEDMALLOC_KW(GREG *G); /* 86 */
+YY_RULE(int) yy_TextInside(GREG *G); /* 223 */
+YY_RULE(int) yy_TextChunk(GREG *G); /* 222 */
+YY_RULE(int) yy_Interpolation(GREG *G); /* 221 */
+YY_RULE(int) yy_StringChunk(GREG *G); /* 220 */
+YY_RULE(int) yy_DOUBLE_QUOTE(GREG *G); /* 219 */
+YY_RULE(int) yy_SINGLE_QUOTE(GREG *G); /* 218 */
+YY_RULE(int) yy_FP_LIT_SUFFIX(GREG *G); /* 217 */
+YY_RULE(int) yy_INT_LIT_SUFFIX(GREG *G); /* 216 */
+YY_RULE(int) yy_CommentMultiLineWithDocs(GREG *G); /* 215 */
+YY_RULE(int) yy_Comment(GREG *G); /* 214 */
+YY_RULE(int) yy_CommentMultiLine(GREG *G); /* 213 */
+YY_RULE(int) yy_CLOS_COMMENT(GREG *G); /* 212 */
+YY_RULE(int) yy_KW(GREG *G); /* 211 */
+YY_RULE(int) yy_FALSE_KW(GREG *G); /* 210 */
+YY_RULE(int) yy_TRUE_KW(GREG *G); /* 209 */
+YY_RULE(int) yy_NULL_KW(GREG *G); /* 208 */
+YY_RULE(int) yy_BOOL_LIT(GREG *G); /* 207 */
+YY_RULE(int) yy_CHAR_LIT(GREG *G); /* 206 */
+YY_RULE(int) yy_STRING_LIT(GREG *G); /* 205 */
+YY_RULE(int) yy_TEXT_STRING_LIT(GREG *G); /* 204 */
+YY_RULE(int) yy_RAW_STRING_LIT(GREG *G); /* 203 */
+YY_RULE(int) yy_FLOAT_LIT(GREG *G); /* 202 */
+YY_RULE(int) yy_BIN_LIT(GREG *G); /* 201 */
+YY_RULE(int) yy_DEC_LIT(GREG *G); /* 200 */
+YY_RULE(int) yy_HEX_LIT(GREG *G); /* 199 */
+YY_RULE(int) yy_OCT_LIT(GREG *G); /* 198 */
+YY_RULE(int) yy_ArrayLiteral(GREG *G); /* 197 */
+YY_RULE(int) yy_ValueCore(GREG *G); /* 196 */
+YY_RULE(int) yy_VariableAccess(GREG *G); /* 195 */
+YY_RULE(int) yy_ACS(GREG *G); /* 194 */
+YY_RULE(int) yy_FunctionCallCore(GREG *G); /* 193 */
+YY_RULE(int) yy_FunctionCallNoname(GREG *G); /* 192 */
+YY_RULE(int) yy_AS_KW(GREG *G); /* 191 */
+YY_RULE(int) yy_CLOS_SQUAR(GREG *G); /* 190 */
+YY_RULE(int) yy_IDENT_CORE(GREG *G); /* 189 */
+YY_RULE(int) yy_SLASH(GREG *G); /* 188 */
+YY_RULE(int) yy_EXP(GREG *G); /* 187 */
+YY_RULE(int) yy_Access(GREG *G); /* 186 */
+YY_RULE(int) yy_B_NOT(GREG *G); /* 185 */
+YY_RULE(int) yy_L_NOT(GREG *G); /* 184 */
+YY_RULE(int) yy_ProductCore(GREG *G); /* 183 */
+YY_RULE(int) yy_ProductBinaryNot(GREG *G); /* 182 */
+YY_RULE(int) yy_ProductLogicalNot(GREG *G); /* 181 */
+YY_RULE(int) yy_PERCENT(GREG *G); /* 180 */
+YY_RULE(int) yy_MINUS(GREG *G); /* 179 */
+YY_RULE(int) yy_Product(GREG *G); /* 178 */
+YY_RULE(int) yy_B_RSHIFT(GREG *G); /* 177 */
+YY_RULE(int) yy_B_LSHIFT(GREG *G); /* 176 */
+YY_RULE(int) yy_Sum(GREG *G); /* 175 */
+YY_RULE(int) yy_DOUBLE_DOT(GREG *G); /* 174 */
+YY_RULE(int) yy_Shift(GREG *G); /* 173 */
+YY_RULE(int) yy_MORETHAN_EQ(GREG *G); /* 172 */
+YY_RULE(int) yy_LESSTHAN_EQ(GREG *G); /* 171 */
+YY_RULE(int) yy_CMP(GREG *G); /* 170 */
+YY_RULE(int) yy_Range(GREG *G); /* 169 */
+YY_RULE(int) yy_NOT_EQUALS(GREG *G); /* 168 */
+YY_RULE(int) yy_EQUALS(GREG *G); /* 167 */
+YY_RULE(int) yy_Inequality(GREG *G); /* 166 */
+YY_RULE(int) yy_B_AND(GREG *G); /* 165 */
+YY_RULE(int) yy_Equality(GREG *G); /* 164 */
+YY_RULE(int) yy_B_XOR(GREG *G); /* 163 */
+YY_RULE(int) yy_BinaryAnd(GREG *G); /* 162 */
+YY_RULE(int) yy_B_OR(GREG *G); /* 161 */
+YY_RULE(int) yy_BinaryXor(GREG *G); /* 160 */
+YY_RULE(int) yy_L_AND(GREG *G); /* 159 */
+YY_RULE(int) yy_BinaryOr(GREG *G); /* 158 */
+YY_RULE(int) yy_L_OR(GREG *G); /* 157 */
+YY_RULE(int) yy_LogicalAnd(GREG *G); /* 156 */
+YY_RULE(int) yy_DOUBLE_QUEST(GREG *G); /* 155 */
+YY_RULE(int) yy_LogicalOr(GREG *G); /* 154 */
+YY_RULE(int) yy_QUEST(GREG *G); /* 153 */
+YY_RULE(int) yy_NullCoalescing(GREG *G); /* 152 */
+YY_RULE(int) yy_ASS_B_AND(GREG *G); /* 151 */
+YY_RULE(int) yy_ASS_B_OR(GREG *G); /* 150 */
+YY_RULE(int) yy_ASS_B_XOR(GREG *G); /* 149 */
+YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G); /* 148 */
+YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G); /* 147 */
+YY_RULE(int) yy_ASS_DIV(GREG *G); /* 146 */
+YY_RULE(int) yy_ASS_EXP(GREG *G); /* 145 */
+YY_RULE(int) yy_ASS_MUL(GREG *G); /* 144 */
+YY_RULE(int) yy_ASS_SUB(GREG *G); /* 143 */
+YY_RULE(int) yy_ASS_MOD(GREG *G); /* 142 */
+YY_RULE(int) yy_ASS_ADD(GREG *G); /* 141 */
+YY_RULE(int) yy_Ternary(GREG *G); /* 140 */
+YY_RULE(int) yy_Assignment(GREG *G); /* 139 */
+YY_RULE(int) yy_FunctionCall(GREG *G); /* 138 */
+YY_RULE(int) yy_BinaryOperation(GREG *G); /* 137 */
+YY_RULE(int) yy_DoubleArrow(GREG *G); /* 136 */
+YY_RULE(int) yy_RETURN_KW(GREG *G); /* 135 */
+YY_RULE(int) yy_WHILE_KW(GREG *G); /* 134 */
+YY_RULE(int) yy_IN_KW(GREG *G); /* 133 */
+YY_RULE(int) yy_FOR_KW(GREG *G); /* 132 */
+YY_RULE(int) yy_ImplicitDecl(GREG *G); /* 131 */
+YY_RULE(int) yy_CONTINUE_KW(GREG *G); /* 130 */
+YY_RULE(int) yy_BREAK_KW(GREG *G); /* 129 */
+YY_RULE(int) yy_Continue(GREG *G); /* 128 */
+YY_RULE(int) yy_Break(GREG *G); /* 127 */
+YY_RULE(int) yy_While(GREG *G); /* 126 */
+YY_RULE(int) yy_Foreach(GREG *G); /* 125 */
+YY_RULE(int) yy_CATCH_KW(GREG *G); /* 124 */
+YY_RULE(int) yy_Catch(GREG *G); /* 123 */
+YY_RULE(int) yy_TRY_KW(GREG *G); /* 122 */
+YY_RULE(int) yy_Value(GREG *G); /* 121 */
+YY_RULE(int) yy_MATCH_KW(GREG *G); /* 120 */
+YY_RULE(int) yy_DOUBLE_ARROW(GREG *G); /* 119 */
+YY_RULE(int) yy_CaseExpr(GREG *G); /* 118 */
+YY_RULE(int) yy_CASE_KW(GREG *G); /* 117 */
+YY_RULE(int) yy_Case(GREG *G); /* 116 */
+YY_RULE(int) yy_ELSE_KW(GREG *G); /* 115 */
+YY_RULE(int) yy_Body(GREG *G); /* 114 */
+YY_RULE(int) yy_IF_KW(GREG *G); /* 113 */
+YY_RULE(int) yy_Else(GREG *G); /* 112 */
+YY_RULE(int) yy_If(GREG *G); /* 111 */
+YY_RULE(int) yy_Return(GREG *G); /* 110 */
+YY_RULE(int) yy_Try(GREG *G); /* 109 */
+YY_RULE(int) yy_Match(GREG *G); /* 108 */
+YY_RULE(int) yy_FlowControl(GREG *G); /* 107 */
+YY_RULE(int) yy_Block(GREG *G); /* 106 */
+YY_RULE(int) yy_Conditional(GREG *G); /* 105 */
+YY_RULE(int) yy_CommentLine(GREG *G); /* 104 */
+YY_RULE(int) yy_EoledStatement(GREG *G); /* 103 */
+YY_RULE(int) yy_StmtCore(GREG *G); /* 102 */
+YY_RULE(int) yy_FuncTypeCore(GREG *G); /* 101 */
+YY_RULE(int) yy_TypeListCore(GREG *G); /* 100 */
+YY_RULE(int) yy_TypeList(GREG *G); /* 99 */
+YY_RULE(int) yy_Old(GREG *G); /* 98 */
+YY_RULE(int) yy_GenericType(GREG *G); /* 97 */
+YY_RULE(int) yy_FuncType(GREG *G); /* 96 */
+YY_RULE(int) yy_TypeBase(GREG *G); /* 95 */
+YY_RULE(int) yy_SET_KW(GREG *G); /* 94 */
+YY_RULE(int) yy_GET_KW(GREG *G); /* 93 */
+YY_RULE(int) yy_PropertyDeclSetter(GREG *G); /* 92 */
+YY_RULE(int) yy_PropertyDeclGetter(GREG *G); /* 91 */
+YY_RULE(int) yy_PROPASS_DECL(GREG *G); /* 90 */
+YY_RULE(int) yy_PropertyDeclCore(GREG *G); /* 89 */
+YY_RULE(int) yy_ConventionalPropertyDecl(GREG *G); /* 88 */
+YY_RULE(int) yy_PropertyDeclFromExpr(GREG *G); /* 87 */
+YY_RULE(int) yy_ConventionalVarDecl(GREG *G); /* 86 */
 YY_RULE(int) yy_CONST_KW(GREG *G); /* 85 */
 YY_RULE(int) yy_ASS_DECL(GREG *G); /* 84 */
 YY_RULE(int) yy_Tuple(GREG *G); /* 83 */
@@ -2044,71 +2032,6 @@ YY_ACTION(void) yy_1_Access(GREG *G, char *yytext, int yyleng, yythunk *thunk, Y
 #undef index
 #undef l
 #undef ident
-}
-YY_ACTION(void) yy_5_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
-{
-#define i G->val[-1]
-#define f G->val[-2]
-#define expr G->val[-3]
-  yyprintf((stderr, "do yy_5_SafeNavAccess"));
-  yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {yy=nq_onSafeNavigationEnd(core->this); }\n"));
-  yy=nq_onSafeNavigationEnd(core->this); ;
-#undef i
-#undef f
-#undef expr
-}
-YY_ACTION(void) yy_4_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
-{
-#define i G->val[-1]
-#define f G->val[-2]
-#define expr G->val[-3]
-  yyprintf((stderr, "do yy_4_SafeNavAccess"));
-  yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {nq_onSafeNavigationIdent(core->this, i); }\n"));
-  nq_onSafeNavigationIdent(core->this, i); ;
-#undef i
-#undef f
-#undef expr
-}
-YY_ACTION(void) yy_3_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
-{
-#define i G->val[-1]
-#define f G->val[-2]
-#define expr G->val[-3]
-  yyprintf((stderr, "do yy_3_SafeNavAccess"));
-  yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {nq_onSafeNavigationMethod(core->this, f); }\n"));
-  nq_onSafeNavigationMethod(core->this, f); ;
-#undef i
-#undef f
-#undef expr
-}
-YY_ACTION(void) yy_2_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
-{
-#define i G->val[-1]
-#define f G->val[-2]
-#define expr G->val[-3]
-  yyprintf((stderr, "do yy_2_SafeNavAccess"));
-  yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {nq_onSafeNavigationSection(core->this); }\n"));
-  nq_onSafeNavigationSection(core->this); ;
-#undef i
-#undef f
-#undef expr
-}
-YY_ACTION(void) yy_1_SafeNavAccess(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
-{
-#define i G->val[-1]
-#define f G->val[-2]
-#define expr G->val[-3]
-  yyprintf((stderr, "do yy_1_SafeNavAccess"));
-  yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {tokenPos; nq_onSafeNavigationStart(core->this, expr); }\n"));
-  tokenPos; nq_onSafeNavigationStart(core->this, expr); ;
-#undef i
-#undef f
-#undef expr
 }
 YY_ACTION(void) yy_6_ProductCore(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
@@ -4739,23 +4662,6 @@ YY_ACTION(void) yy_1_VariableDecl(GREG *G, char *yytext, int yyleng, yythunk *th
   yy=v ;
 #undef v
 }
-YY_ACTION(void) yy_14_ConventionalVarDecl(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
-{
-#define unmangledName G->val[-1]
-#define externName G->val[-2]
-#define nextDeclName G->val[-3]
-#define varDeclName G->val[-4]
-#define doc G->val[-5]
-  yyprintf((stderr, "do yy_14_ConventionalVarDecl"));
-  yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {yy=nq_onVarDeclEnd(core->this); }\n"));
-  yy=nq_onVarDeclEnd(core->this); ;
-#undef unmangledName
-#undef externName
-#undef nextDeclName
-#undef varDeclName
-#undef doc
-}
 YY_ACTION(void) yy_13_ConventionalVarDecl(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define unmangledName G->val[-1]
@@ -4765,8 +4671,8 @@ YY_ACTION(void) yy_13_ConventionalVarDecl(GREG *G, char *yytext, int yyleng, yyt
 #define doc G->val[-5]
   yyprintf((stderr, "do yy_13_ConventionalVarDecl"));
   yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {nq_onVarDeclExpr(core->this, yy); }\n"));
-  nq_onVarDeclExpr(core->this, yy); ;
+  yyprintf((stderr, "\n  {yy=nq_onVarDeclEnd(core->this); }\n"));
+  yy=nq_onVarDeclEnd(core->this); ;
 #undef unmangledName
 #undef externName
 #undef nextDeclName
@@ -4782,8 +4688,8 @@ YY_ACTION(void) yy_12_ConventionalVarDecl(GREG *G, char *yytext, int yyleng, yyt
 #define doc G->val[-5]
   yyprintf((stderr, "do yy_12_ConventionalVarDecl"));
   yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {nq_onVarDeclType(core->this, yy); }\n"));
-  nq_onVarDeclType(core->this, yy); ;
+  yyprintf((stderr, "\n  {nq_onVarDeclExpr(core->this, yy); }\n"));
+  nq_onVarDeclExpr(core->this, yy); ;
 #undef unmangledName
 #undef externName
 #undef nextDeclName
@@ -4799,8 +4705,8 @@ YY_ACTION(void) yy_11_ConventionalVarDecl(GREG *G, char *yytext, int yyleng, yyt
 #define doc G->val[-5]
   yyprintf((stderr, "do yy_11_ConventionalVarDecl"));
   yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {nq_onVarDeclForcedMalloc(core->this);}\n"));
-  nq_onVarDeclForcedMalloc(core->this);;
+  yyprintf((stderr, "\n  {nq_onVarDeclType(core->this, yy); }\n"));
+  nq_onVarDeclType(core->this, yy); ;
 #undef unmangledName
 #undef externName
 #undef nextDeclName
@@ -4977,21 +4883,6 @@ YY_ACTION(void) yy_1_ConventionalVarDecl(GREG *G, char *yytext, int yyleng, yyth
 #undef varDeclName
 #undef doc
 }
-YY_ACTION(void) yy_8_VarDeclFromExpr(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
-{
-#define r G->val[-1]
-#define tup G->val[-2]
-#define i G->val[-3]
-#define doc G->val[-4]
-  yyprintf((stderr, "do yy_8_VarDeclFromExpr"));
-  yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {yy=nq_onVarDeclEnd(core->this); }\n"));
-  yy=nq_onVarDeclEnd(core->this); ;
-#undef r
-#undef tup
-#undef i
-#undef doc
-}
 YY_ACTION(void) yy_7_VarDeclFromExpr(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define r G->val[-1]
@@ -5000,8 +4891,8 @@ YY_ACTION(void) yy_7_VarDeclFromExpr(GREG *G, char *yytext, int yyleng, yythunk 
 #define doc G->val[-4]
   yyprintf((stderr, "do yy_7_VarDeclFromExpr"));
   yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {nq_onVarDeclExpr(core->this, r); }\n"));
-  nq_onVarDeclExpr(core->this, r); ;
+  yyprintf((stderr, "\n  {yy=nq_onVarDeclEnd(core->this); }\n"));
+  yy=nq_onVarDeclEnd(core->this); ;
 #undef r
 #undef tup
 #undef i
@@ -5015,8 +4906,8 @@ YY_ACTION(void) yy_6_VarDeclFromExpr(GREG *G, char *yytext, int yyleng, yythunk 
 #define doc G->val[-4]
   yyprintf((stderr, "do yy_6_VarDeclFromExpr"));
   yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {nq_onVarDeclForcedMalloc(core->this);}\n"));
-  nq_onVarDeclForcedMalloc(core->this);;
+  yyprintf((stderr, "\n  {nq_onVarDeclExpr(core->this, r); }\n"));
+  nq_onVarDeclExpr(core->this, r); ;
 #undef r
 #undef tup
 #undef i
@@ -6569,24 +6460,6 @@ YY_ACTION(void) yy_1_UseCore(GREG *G, char *yytext, int yyleng, yythunk *thunk, 
   yyprintf((stderr, "\n  {tokenPos; nq_onUse(core->this, nq_StringClone(yytext)) }\n"));
   tokenPos; nq_onUse(core->this, nq_StringClone(yytext)) ;
 }
-YY_ACTION(void) yy_4_VersionNegation(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
-{
-#define spec G->val[-1]
-  yyprintf((stderr, "do yy_4_VersionNegation"));
-  yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {yy=nq_onVersionNegation(core->this, spec) }\n"));
-  yy=nq_onVersionNegation(core->this, spec) ;
-#undef spec
-}
-YY_ACTION(void) yy_3_VersionNegation(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
-{
-#define spec G->val[-1]
-  yyprintf((stderr, "do yy_3_VersionNegation"));
-  yyprintfvTcontext(yytext);
-  yyprintf((stderr, "\n  {tokenPos; }\n"));
-  tokenPos; ;
-#undef spec
-}
 YY_ACTION(void) yy_2_VersionNegation(GREG *G, char *yytext, int yyleng, yythunk *thunk, YY_XTYPE YY_XVAR)
 {
 #define spec G->val[-1]
@@ -7895,15 +7768,43 @@ YY_RULE(int) yy_IDENT_CORE(GREG *G)
 
   return 0;
 }
-YY_RULE(int) yy_SAFE_NAV(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "SAFE_NAV"));
-  if (!yymatchChar(G, '$')) goto l195;
-  yyprintf((stderr, "  ok   SAFE_NAV"));
+YY_RULE(int) yy_SLASH(GREG *G)
+{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "SLASH"));
+  if (!yymatchChar(G, '/')) goto l195;
+
+  {  int yypos196= G->pos, yythunkpos196= G->thunkpos;  if (!yymatchChar(G, '=')) goto l196;
+  goto l195;
+  l196:;	  G->pos= yypos196; G->thunkpos= yythunkpos196;
+  }
+  {  int yypos197= G->pos, yythunkpos197= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "/*")) goto l197;
+  goto l195;
+  l197:;	  G->pos= yypos197; G->thunkpos= yythunkpos197;
+  }  if (!yy__(G))  goto l195;
+  yyprintf((stderr, "  ok   SLASH"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l195:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SAFE_NAV"));
+  l195:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SLASH"));
+  yyprintfvGcontext;
+  yyprintfv((stderr, "\n"));
+
+  return 0;
+}
+YY_RULE(int) yy_EXP(GREG *G)
+{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXP"));
+  if (!yymatchString(G, "**")) goto l198;
+
+  {  int yypos199= G->pos, yythunkpos199= G->thunkpos;  if (!yymatchChar(G, '=')) goto l199;
+  goto l198;
+  l199:;	  G->pos= yypos199; G->thunkpos= yythunkpos199;
+  }  if (!yy__(G))  goto l198;
+  yyprintf((stderr, "  ok   EXP"));
+  yyprintfGcontext;
+  yyprintf((stderr, "\n"));
+
+  return 1;
+  l198:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXP"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -7913,225 +7814,99 @@ YY_RULE(int) yy_Access(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Access"));
 
-  {  int yypos197= G->pos, yythunkpos197= G->thunkpos;  if (!yy_IDENT_CORE(G))  goto l198;
+  {  int yypos201= G->pos, yythunkpos201= G->thunkpos;  if (!yy_IDENT_CORE(G))  goto l202;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_1_Access, G->begin, G->end, "yy_1_Access");
-  if (!yymatchChar(G, '&')) goto l198;
+  if (!yymatchChar(G, '&')) goto l202;
 
-  {  int yypos199= G->pos, yythunkpos199= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l199;
-  goto l198;
-  l199:;	  G->pos= yypos199; G->thunkpos= yythunkpos199;
-  }  if (!yy__(G))  goto l198;
+  {  int yypos203= G->pos, yythunkpos203= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l203;
+  goto l202;
+  l203:;	  G->pos= yypos203; G->thunkpos= yythunkpos203;
+  }  if (!yy__(G))  goto l202;
   yyDo(G, yy_2_Access, G->begin, G->end, "yy_2_Access");
-  goto l197;
-  l198:;	  G->pos= yypos197; G->thunkpos= yythunkpos197;  if (!yy_Value(G))  goto l196;
+  goto l201;
+  l202:;	  G->pos= yypos201; G->thunkpos= yythunkpos201;  if (!yy_Value(G))  goto l200;
   yyDo(G, yySet, -4, 0, "yySet");
 
   }
-  l197:;	
-  l200:;	
-  {  int yypos201= G->pos, yythunkpos201= G->thunkpos;
-  {  int yypos202= G->pos, yythunkpos202= G->thunkpos;  if (!yy__(G))  goto l203;
-  if (!yymatchChar(G, '[')) goto l203;
-  if (!yy__(G))  goto l203;
+  l201:;	
+  l204:;	
+  {  int yypos205= G->pos, yythunkpos205= G->thunkpos;
+  {  int yypos206= G->pos, yythunkpos206= G->thunkpos;  if (!yy__(G))  goto l207;
+  if (!yymatchChar(G, '[')) goto l207;
+  if (!yy__(G))  goto l207;
   yyDo(G, yy_3_Access, G->begin, G->end, "yy_3_Access");
-  if (!yy_Expr(G))  goto l203;
+  if (!yy_Expr(G))  goto l207;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l203;
+  if (!yy__(G))  goto l207;
   yyDo(G, yy_4_Access, G->begin, G->end, "yy_4_Access");
 
-  l204:;	
-  {  int yypos205= G->pos, yythunkpos205= G->thunkpos;  if (!yymatchChar(G, ',')) goto l205;
-  if (!yy_WS(G))  goto l205;
-  if (!yy_Expr(G))  goto l205;
+  l208:;	
+  {  int yypos209= G->pos, yythunkpos209= G->thunkpos;  if (!yymatchChar(G, ',')) goto l209;
+  if (!yy_WS(G))  goto l209;
+  if (!yy_Expr(G))  goto l209;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l205;
+  if (!yy__(G))  goto l209;
   yyDo(G, yy_5_Access, G->begin, G->end, "yy_5_Access");
-  goto l204;
-  l205:;	  G->pos= yypos205; G->thunkpos= yythunkpos205;
-  }  if (!yy__(G))  goto l203;
-  if (!yy_CLOS_SQUAR(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed array access! Expected ']' to end array access.\n"); ; } goto l203; }
-  if (!yy__(G))  goto l203;
+  goto l208;
+  l209:;	  G->pos= yypos209; G->thunkpos= yythunkpos209;
+  }  if (!yy__(G))  goto l207;
+  if (!yy_CLOS_SQUAR(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed array access! Expected ']' to end array access.\n"); ; } goto l207; }
+  if (!yy__(G))  goto l207;
   yyDo(G, yy_6_Access, G->begin, G->end, "yy_6_Access");
-  goto l202;
-  l203:;	  G->pos= yypos202; G->thunkpos= yythunkpos202;  if (!yy__(G))  goto l206;
-  if (!yy_FunctionCall(G))  goto l206;
+  goto l206;
+  l207:;	  G->pos= yypos206; G->thunkpos= yythunkpos206;  if (!yy__(G))  goto l210;
+  if (!yy_FunctionCall(G))  goto l210;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_7_Access, G->begin, G->end, "yy_7_Access");
-  goto l202;
-  l206:;	  G->pos= yypos202; G->thunkpos= yythunkpos202;  if (!yy__(G))  goto l207;
-  if (!yy_IDENT_CORE(G))  goto l207;
+  goto l206;
+  l210:;	  G->pos= yypos206; G->thunkpos= yythunkpos206;  if (!yy__(G))  goto l211;
+  if (!yy_IDENT_CORE(G))  goto l211;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Access, G->begin, G->end, "yy_8_Access");
-  goto l202;
-  l207:;	  G->pos= yypos202; G->thunkpos= yythunkpos202;  if (!yy__(G))  goto l208;
-  if (!yy_AS_KW(G))  goto l208;
+  goto l206;
+  l211:;	  G->pos= yypos206; G->thunkpos= yythunkpos206;  if (!yy__(G))  goto l212;
+  if (!yy_AS_KW(G))  goto l212;
   yyDo(G, yy_9_Access, G->begin, G->end, "yy_9_Access");
-  if (!yy__(G))  goto l208;
-  if (!yy_Type(G))  goto l208;
+  if (!yy__(G))  goto l212;
+  if (!yy_Type(G))  goto l212;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_Access, G->begin, G->end, "yy_10_Access");
-  goto l202;
-  l208:;	  G->pos= yypos202; G->thunkpos= yythunkpos202;  if (!yymatchChar(G, '&')) goto l209;
+  goto l206;
+  l212:;	  G->pos= yypos206; G->thunkpos= yythunkpos206;  if (!yymatchChar(G, '&')) goto l213;
 
-  {  int yypos210= G->pos, yythunkpos210= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l210;
-  goto l209;
-  l210:;	  G->pos= yypos210; G->thunkpos= yythunkpos210;
-  }  if (!yy__(G))  goto l209;
+  {  int yypos214= G->pos, yythunkpos214= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l214;
+  goto l213;
+  l214:;	  G->pos= yypos214; G->thunkpos= yythunkpos214;
+  }  if (!yy__(G))  goto l213;
 
-  {  int yypos211= G->pos, yythunkpos211= G->thunkpos;
-  {  int yypos212= G->pos, yythunkpos212= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\046\000\000\001\022\000\010\000\000\000\000\000\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t\\r\\n;,)}")) goto l213;
-  goto l212;
-  l213:;	  G->pos= yypos212; G->thunkpos= yythunkpos212;  if (!yymatchChar(G, ']')) goto l209;
+  {  int yypos215= G->pos, yythunkpos215= G->thunkpos;
+  {  int yypos216= G->pos, yythunkpos216= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\046\000\000\001\022\000\010\000\000\000\000\000\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t\\r\\n;,)}")) goto l217;
+  goto l216;
+  l217:;	  G->pos= yypos216; G->thunkpos= yythunkpos216;  if (!yymatchChar(G, ']')) goto l213;
 
   }
-  l212:;	  G->pos= yypos211; G->thunkpos= yythunkpos211;
+  l216:;	  G->pos= yypos215; G->thunkpos= yythunkpos215;
   }  yyDo(G, yy_11_Access, G->begin, G->end, "yy_11_Access");
-  goto l202;
-  l209:;	  G->pos= yypos202; G->thunkpos= yythunkpos202;  if (!yymatchChar(G, '@')) goto l214;
+  goto l206;
+  l213:;	  G->pos= yypos206; G->thunkpos= yythunkpos206;  if (!yymatchChar(G, '@')) goto l218;
   yyDo(G, yy_12_Access, G->begin, G->end, "yy_12_Access");
-  goto l202;
-  l214:;	  G->pos= yypos202; G->thunkpos= yythunkpos202;  if (!yy__(G))  goto l201;
-  if (!yy_FunctionCallNoname(G))  goto l201;
+  goto l206;
+  l218:;	  G->pos= yypos206; G->thunkpos= yythunkpos206;  if (!yy__(G))  goto l205;
+  if (!yy_FunctionCallNoname(G))  goto l205;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_13_Access, G->begin, G->end, "yy_13_Access");
 
   }
-  l202:;	  goto l200;
-  l201:;	  G->pos= yypos201; G->thunkpos= yythunkpos201;
-  }  if (!yy__(G))  goto l196;
+  l206:;	  goto l204;
+  l205:;	  G->pos= yypos205; G->thunkpos= yythunkpos205;
+  }  if (!yy__(G))  goto l200;
   yyprintf((stderr, "  ok   Access"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l196:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Access"));
-  yyprintfvGcontext;
-  yyprintfv((stderr, "\n"));
-
-  return 0;
-}
-YY_RULE(int) yy_SLASH(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "SLASH"));
-  if (!yymatchChar(G, '/')) goto l215;
-
-  {  int yypos216= G->pos, yythunkpos216= G->thunkpos;  if (!yymatchChar(G, '=')) goto l216;
-  goto l215;
-  l216:;	  G->pos= yypos216; G->thunkpos= yythunkpos216;
-  }
-  {  int yypos217= G->pos, yythunkpos217= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "/*")) goto l217;
-  goto l215;
-  l217:;	  G->pos= yypos217; G->thunkpos= yythunkpos217;
-  }  if (!yy__(G))  goto l215;
-  yyprintf((stderr, "  ok   SLASH"));
-  yyprintfGcontext;
-  yyprintf((stderr, "\n"));
-
-  return 1;
-  l215:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SLASH"));
-  yyprintfvGcontext;
-  yyprintfv((stderr, "\n"));
-
-  return 0;
-}
-YY_RULE(int) yy_EXP(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXP"));
-  if (!yymatchString(G, "**")) goto l218;
-
-  {  int yypos219= G->pos, yythunkpos219= G->thunkpos;  if (!yymatchChar(G, '=')) goto l219;
-  goto l218;
-  l219:;	  G->pos= yypos219; G->thunkpos= yythunkpos219;
-  }  if (!yy__(G))  goto l218;
-  yyprintf((stderr, "  ok   EXP"));
-  yyprintfGcontext;
-  yyprintf((stderr, "\n"));
-
-  return 1;
-  l218:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXP"));
-  yyprintfvGcontext;
-  yyprintfv((stderr, "\n"));
-
-  return 0;
-}
-YY_RULE(int) yy_SafeNavAccess(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
-  yyprintfv((stderr, "%s\n", "SafeNavAccess"));
-  if (!yy_Access(G))  goto l220;
-  yyDo(G, yySet, -3, 0, "yySet");
-
-  {  int yypos221= G->pos, yythunkpos221= G->thunkpos;  yyDo(G, yy_1_SafeNavAccess, G->begin, G->end, "yy_1_SafeNavAccess");
-  if (!yy_SAFE_NAV(G))  goto l221;
-  yyDo(G, yy_2_SafeNavAccess, G->begin, G->end, "yy_2_SafeNavAccess");
-  if (!yy__(G))  goto l221;
-
-  {  int yypos227= G->pos, yythunkpos227= G->thunkpos;  if (!yy_FunctionCall(G))  goto l228;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
-  goto l227;
-  l228:;	  G->pos= yypos227; G->thunkpos= yythunkpos227;  if (!yy_IDENT_CORE(G))  goto l221;
-  yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_4_SafeNavAccess, G->begin, G->end, "yy_4_SafeNavAccess");
-
-  }
-  l227:;	  if (!yy__(G))  goto l221;
-
-  l225:;	
-  {  int yypos226= G->pos, yythunkpos226= G->thunkpos;
-  {  int yypos229= G->pos, yythunkpos229= G->thunkpos;  if (!yy_FunctionCall(G))  goto l230;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
-  goto l229;
-  l230:;	  G->pos= yypos229; G->thunkpos= yythunkpos229;  if (!yy_IDENT_CORE(G))  goto l226;
-  yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_4_SafeNavAccess, G->begin, G->end, "yy_4_SafeNavAccess");
-
-  }
-  l229:;	  if (!yy__(G))  goto l226;
-  goto l225;
-  l226:;	  G->pos= yypos226; G->thunkpos= yythunkpos226;
-  }
-  l223:;	
-  {  int yypos224= G->pos, yythunkpos224= G->thunkpos;  if (!yy_SAFE_NAV(G))  goto l224;
-  yyDo(G, yy_2_SafeNavAccess, G->begin, G->end, "yy_2_SafeNavAccess");
-  if (!yy__(G))  goto l224;
-
-  {  int yypos233= G->pos, yythunkpos233= G->thunkpos;  if (!yy_FunctionCall(G))  goto l234;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
-  goto l233;
-  l234:;	  G->pos= yypos233; G->thunkpos= yythunkpos233;  if (!yy_IDENT_CORE(G))  goto l224;
-  yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_4_SafeNavAccess, G->begin, G->end, "yy_4_SafeNavAccess");
-
-  }
-  l233:;	  if (!yy__(G))  goto l224;
-
-  l231:;	
-  {  int yypos232= G->pos, yythunkpos232= G->thunkpos;
-  {  int yypos235= G->pos, yythunkpos235= G->thunkpos;  if (!yy_FunctionCall(G))  goto l236;
-  yyDo(G, yySet, -2, 0, "yySet");
-  yyDo(G, yy_3_SafeNavAccess, G->begin, G->end, "yy_3_SafeNavAccess");
-  goto l235;
-  l236:;	  G->pos= yypos235; G->thunkpos= yythunkpos235;  if (!yy_IDENT_CORE(G))  goto l232;
-  yyDo(G, yySet, -1, 0, "yySet");
-  yyDo(G, yy_4_SafeNavAccess, G->begin, G->end, "yy_4_SafeNavAccess");
-
-  }
-  l235:;	  if (!yy__(G))  goto l232;
-  goto l231;
-  l232:;	  G->pos= yypos232; G->thunkpos= yythunkpos232;
-  }  goto l223;
-  l224:;	  G->pos= yypos224; G->thunkpos= yythunkpos224;
-  }  yyDo(G, yy_5_SafeNavAccess, G->begin, G->end, "yy_5_SafeNavAccess");
-  goto l222;
-  l221:;	  G->pos= yypos221; G->thunkpos= yythunkpos221;
-  }
-  l222:;	  yyprintf((stderr, "  ok   SafeNavAccess"));
-  yyprintfGcontext;
-  yyprintf((stderr, "\n"));
-  yyDo(G, yyPop, 3, 0, "yyPop");
-  return 1;
-  l220:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SafeNavAccess"));
+  l200:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Access"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8139,18 +7914,18 @@ YY_RULE(int) yy_SafeNavAccess(GREG *G)
 }
 YY_RULE(int) yy_B_NOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_NOT"));
-  if (!yymatchChar(G, '~')) goto l237;
+  if (!yymatchChar(G, '~')) goto l219;
 
-  {  int yypos238= G->pos, yythunkpos238= G->thunkpos;  if (!yymatchChar(G, '=')) goto l238;
-  goto l237;
-  l238:;	  G->pos= yypos238; G->thunkpos= yythunkpos238;
-  }  if (!yy__(G))  goto l237;
+  {  int yypos220= G->pos, yythunkpos220= G->thunkpos;  if (!yymatchChar(G, '=')) goto l220;
+  goto l219;
+  l220:;	  G->pos= yypos220; G->thunkpos= yythunkpos220;
+  }  if (!yy__(G))  goto l219;
   yyprintf((stderr, "  ok   B_NOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l237:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_NOT"));
+  l219:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_NOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8158,18 +7933,18 @@ YY_RULE(int) yy_B_NOT(GREG *G)
 }
 YY_RULE(int) yy_L_NOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_NOT"));
-  if (!yymatchChar(G, '!')) goto l239;
+  if (!yymatchChar(G, '!')) goto l221;
 
-  {  int yypos240= G->pos, yythunkpos240= G->thunkpos;  if (!yymatchChar(G, '=')) goto l240;
-  goto l239;
-  l240:;	  G->pos= yypos240; G->thunkpos= yythunkpos240;
-  }  if (!yy__(G))  goto l239;
+  {  int yypos222= G->pos, yythunkpos222= G->thunkpos;  if (!yymatchChar(G, '=')) goto l222;
+  goto l221;
+  l222:;	  G->pos= yypos222; G->thunkpos= yythunkpos222;
+  }  if (!yy__(G))  goto l221;
   yyprintf((stderr, "  ok   L_NOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l239:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_NOT"));
+  l221:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_NOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8178,41 +7953,41 @@ YY_RULE(int) yy_L_NOT(GREG *G)
 YY_RULE(int) yy_ProductCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductCore"));
-  if (!yy_SafeNavAccess(G))  goto l241;
+  if (!yy_Access(G))  goto l223;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l242:;	
-  {  int yypos243= G->pos, yythunkpos243= G->thunkpos;
-  {  int yypos244= G->pos, yythunkpos244= G->thunkpos;  if (!yy_EXP(G))  goto l245;
+  l224:;	
+  {  int yypos225= G->pos, yythunkpos225= G->thunkpos;
+  {  int yypos226= G->pos, yythunkpos226= G->thunkpos;  if (!yy_EXP(G))  goto l227;
   yyDo(G, yy_1_ProductCore, G->begin, G->end, "yy_1_ProductCore");
-  if (!yy_WS(G))  goto l245;
-  if (!yy_Product(G))  goto l245;
+  if (!yy_WS(G))  goto l227;
+  if (!yy_Product(G))  goto l227;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_ProductCore, G->begin, G->end, "yy_2_ProductCore");
-  goto l244;
-  l245:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;  if (!yy_STAR(G))  goto l246;
+  goto l226;
+  l227:;	  G->pos= yypos226; G->thunkpos= yythunkpos226;  if (!yy_STAR(G))  goto l228;
   yyDo(G, yy_3_ProductCore, G->begin, G->end, "yy_3_ProductCore");
-  if (!yy_WS(G))  goto l246;
-  if (!yy_SafeNavAccess(G))  goto l246;
+  if (!yy_WS(G))  goto l228;
+  if (!yy_Access(G))  goto l228;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_ProductCore, G->begin, G->end, "yy_4_ProductCore");
-  goto l244;
-  l246:;	  G->pos= yypos244; G->thunkpos= yythunkpos244;  if (!yy_SLASH(G))  goto l243;
+  goto l226;
+  l228:;	  G->pos= yypos226; G->thunkpos= yythunkpos226;  if (!yy_SLASH(G))  goto l225;
   yyDo(G, yy_5_ProductCore, G->begin, G->end, "yy_5_ProductCore");
-  if (!yy_WS(G))  goto l243;
-  if (!yy_SafeNavAccess(G))  goto l243;
+  if (!yy_WS(G))  goto l225;
+  if (!yy_Access(G))  goto l225;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_ProductCore, G->begin, G->end, "yy_6_ProductCore");
 
   }
-  l244:;	  goto l242;
-  l243:;	  G->pos= yypos243; G->thunkpos= yythunkpos243;
+  l226:;	  goto l224;
+  l225:;	  G->pos= yypos225; G->thunkpos= yythunkpos225;
   }  yyprintf((stderr, "  ok   ProductCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l241:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductCore"));
+  l223:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8221,19 +7996,19 @@ YY_RULE(int) yy_ProductCore(GREG *G)
 YY_RULE(int) yy_ProductBinaryNot(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductBinaryNot"));
-  if (!yy_B_NOT(G))  goto l247;
+  if (!yy_B_NOT(G))  goto l229;
   yyDo(G, yy_1_ProductBinaryNot, G->begin, G->end, "yy_1_ProductBinaryNot");
-  if (!yy__(G))  goto l247;
-  if (!yy_Product(G))  goto l247;
+  if (!yy__(G))  goto l229;
+  if (!yy_Product(G))  goto l229;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l247;
+  if (!yy__(G))  goto l229;
   yyDo(G, yy_2_ProductBinaryNot, G->begin, G->end, "yy_2_ProductBinaryNot");
   yyprintf((stderr, "  ok   ProductBinaryNot"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l247:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductBinaryNot"));
+  l229:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductBinaryNot"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8242,19 +8017,19 @@ YY_RULE(int) yy_ProductBinaryNot(GREG *G)
 YY_RULE(int) yy_ProductLogicalNot(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ProductLogicalNot"));
-  if (!yy_L_NOT(G))  goto l248;
+  if (!yy_L_NOT(G))  goto l230;
   yyDo(G, yy_1_ProductLogicalNot, G->begin, G->end, "yy_1_ProductLogicalNot");
-  if (!yy__(G))  goto l248;
-  if (!yy_Product(G))  goto l248;
+  if (!yy__(G))  goto l230;
+  if (!yy_Product(G))  goto l230;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l248;
+  if (!yy__(G))  goto l230;
   yyDo(G, yy_2_ProductLogicalNot, G->begin, G->end, "yy_2_ProductLogicalNot");
   yyprintf((stderr, "  ok   ProductLogicalNot"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l248:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductLogicalNot"));
+  l230:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ProductLogicalNot"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8262,18 +8037,18 @@ YY_RULE(int) yy_ProductLogicalNot(GREG *G)
 }
 YY_RULE(int) yy_PERCENT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PERCENT"));
-  if (!yymatchChar(G, '%')) goto l249;
+  if (!yymatchChar(G, '%')) goto l231;
 
-  {  int yypos250= G->pos, yythunkpos250= G->thunkpos;  if (!yymatchChar(G, '=')) goto l250;
-  goto l249;
-  l250:;	  G->pos= yypos250; G->thunkpos= yythunkpos250;
-  }  if (!yy__(G))  goto l249;
+  {  int yypos232= G->pos, yythunkpos232= G->thunkpos;  if (!yymatchChar(G, '=')) goto l232;
+  goto l231;
+  l232:;	  G->pos= yypos232; G->thunkpos= yythunkpos232;
+  }  if (!yy__(G))  goto l231;
   yyprintf((stderr, "  ok   PERCENT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l249:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PERCENT"));
+  l231:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PERCENT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8281,18 +8056,18 @@ YY_RULE(int) yy_PERCENT(GREG *G)
 }
 YY_RULE(int) yy_MINUS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MINUS"));
-  if (!yymatchChar(G, '-')) goto l251;
+  if (!yymatchChar(G, '-')) goto l233;
 
-  {  int yypos252= G->pos, yythunkpos252= G->thunkpos;  if (!yymatchChar(G, '=')) goto l252;
-  goto l251;
-  l252:;	  G->pos= yypos252; G->thunkpos= yythunkpos252;
-  }  if (!yy__(G))  goto l251;
+  {  int yypos234= G->pos, yythunkpos234= G->thunkpos;  if (!yymatchChar(G, '=')) goto l234;
+  goto l233;
+  l234:;	  G->pos= yypos234; G->thunkpos= yythunkpos234;
+  }  if (!yy__(G))  goto l233;
   yyprintf((stderr, "  ok   MINUS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l251:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MINUS"));
+  l233:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MINUS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8301,19 +8076,19 @@ YY_RULE(int) yy_MINUS(GREG *G)
 YY_RULE(int) yy_Product(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Product"));
 
-  {  int yypos254= G->pos, yythunkpos254= G->thunkpos;  if (!yy_ProductLogicalNot(G))  goto l255;
-  goto l254;
-  l255:;	  G->pos= yypos254; G->thunkpos= yythunkpos254;  if (!yy_ProductBinaryNot(G))  goto l256;
-  goto l254;
-  l256:;	  G->pos= yypos254; G->thunkpos= yythunkpos254;  if (!yy_ProductCore(G))  goto l253;
+  {  int yypos236= G->pos, yythunkpos236= G->thunkpos;  if (!yy_ProductLogicalNot(G))  goto l237;
+  goto l236;
+  l237:;	  G->pos= yypos236; G->thunkpos= yythunkpos236;  if (!yy_ProductBinaryNot(G))  goto l238;
+  goto l236;
+  l238:;	  G->pos= yypos236; G->thunkpos= yythunkpos236;  if (!yy_ProductCore(G))  goto l235;
 
   }
-  l254:;	  yyprintf((stderr, "  ok   Product"));
+  l236:;	  yyprintf((stderr, "  ok   Product"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l253:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Product"));
+  l235:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Product"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8321,18 +8096,18 @@ YY_RULE(int) yy_Product(GREG *G)
 }
 YY_RULE(int) yy_B_RSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_RSHIFT"));
-  if (!yymatchString(G, ">>")) goto l257;
+  if (!yymatchString(G, ">>")) goto l239;
 
-  {  int yypos258= G->pos, yythunkpos258= G->thunkpos;  if (!yymatchChar(G, '=')) goto l258;
-  goto l257;
-  l258:;	  G->pos= yypos258; G->thunkpos= yythunkpos258;
-  }  if (!yy__(G))  goto l257;
+  {  int yypos240= G->pos, yythunkpos240= G->thunkpos;  if (!yymatchChar(G, '=')) goto l240;
+  goto l239;
+  l240:;	  G->pos= yypos240; G->thunkpos= yythunkpos240;
+  }  if (!yy__(G))  goto l239;
   yyprintf((stderr, "  ok   B_RSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l257:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_RSHIFT"));
+  l239:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_RSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8340,18 +8115,18 @@ YY_RULE(int) yy_B_RSHIFT(GREG *G)
 }
 YY_RULE(int) yy_B_LSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_LSHIFT"));
-  if (!yymatchString(G, "<<")) goto l259;
+  if (!yymatchString(G, "<<")) goto l241;
 
-  {  int yypos260= G->pos, yythunkpos260= G->thunkpos;  if (!yymatchChar(G, '=')) goto l260;
-  goto l259;
-  l260:;	  G->pos= yypos260; G->thunkpos= yythunkpos260;
-  }  if (!yy__(G))  goto l259;
+  {  int yypos242= G->pos, yythunkpos242= G->thunkpos;  if (!yymatchChar(G, '=')) goto l242;
+  goto l241;
+  l242:;	  G->pos= yypos242; G->thunkpos= yythunkpos242;
+  }  if (!yy__(G))  goto l241;
   yyprintf((stderr, "  ok   B_LSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l259:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_LSHIFT"));
+  l241:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_LSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8360,41 +8135,41 @@ YY_RULE(int) yy_B_LSHIFT(GREG *G)
 YY_RULE(int) yy_Sum(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Sum"));
-  if (!yy_Product(G))  goto l261;
+  if (!yy_Product(G))  goto l243;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l262:;	
-  {  int yypos263= G->pos, yythunkpos263= G->thunkpos;
-  {  int yypos264= G->pos, yythunkpos264= G->thunkpos;  if (!yy_PLUS(G))  goto l265;
+  l244:;	
+  {  int yypos245= G->pos, yythunkpos245= G->thunkpos;
+  {  int yypos246= G->pos, yythunkpos246= G->thunkpos;  if (!yy_PLUS(G))  goto l247;
   yyDo(G, yy_1_Sum, G->begin, G->end, "yy_1_Sum");
-  if (!yy_WS(G))  goto l265;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+") ; } goto l265; }
+  if (!yy_WS(G))  goto l247;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+") ; } goto l247; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Sum, G->begin, G->end, "yy_2_Sum");
-  goto l264;
-  l265:;	  G->pos= yypos264; G->thunkpos= yythunkpos264;  if (!yy_MINUS(G))  goto l266;
+  goto l246;
+  l247:;	  G->pos= yypos246; G->thunkpos= yythunkpos246;  if (!yy_MINUS(G))  goto l248;
   yyDo(G, yy_3_Sum, G->begin, G->end, "yy_3_Sum");
-  if (!yy_WS(G))  goto l266;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-") ; } goto l266; }
+  if (!yy_WS(G))  goto l248;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-") ; } goto l248; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Sum, G->begin, G->end, "yy_4_Sum");
-  goto l264;
-  l266:;	  G->pos= yypos264; G->thunkpos= yythunkpos264;  if (!yy_PERCENT(G))  goto l263;
+  goto l246;
+  l248:;	  G->pos= yypos246; G->thunkpos= yythunkpos246;  if (!yy_PERCENT(G))  goto l245;
   yyDo(G, yy_5_Sum, G->begin, G->end, "yy_5_Sum");
-  if (!yy_WS(G))  goto l263;
-  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%") ; } goto l263; }
+  if (!yy_WS(G))  goto l245;
+  if (!yy_Product(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%") ; } goto l245; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Sum, G->begin, G->end, "yy_6_Sum");
 
   }
-  l264:;	  goto l262;
-  l263:;	  G->pos= yypos263; G->thunkpos= yythunkpos263;
+  l246:;	  goto l244;
+  l245:;	  G->pos= yypos245; G->thunkpos= yythunkpos245;
   }  yyprintf((stderr, "  ok   Sum"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l261:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Sum"));
+  l243:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Sum"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8402,14 +8177,14 @@ YY_RULE(int) yy_Sum(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_DOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_DOT"));
-  if (!yymatchString(G, "..")) goto l267;
-  if (!yy__(G))  goto l267;
+  if (!yymatchString(G, "..")) goto l249;
+  if (!yy__(G))  goto l249;
   yyprintf((stderr, "  ok   DOUBLE_DOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l267:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_DOT"));
+  l249:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_DOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8418,34 +8193,34 @@ YY_RULE(int) yy_DOUBLE_DOT(GREG *G)
 YY_RULE(int) yy_Shift(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Shift"));
-  if (!yy_Sum(G))  goto l268;
+  if (!yy_Sum(G))  goto l250;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l269:;	
-  {  int yypos270= G->pos, yythunkpos270= G->thunkpos;
-  {  int yypos271= G->pos, yythunkpos271= G->thunkpos;  if (!yy_B_LSHIFT(G))  goto l272;
+  l251:;	
+  {  int yypos252= G->pos, yythunkpos252= G->thunkpos;
+  {  int yypos253= G->pos, yythunkpos253= G->thunkpos;  if (!yy_B_LSHIFT(G))  goto l254;
   yyDo(G, yy_1_Shift, G->begin, G->end, "yy_1_Shift");
-  if (!yy_WS(G))  goto l272;
-  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<") ; } goto l272; }
+  if (!yy_WS(G))  goto l254;
+  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<") ; } goto l254; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Shift, G->begin, G->end, "yy_2_Shift");
-  goto l271;
-  l272:;	  G->pos= yypos271; G->thunkpos= yythunkpos271;  if (!yy_B_RSHIFT(G))  goto l270;
+  goto l253;
+  l254:;	  G->pos= yypos253; G->thunkpos= yythunkpos253;  if (!yy_B_RSHIFT(G))  goto l252;
   yyDo(G, yy_3_Shift, G->begin, G->end, "yy_3_Shift");
-  if (!yy_WS(G))  goto l270;
-  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>") ; } goto l270; }
+  if (!yy_WS(G))  goto l252;
+  if (!yy_Sum(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>") ; } goto l252; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Shift, G->begin, G->end, "yy_4_Shift");
 
   }
-  l271:;	  goto l269;
-  l270:;	  G->pos= yypos270; G->thunkpos= yythunkpos270;
+  l253:;	  goto l251;
+  l252:;	  G->pos= yypos252; G->thunkpos= yythunkpos252;
   }  yyprintf((stderr, "  ok   Shift"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l268:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Shift"));
+  l250:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Shift"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8453,14 +8228,14 @@ YY_RULE(int) yy_Shift(GREG *G)
 }
 YY_RULE(int) yy_MORETHAN_EQ(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MORETHAN_EQ"));
-  if (!yymatchString(G, ">=")) goto l273;
-  if (!yy__(G))  goto l273;
+  if (!yymatchString(G, ">=")) goto l255;
+  if (!yy__(G))  goto l255;
   yyprintf((stderr, "  ok   MORETHAN_EQ"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l273:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN_EQ"));
+  l255:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN_EQ"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8468,14 +8243,14 @@ YY_RULE(int) yy_MORETHAN_EQ(GREG *G)
 }
 YY_RULE(int) yy_LESSTHAN_EQ(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "LESSTHAN_EQ"));
-  if (!yymatchString(G, "<=")) goto l274;
-  if (!yy__(G))  goto l274;
+  if (!yymatchString(G, "<=")) goto l256;
+  if (!yy__(G))  goto l256;
   yyprintf((stderr, "  ok   LESSTHAN_EQ"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l274:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN_EQ"));
+  l256:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN_EQ"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8483,14 +8258,14 @@ YY_RULE(int) yy_LESSTHAN_EQ(GREG *G)
 }
 YY_RULE(int) yy_CMP(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CMP"));
-  if (!yymatchString(G, "<=>")) goto l275;
-  if (!yy__(G))  goto l275;
+  if (!yymatchString(G, "<=>")) goto l257;
+  if (!yy__(G))  goto l257;
   yyprintf((stderr, "  ok   CMP"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l275:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CMP"));
+  l257:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CMP"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8499,24 +8274,24 @@ YY_RULE(int) yy_CMP(GREG *G)
 YY_RULE(int) yy_Range(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Range"));
-  if (!yy_Shift(G))  goto l276;
+  if (!yy_Shift(G))  goto l258;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l277:;	
-  {  int yypos278= G->pos, yythunkpos278= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l278;
+  l259:;	
+  {  int yypos260= G->pos, yythunkpos260= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l260;
   yyDo(G, yy_1_Range, G->begin, G->end, "yy_1_Range");
-  if (!yy_WS(G))  goto l278;
-  if (!yy_Shift(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("..") ; } goto l278; }
+  if (!yy_WS(G))  goto l260;
+  if (!yy_Shift(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("..") ; } goto l260; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Range, G->begin, G->end, "yy_2_Range");
-  goto l277;
-  l278:;	  G->pos= yypos278; G->thunkpos= yythunkpos278;
+  goto l259;
+  l260:;	  G->pos= yypos260; G->thunkpos= yythunkpos260;
   }  yyprintf((stderr, "  ok   Range"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l276:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Range"));
+  l258:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Range"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8524,14 +8299,14 @@ YY_RULE(int) yy_Range(GREG *G)
 }
 YY_RULE(int) yy_NOT_EQUALS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "NOT_EQUALS"));
-  if (!yymatchString(G, "!=")) goto l279;
-  if (!yy__(G))  goto l279;
+  if (!yymatchString(G, "!=")) goto l261;
+  if (!yy__(G))  goto l261;
   yyprintf((stderr, "  ok   NOT_EQUALS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l279:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NOT_EQUALS"));
+  l261:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NOT_EQUALS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8539,14 +8314,14 @@ YY_RULE(int) yy_NOT_EQUALS(GREG *G)
 }
 YY_RULE(int) yy_EQUALS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EQUALS"));
-  if (!yymatchString(G, "==")) goto l280;
-  if (!yy__(G))  goto l280;
+  if (!yymatchString(G, "==")) goto l262;
+  if (!yy__(G))  goto l262;
   yyprintf((stderr, "  ok   EQUALS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l280:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EQUALS"));
+  l262:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EQUALS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8555,55 +8330,55 @@ YY_RULE(int) yy_EQUALS(GREG *G)
 YY_RULE(int) yy_Inequality(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Inequality"));
-  if (!yy_Range(G))  goto l281;
+  if (!yy_Range(G))  goto l263;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l282:;	
-  {  int yypos283= G->pos, yythunkpos283= G->thunkpos;
-  {  int yypos284= G->pos, yythunkpos284= G->thunkpos;  if (!yy_LESSTHAN(G))  goto l285;
+  l264:;	
+  {  int yypos265= G->pos, yythunkpos265= G->thunkpos;
+  {  int yypos266= G->pos, yythunkpos266= G->thunkpos;  if (!yy_LESSTHAN(G))  goto l267;
   yyDo(G, yy_1_Inequality, G->begin, G->end, "yy_1_Inequality");
-  if (!yy_WS(G))  goto l285;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<") ; } goto l285; }
+  if (!yy_WS(G))  goto l267;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<") ; } goto l267; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Inequality, G->begin, G->end, "yy_2_Inequality");
-  goto l284;
-  l285:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;  if (!yy_MORETHAN(G))  goto l286;
+  goto l266;
+  l267:;	  G->pos= yypos266; G->thunkpos= yythunkpos266;  if (!yy_MORETHAN(G))  goto l268;
   yyDo(G, yy_3_Inequality, G->begin, G->end, "yy_3_Inequality");
-  if (!yy_WS(G))  goto l286;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">") ; } goto l286; }
+  if (!yy_WS(G))  goto l268;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">") ; } goto l268; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Inequality, G->begin, G->end, "yy_4_Inequality");
-  goto l284;
-  l286:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;  if (!yy_CMP(G))  goto l287;
+  goto l266;
+  l268:;	  G->pos= yypos266; G->thunkpos= yythunkpos266;  if (!yy_CMP(G))  goto l269;
   yyDo(G, yy_5_Inequality, G->begin, G->end, "yy_5_Inequality");
-  if (!yy_WS(G))  goto l287;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=>") ; } goto l287; }
+  if (!yy_WS(G))  goto l269;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=>") ; } goto l269; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Inequality, G->begin, G->end, "yy_6_Inequality");
-  goto l284;
-  l287:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;  if (!yy_LESSTHAN_EQ(G))  goto l288;
+  goto l266;
+  l269:;	  G->pos= yypos266; G->thunkpos= yythunkpos266;  if (!yy_LESSTHAN_EQ(G))  goto l270;
   yyDo(G, yy_7_Inequality, G->begin, G->end, "yy_7_Inequality");
-  if (!yy_WS(G))  goto l288;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=") ; } goto l288; }
+  if (!yy_WS(G))  goto l270;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<=") ; } goto l270; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Inequality, G->begin, G->end, "yy_8_Inequality");
-  goto l284;
-  l288:;	  G->pos= yypos284; G->thunkpos= yythunkpos284;  if (!yy_MORETHAN_EQ(G))  goto l283;
+  goto l266;
+  l270:;	  G->pos= yypos266; G->thunkpos= yythunkpos266;  if (!yy_MORETHAN_EQ(G))  goto l265;
   yyDo(G, yy_9_Inequality, G->begin, G->end, "yy_9_Inequality");
-  if (!yy_WS(G))  goto l283;
-  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">=") ; } goto l283; }
+  if (!yy_WS(G))  goto l265;
+  if (!yy_Range(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">=") ; } goto l265; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_Inequality, G->begin, G->end, "yy_10_Inequality");
 
   }
-  l284:;	  goto l282;
-  l283:;	  G->pos= yypos283; G->thunkpos= yythunkpos283;
+  l266:;	  goto l264;
+  l265:;	  G->pos= yypos265; G->thunkpos= yythunkpos265;
   }  yyprintf((stderr, "  ok   Inequality"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l281:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Inequality"));
+  l263:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Inequality"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8612,21 +8387,21 @@ YY_RULE(int) yy_Inequality(GREG *G)
 YY_RULE(int) yy_B_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_AND"));
 
-  {  int yypos290= G->pos, yythunkpos290= G->thunkpos;  if (!yy_L_AND(G))  goto l290;
-  goto l289;
-  l290:;	  G->pos= yypos290; G->thunkpos= yythunkpos290;
-  }  if (!yymatchChar(G, '&')) goto l289;
+  {  int yypos272= G->pos, yythunkpos272= G->thunkpos;  if (!yy_L_AND(G))  goto l272;
+  goto l271;
+  l272:;	  G->pos= yypos272; G->thunkpos= yythunkpos272;
+  }  if (!yymatchChar(G, '&')) goto l271;
 
-  {  int yypos291= G->pos, yythunkpos291= G->thunkpos;  if (!yymatchChar(G, '=')) goto l291;
-  goto l289;
-  l291:;	  G->pos= yypos291; G->thunkpos= yythunkpos291;
-  }  if (!yy__(G))  goto l289;
+  {  int yypos273= G->pos, yythunkpos273= G->thunkpos;  if (!yymatchChar(G, '=')) goto l273;
+  goto l271;
+  l273:;	  G->pos= yypos273; G->thunkpos= yythunkpos273;
+  }  if (!yy__(G))  goto l271;
   yyprintf((stderr, "  ok   B_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l289:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_AND"));
+  l271:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8635,34 +8410,34 @@ YY_RULE(int) yy_B_AND(GREG *G)
 YY_RULE(int) yy_Equality(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Equality"));
-  if (!yy_Inequality(G))  goto l292;
+  if (!yy_Inequality(G))  goto l274;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l293:;	
-  {  int yypos294= G->pos, yythunkpos294= G->thunkpos;
-  {  int yypos295= G->pos, yythunkpos295= G->thunkpos;  if (!yy_EQUALS(G))  goto l296;
+  l275:;	
+  {  int yypos276= G->pos, yythunkpos276= G->thunkpos;
+  {  int yypos277= G->pos, yythunkpos277= G->thunkpos;  if (!yy_EQUALS(G))  goto l278;
   yyDo(G, yy_1_Equality, G->begin, G->end, "yy_1_Equality");
-  if (!yy_WS(G))  goto l296;
-  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("==") ; } goto l296; }
+  if (!yy_WS(G))  goto l278;
+  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("==") ; } goto l278; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Equality, G->begin, G->end, "yy_2_Equality");
-  goto l295;
-  l296:;	  G->pos= yypos295; G->thunkpos= yythunkpos295;  if (!yy_NOT_EQUALS(G))  goto l294;
+  goto l277;
+  l278:;	  G->pos= yypos277; G->thunkpos= yythunkpos277;  if (!yy_NOT_EQUALS(G))  goto l276;
   yyDo(G, yy_3_Equality, G->begin, G->end, "yy_3_Equality");
-  if (!yy_WS(G))  goto l294;
-  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("!=") ; } goto l294; }
+  if (!yy_WS(G))  goto l276;
+  if (!yy_Inequality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("!=") ; } goto l276; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Equality, G->begin, G->end, "yy_4_Equality");
 
   }
-  l295:;	  goto l293;
-  l294:;	  G->pos= yypos294; G->thunkpos= yythunkpos294;
+  l277:;	  goto l275;
+  l276:;	  G->pos= yypos276; G->thunkpos= yythunkpos276;
   }  yyprintf((stderr, "  ok   Equality"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l292:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Equality"));
+  l274:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Equality"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8670,18 +8445,18 @@ YY_RULE(int) yy_Equality(GREG *G)
 }
 YY_RULE(int) yy_B_XOR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_XOR"));
-  if (!yymatchChar(G, '^')) goto l297;
+  if (!yymatchChar(G, '^')) goto l279;
 
-  {  int yypos298= G->pos, yythunkpos298= G->thunkpos;  if (!yymatchChar(G, '=')) goto l298;
-  goto l297;
-  l298:;	  G->pos= yypos298; G->thunkpos= yythunkpos298;
-  }  if (!yy__(G))  goto l297;
+  {  int yypos280= G->pos, yythunkpos280= G->thunkpos;  if (!yymatchChar(G, '=')) goto l280;
+  goto l279;
+  l280:;	  G->pos= yypos280; G->thunkpos= yythunkpos280;
+  }  if (!yy__(G))  goto l279;
   yyprintf((stderr, "  ok   B_XOR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l297:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_XOR"));
+  l279:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_XOR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8690,24 +8465,24 @@ YY_RULE(int) yy_B_XOR(GREG *G)
 YY_RULE(int) yy_BinaryAnd(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryAnd"));
-  if (!yy_Equality(G))  goto l299;
+  if (!yy_Equality(G))  goto l281;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l300:;	
-  {  int yypos301= G->pos, yythunkpos301= G->thunkpos;  if (!yy_B_AND(G))  goto l301;
+  l282:;	
+  {  int yypos283= G->pos, yythunkpos283= G->thunkpos;  if (!yy_B_AND(G))  goto l283;
   yyDo(G, yy_1_BinaryAnd, G->begin, G->end, "yy_1_BinaryAnd");
-  if (!yy_WS(G))  goto l301;
-  if (!yy_Equality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&") ; } goto l301; }
+  if (!yy_WS(G))  goto l283;
+  if (!yy_Equality(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&") ; } goto l283; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryAnd, G->begin, G->end, "yy_2_BinaryAnd");
-  goto l300;
-  l301:;	  G->pos= yypos301; G->thunkpos= yythunkpos301;
+  goto l282;
+  l283:;	  G->pos= yypos283; G->thunkpos= yythunkpos283;
   }  yyprintf((stderr, "  ok   BinaryAnd"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l299:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryAnd"));
+  l281:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryAnd"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8716,21 +8491,21 @@ YY_RULE(int) yy_BinaryAnd(GREG *G)
 YY_RULE(int) yy_B_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "B_OR"));
 
-  {  int yypos303= G->pos, yythunkpos303= G->thunkpos;  if (!yy_L_OR(G))  goto l303;
-  goto l302;
-  l303:;	  G->pos= yypos303; G->thunkpos= yythunkpos303;
-  }  if (!yymatchChar(G, '|')) goto l302;
+  {  int yypos285= G->pos, yythunkpos285= G->thunkpos;  if (!yy_L_OR(G))  goto l285;
+  goto l284;
+  l285:;	  G->pos= yypos285; G->thunkpos= yythunkpos285;
+  }  if (!yymatchChar(G, '|')) goto l284;
 
-  {  int yypos304= G->pos, yythunkpos304= G->thunkpos;  if (!yymatchChar(G, '=')) goto l304;
-  goto l302;
-  l304:;	  G->pos= yypos304; G->thunkpos= yythunkpos304;
-  }  if (!yy__(G))  goto l302;
+  {  int yypos286= G->pos, yythunkpos286= G->thunkpos;  if (!yymatchChar(G, '=')) goto l286;
+  goto l284;
+  l286:;	  G->pos= yypos286; G->thunkpos= yythunkpos286;
+  }  if (!yy__(G))  goto l284;
   yyprintf((stderr, "  ok   B_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l302:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_OR"));
+  l284:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "B_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8739,24 +8514,24 @@ YY_RULE(int) yy_B_OR(GREG *G)
 YY_RULE(int) yy_BinaryXor(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryXor"));
-  if (!yy_BinaryAnd(G))  goto l305;
+  if (!yy_BinaryAnd(G))  goto l287;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l306:;	
-  {  int yypos307= G->pos, yythunkpos307= G->thunkpos;  if (!yy_B_XOR(G))  goto l307;
+  l288:;	
+  {  int yypos289= G->pos, yythunkpos289= G->thunkpos;  if (!yy_B_XOR(G))  goto l289;
   yyDo(G, yy_1_BinaryXor, G->begin, G->end, "yy_1_BinaryXor");
-  if (!yy_WS(G))  goto l307;
-  if (!yy_BinaryAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^") ; } goto l307; }
+  if (!yy_WS(G))  goto l289;
+  if (!yy_BinaryAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^") ; } goto l289; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryXor, G->begin, G->end, "yy_2_BinaryXor");
-  goto l306;
-  l307:;	  G->pos= yypos307; G->thunkpos= yythunkpos307;
+  goto l288;
+  l289:;	  G->pos= yypos289; G->thunkpos= yythunkpos289;
   }  yyprintf((stderr, "  ok   BinaryXor"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l305:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryXor"));
+  l287:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryXor"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8764,14 +8539,14 @@ YY_RULE(int) yy_BinaryXor(GREG *G)
 }
 YY_RULE(int) yy_L_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_AND"));
-  if (!yymatchString(G, "&&")) goto l308;
-  if (!yy__(G))  goto l308;
+  if (!yymatchString(G, "&&")) goto l290;
+  if (!yy__(G))  goto l290;
   yyprintf((stderr, "  ok   L_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l308:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_AND"));
+  l290:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8780,24 +8555,24 @@ YY_RULE(int) yy_L_AND(GREG *G)
 YY_RULE(int) yy_BinaryOr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "BinaryOr"));
-  if (!yy_BinaryXor(G))  goto l309;
+  if (!yy_BinaryXor(G))  goto l291;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l310:;	
-  {  int yypos311= G->pos, yythunkpos311= G->thunkpos;  if (!yy_B_OR(G))  goto l311;
+  l292:;	
+  {  int yypos293= G->pos, yythunkpos293= G->thunkpos;  if (!yy_B_OR(G))  goto l293;
   yyDo(G, yy_1_BinaryOr, G->begin, G->end, "yy_1_BinaryOr");
-  if (!yy_WS(G))  goto l311;
-  if (!yy_BinaryXor(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|") ; } goto l311; }
+  if (!yy_WS(G))  goto l293;
+  if (!yy_BinaryXor(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|") ; } goto l293; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_BinaryOr, G->begin, G->end, "yy_2_BinaryOr");
-  goto l310;
-  l311:;	  G->pos= yypos311; G->thunkpos= yythunkpos311;
+  goto l292;
+  l293:;	  G->pos= yypos293; G->thunkpos= yythunkpos293;
   }  yyprintf((stderr, "  ok   BinaryOr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l309:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOr"));
+  l291:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8805,14 +8580,14 @@ YY_RULE(int) yy_BinaryOr(GREG *G)
 }
 YY_RULE(int) yy_L_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "L_OR"));
-  if (!yymatchString(G, "||")) goto l312;
-  if (!yy__(G))  goto l312;
+  if (!yymatchString(G, "||")) goto l294;
+  if (!yy__(G))  goto l294;
   yyprintf((stderr, "  ok   L_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l312:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_OR"));
+  l294:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "L_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8821,24 +8596,24 @@ YY_RULE(int) yy_L_OR(GREG *G)
 YY_RULE(int) yy_LogicalAnd(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "LogicalAnd"));
-  if (!yy_BinaryOr(G))  goto l313;
+  if (!yy_BinaryOr(G))  goto l295;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l314:;	
-  {  int yypos315= G->pos, yythunkpos315= G->thunkpos;  if (!yy_L_AND(G))  goto l315;
+  l296:;	
+  {  int yypos297= G->pos, yythunkpos297= G->thunkpos;  if (!yy_L_AND(G))  goto l297;
   yyDo(G, yy_1_LogicalAnd, G->begin, G->end, "yy_1_LogicalAnd");
-  if (!yy_WS(G))  goto l315;
-  if (!yy_BinaryOr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&&") ; } goto l315; }
+  if (!yy_WS(G))  goto l297;
+  if (!yy_BinaryOr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&&") ; } goto l297; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_LogicalAnd, G->begin, G->end, "yy_2_LogicalAnd");
-  goto l314;
-  l315:;	  G->pos= yypos315; G->thunkpos= yythunkpos315;
+  goto l296;
+  l297:;	  G->pos= yypos297; G->thunkpos= yythunkpos297;
   }  yyprintf((stderr, "  ok   LogicalAnd"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l313:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalAnd"));
+  l295:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalAnd"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8846,14 +8621,14 @@ YY_RULE(int) yy_LogicalAnd(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_QUEST(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_QUEST"));
-  if (!yymatchString(G, "??")) goto l316;
-  if (!yy__(G))  goto l316;
+  if (!yymatchString(G, "??")) goto l298;
+  if (!yy__(G))  goto l298;
   yyprintf((stderr, "  ok   DOUBLE_QUEST"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l316:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_QUEST"));
+  l298:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_QUEST"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8862,24 +8637,24 @@ YY_RULE(int) yy_DOUBLE_QUEST(GREG *G)
 YY_RULE(int) yy_LogicalOr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "LogicalOr"));
-  if (!yy_LogicalAnd(G))  goto l317;
+  if (!yy_LogicalAnd(G))  goto l299;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l318:;	
-  {  int yypos319= G->pos, yythunkpos319= G->thunkpos;  if (!yy_L_OR(G))  goto l319;
+  l300:;	
+  {  int yypos301= G->pos, yythunkpos301= G->thunkpos;  if (!yy_L_OR(G))  goto l301;
   yyDo(G, yy_1_LogicalOr, G->begin, G->end, "yy_1_LogicalOr");
-  if (!yy_WS(G))  goto l319;
-  if (!yy_LogicalAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("||") ; } goto l319; }
+  if (!yy_WS(G))  goto l301;
+  if (!yy_LogicalAnd(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("||") ; } goto l301; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_LogicalOr, G->begin, G->end, "yy_2_LogicalOr");
-  goto l318;
-  l319:;	  G->pos= yypos319; G->thunkpos= yythunkpos319;
+  goto l300;
+  l301:;	  G->pos= yypos301; G->thunkpos= yythunkpos301;
   }  yyprintf((stderr, "  ok   LogicalOr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l317:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalOr"));
+  l299:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LogicalOr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8887,14 +8662,14 @@ YY_RULE(int) yy_LogicalOr(GREG *G)
 }
 YY_RULE(int) yy_QUEST(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "QUEST"));
-  if (!yymatchChar(G, '?')) goto l320;
-  if (!yy__(G))  goto l320;
+  if (!yymatchChar(G, '?')) goto l302;
+  if (!yy__(G))  goto l302;
   yyprintf((stderr, "  ok   QUEST"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l320:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "QUEST"));
+  l302:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "QUEST"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8903,24 +8678,24 @@ YY_RULE(int) yy_QUEST(GREG *G)
 YY_RULE(int) yy_NullCoalescing(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "NullCoalescing"));
-  if (!yy_LogicalOr(G))  goto l321;
+  if (!yy_LogicalOr(G))  goto l303;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  {  int yypos322= G->pos, yythunkpos322= G->thunkpos;  if (!yy_DOUBLE_QUEST(G))  goto l322;
+  {  int yypos304= G->pos, yythunkpos304= G->thunkpos;  if (!yy_DOUBLE_QUEST(G))  goto l304;
   yyDo(G, yy_1_NullCoalescing, G->begin, G->end, "yy_1_NullCoalescing");
-  if (!yy_WS(G))  goto l322;
-  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("??") ; } goto l322; }
+  if (!yy_WS(G))  goto l304;
+  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("??") ; } goto l304; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_NullCoalescing, G->begin, G->end, "yy_2_NullCoalescing");
-  goto l323;
-  l322:;	  G->pos= yypos322; G->thunkpos= yythunkpos322;
+  goto l305;
+  l304:;	  G->pos= yypos304; G->thunkpos= yythunkpos304;
   }
-  l323:;	  yyprintf((stderr, "  ok   NullCoalescing"));
+  l305:;	  yyprintf((stderr, "  ok   NullCoalescing"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l321:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NullCoalescing"));
+  l303:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "NullCoalescing"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8928,14 +8703,14 @@ YY_RULE(int) yy_NullCoalescing(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_AND(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_AND"));
-  if (!yymatchString(G, "&=")) goto l324;
-  if (!yy__(G))  goto l324;
+  if (!yymatchString(G, "&=")) goto l306;
+  if (!yy__(G))  goto l306;
   yyprintf((stderr, "  ok   ASS_B_AND"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l324:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_AND"));
+  l306:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_AND"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8943,14 +8718,14 @@ YY_RULE(int) yy_ASS_B_AND(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_OR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_OR"));
-  if (!yymatchString(G, "|=")) goto l325;
-  if (!yy__(G))  goto l325;
+  if (!yymatchString(G, "|=")) goto l307;
+  if (!yy__(G))  goto l307;
   yyprintf((stderr, "  ok   ASS_B_OR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l325:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_OR"));
+  l307:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_OR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8958,14 +8733,14 @@ YY_RULE(int) yy_ASS_B_OR(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_XOR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_XOR"));
-  if (!yymatchString(G, "^=")) goto l326;
-  if (!yy__(G))  goto l326;
+  if (!yymatchString(G, "^=")) goto l308;
+  if (!yy__(G))  goto l308;
   yyprintf((stderr, "  ok   ASS_B_XOR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l326:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_XOR"));
+  l308:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_XOR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8973,14 +8748,14 @@ YY_RULE(int) yy_ASS_B_XOR(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_RSHIFT"));
-  if (!yymatchString(G, ">>=")) goto l327;
-  if (!yy__(G))  goto l327;
+  if (!yymatchString(G, ">>=")) goto l309;
+  if (!yy__(G))  goto l309;
   yyprintf((stderr, "  ok   ASS_B_RSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l327:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_RSHIFT"));
+  l309:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_RSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -8988,14 +8763,14 @@ YY_RULE(int) yy_ASS_B_RSHIFT(GREG *G)
 }
 YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_B_LSHIFT"));
-  if (!yymatchString(G, "<<=")) goto l328;
-  if (!yy__(G))  goto l328;
+  if (!yymatchString(G, "<<=")) goto l310;
+  if (!yy__(G))  goto l310;
   yyprintf((stderr, "  ok   ASS_B_LSHIFT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l328:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_LSHIFT"));
+  l310:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_B_LSHIFT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9003,14 +8778,14 @@ YY_RULE(int) yy_ASS_B_LSHIFT(GREG *G)
 }
 YY_RULE(int) yy_ASS_DIV(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_DIV"));
-  if (!yymatchString(G, "/=")) goto l329;
-  if (!yy__(G))  goto l329;
+  if (!yymatchString(G, "/=")) goto l311;
+  if (!yy__(G))  goto l311;
   yyprintf((stderr, "  ok   ASS_DIV"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l329:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DIV"));
+  l311:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DIV"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9018,14 +8793,14 @@ YY_RULE(int) yy_ASS_DIV(GREG *G)
 }
 YY_RULE(int) yy_ASS_EXP(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_EXP"));
-  if (!yymatchString(G, "**=")) goto l330;
-  if (!yy__(G))  goto l330;
+  if (!yymatchString(G, "**=")) goto l312;
+  if (!yy__(G))  goto l312;
   yyprintf((stderr, "  ok   ASS_EXP"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l330:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_EXP"));
+  l312:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_EXP"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9033,14 +8808,14 @@ YY_RULE(int) yy_ASS_EXP(GREG *G)
 }
 YY_RULE(int) yy_ASS_MUL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_MUL"));
-  if (!yymatchString(G, "*=")) goto l331;
-  if (!yy__(G))  goto l331;
+  if (!yymatchString(G, "*=")) goto l313;
+  if (!yy__(G))  goto l313;
   yyprintf((stderr, "  ok   ASS_MUL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l331:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MUL"));
+  l313:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MUL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9048,14 +8823,14 @@ YY_RULE(int) yy_ASS_MUL(GREG *G)
 }
 YY_RULE(int) yy_ASS_SUB(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_SUB"));
-  if (!yymatchString(G, "-=")) goto l332;
-  if (!yy__(G))  goto l332;
+  if (!yymatchString(G, "-=")) goto l314;
+  if (!yy__(G))  goto l314;
   yyprintf((stderr, "  ok   ASS_SUB"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l332:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_SUB"));
+  l314:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_SUB"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9063,14 +8838,14 @@ YY_RULE(int) yy_ASS_SUB(GREG *G)
 }
 YY_RULE(int) yy_ASS_MOD(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_MOD"));
-  if (!yymatchString(G, "%=")) goto l333;
-  if (!yy__(G))  goto l333;
+  if (!yymatchString(G, "%=")) goto l315;
+  if (!yy__(G))  goto l315;
   yyprintf((stderr, "  ok   ASS_MOD"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l333:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MOD"));
+  l315:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_MOD"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9078,14 +8853,14 @@ YY_RULE(int) yy_ASS_MOD(GREG *G)
 }
 YY_RULE(int) yy_ASS_ADD(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_ADD"));
-  if (!yymatchString(G, "+=")) goto l334;
-  if (!yy__(G))  goto l334;
+  if (!yymatchString(G, "+=")) goto l316;
+  if (!yy__(G))  goto l316;
   yyprintf((stderr, "  ok   ASS_ADD"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l334:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_ADD"));
+  l316:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_ADD"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9094,30 +8869,30 @@ YY_RULE(int) yy_ASS_ADD(GREG *G)
 YY_RULE(int) yy_Ternary(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Ternary"));
-  if (!yy_NullCoalescing(G))  goto l335;
+  if (!yy_NullCoalescing(G))  goto l317;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos336= G->pos, yythunkpos336= G->thunkpos;  if (!yy__(G))  goto l336;
-  if (!yy_QUEST(G))  goto l336;
+  {  int yypos318= G->pos, yythunkpos318= G->thunkpos;  if (!yy__(G))  goto l318;
+  if (!yy_QUEST(G))  goto l318;
   yyDo(G, yy_1_Ternary, G->begin, G->end, "yy_1_Ternary");
-  if (!yy_WS(G))  goto l336;
-  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_MALFORMED_TERNARY, "Expected expression between ? and : in ternary expression!\n") ; } goto l336; }
+  if (!yy_WS(G))  goto l318;
+  if (!yy_NullCoalescing(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_MALFORMED_TERNARY, "Expected expression between ? and : in ternary expression!\n") ; } goto l318; }
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l336;
-  if (!yy_COLON(G))  goto l336;
-  if (!yy_WS(G))  goto l336;
-  if (!yy_NullCoalescing(G))  goto l336;
+  if (!yy__(G))  goto l318;
+  if (!yy_COLON(G))  goto l318;
+  if (!yy_WS(G))  goto l318;
+  if (!yy_NullCoalescing(G))  goto l318;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Ternary, G->begin, G->end, "yy_2_Ternary");
-  goto l337;
-  l336:;	  G->pos= yypos336; G->thunkpos= yythunkpos336;
+  goto l319;
+  l318:;	  G->pos= yypos318; G->thunkpos= yythunkpos318;
   }
-  l337:;	  yyprintf((stderr, "  ok   Ternary"));
+  l319:;	  yyprintf((stderr, "  ok   Ternary"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l335:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Ternary"));
+  l317:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Ternary"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9126,111 +8901,111 @@ YY_RULE(int) yy_Ternary(GREG *G)
 YY_RULE(int) yy_Assignment(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Assignment"));
-  if (!yy_Ternary(G))  goto l338;
+  if (!yy_Ternary(G))  goto l320;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  l339:;	
-  {  int yypos340= G->pos, yythunkpos340= G->thunkpos;
-  {  int yypos341= G->pos, yythunkpos341= G->thunkpos;  if (!yy_ASS(G))  goto l342;
+  l321:;	
+  {  int yypos322= G->pos, yythunkpos322= G->thunkpos;
+  {  int yypos323= G->pos, yythunkpos323= G->thunkpos;  if (!yy_ASS(G))  goto l324;
   yyDo(G, yy_1_Assignment, G->begin, G->end, "yy_1_Assignment");
-  if (!yy_WS(G))  goto l342;
-  if (!yy_Ternary(G))  goto l342;
+  if (!yy_WS(G))  goto l324;
+  if (!yy_Ternary(G))  goto l324;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Assignment, G->begin, G->end, "yy_2_Assignment");
-  goto l341;
-  l342:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS(G))  goto l343;
+  goto l323;
+  l324:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS(G))  goto l325;
   yyDo(G, yy_3_Assignment, G->begin, G->end, "yy_3_Assignment");
-  if (!yy_WS(G))  goto l343;
-  if (!yy_AnonymousFunctionDecl(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=") ; } goto l343; }
+  if (!yy_WS(G))  goto l325;
+  if (!yy_AnonymousFunctionDecl(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=") ; } goto l325; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Assignment, G->begin, G->end, "yy_4_Assignment");
-  goto l341;
-  l343:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_ADD(G))  goto l344;
+  goto l323;
+  l325:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_ADD(G))  goto l326;
   yyDo(G, yy_5_Assignment, G->begin, G->end, "yy_5_Assignment");
-  if (!yy_WS(G))  goto l344;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+=") ; } goto l344; }
+  if (!yy_WS(G))  goto l326;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("+=") ; } goto l326; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Assignment, G->begin, G->end, "yy_6_Assignment");
-  goto l341;
-  l344:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_MOD(G))  goto l345;
+  goto l323;
+  l326:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_MOD(G))  goto l327;
   yyDo(G, yy_7_Assignment, G->begin, G->end, "yy_7_Assignment");
-  if (!yy_WS(G))  goto l345;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%=") ; } goto l345; }
+  if (!yy_WS(G))  goto l327;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("%=") ; } goto l327; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Assignment, G->begin, G->end, "yy_8_Assignment");
-  goto l341;
-  l345:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_SUB(G))  goto l346;
+  goto l323;
+  l327:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_SUB(G))  goto l328;
   yyDo(G, yy_9_Assignment, G->begin, G->end, "yy_9_Assignment");
-  if (!yy_WS(G))  goto l346;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-=") ; } goto l346; }
+  if (!yy_WS(G))  goto l328;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("-=") ; } goto l328; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_Assignment, G->begin, G->end, "yy_10_Assignment");
-  goto l341;
-  l346:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_MUL(G))  goto l347;
+  goto l323;
+  l328:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_MUL(G))  goto l329;
   yyDo(G, yy_11_Assignment, G->begin, G->end, "yy_11_Assignment");
-  if (!yy_WS(G))  goto l347;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("*=") ; } goto l347; }
+  if (!yy_WS(G))  goto l329;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("*=") ; } goto l329; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_12_Assignment, G->begin, G->end, "yy_12_Assignment");
-  goto l341;
-  l347:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_EXP(G))  goto l348;
+  goto l323;
+  l329:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_EXP(G))  goto l330;
   yyDo(G, yy_13_Assignment, G->begin, G->end, "yy_13_Assignment");
-  if (!yy_WS(G))  goto l348;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("**=") ; } goto l348; }
+  if (!yy_WS(G))  goto l330;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("**=") ; } goto l330; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_14_Assignment, G->begin, G->end, "yy_14_Assignment");
-  goto l341;
-  l348:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_DIV(G))  goto l349;
+  goto l323;
+  l330:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_DIV(G))  goto l331;
   yyDo(G, yy_15_Assignment, G->begin, G->end, "yy_15_Assignment");
-  if (!yy_WS(G))  goto l349;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("/=") ; } goto l349; }
+  if (!yy_WS(G))  goto l331;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("/=") ; } goto l331; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_16_Assignment, G->begin, G->end, "yy_16_Assignment");
-  goto l341;
-  l349:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_B_LSHIFT(G))  goto l350;
+  goto l323;
+  l331:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_B_LSHIFT(G))  goto l332;
   yyDo(G, yy_17_Assignment, G->begin, G->end, "yy_17_Assignment");
-  if (!yy_WS(G))  goto l350;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<=") ; } goto l350; }
+  if (!yy_WS(G))  goto l332;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("<<=") ; } goto l332; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_18_Assignment, G->begin, G->end, "yy_18_Assignment");
-  goto l341;
-  l350:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_B_RSHIFT(G))  goto l351;
+  goto l323;
+  l332:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_B_RSHIFT(G))  goto l333;
   yyDo(G, yy_19_Assignment, G->begin, G->end, "yy_19_Assignment");
-  if (!yy_WS(G))  goto l351;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>=") ; } goto l351; }
+  if (!yy_WS(G))  goto l333;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp(">>=") ; } goto l333; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_20_Assignment, G->begin, G->end, "yy_20_Assignment");
-  goto l341;
-  l351:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_B_XOR(G))  goto l352;
+  goto l323;
+  l333:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_B_XOR(G))  goto l334;
   yyDo(G, yy_21_Assignment, G->begin, G->end, "yy_21_Assignment");
-  if (!yy_WS(G))  goto l352;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^=") ; } goto l352; }
+  if (!yy_WS(G))  goto l334;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("^=") ; } goto l334; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_22_Assignment, G->begin, G->end, "yy_22_Assignment");
-  goto l341;
-  l352:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_B_OR(G))  goto l353;
+  goto l323;
+  l334:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_B_OR(G))  goto l335;
   yyDo(G, yy_23_Assignment, G->begin, G->end, "yy_23_Assignment");
-  if (!yy_WS(G))  goto l353;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|=") ; } goto l353; }
+  if (!yy_WS(G))  goto l335;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("|=") ; } goto l335; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_24_Assignment, G->begin, G->end, "yy_24_Assignment");
-  goto l341;
-  l353:;	  G->pos= yypos341; G->thunkpos= yythunkpos341;  if (!yy_ASS_B_AND(G))  goto l340;
+  goto l323;
+  l335:;	  G->pos= yypos323; G->thunkpos= yythunkpos323;  if (!yy_ASS_B_AND(G))  goto l322;
   yyDo(G, yy_25_Assignment, G->begin, G->end, "yy_25_Assignment");
-  if (!yy_WS(G))  goto l340;
-  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&=") ; } goto l340; }
+  if (!yy_WS(G))  goto l322;
+  if (!yy_Ternary(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("&=") ; } goto l322; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_26_Assignment, G->begin, G->end, "yy_26_Assignment");
 
   }
-  l341:;	  goto l339;
-  l340:;	  G->pos= yypos340; G->thunkpos= yythunkpos340;
+  l323:;	  goto l321;
+  l322:;	  G->pos= yypos322; G->thunkpos= yythunkpos322;
   }  yyprintf((stderr, "  ok   Assignment"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l338:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Assignment"));
+  l320:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Assignment"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9239,17 +9014,17 @@ YY_RULE(int) yy_Assignment(GREG *G)
 YY_RULE(int) yy_FunctionCall(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionCall"));
-  if (!yy_IDENT(G))  goto l354;
+  if (!yy_IDENT(G))  goto l336;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_FunctionCall, G->begin, G->end, "yy_1_FunctionCall");
-  if (!yy_FunctionCallCore(G))  goto l354;
+  if (!yy_FunctionCallCore(G))  goto l336;
   yyDo(G, yy_2_FunctionCall, G->begin, G->end, "yy_2_FunctionCall");
   yyprintf((stderr, "  ok   FunctionCall"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l354:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionCall"));
+  l336:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionCall"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9257,13 +9032,13 @@ YY_RULE(int) yy_FunctionCall(GREG *G)
 }
 YY_RULE(int) yy_BinaryOperation(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "BinaryOperation"));
-  if (!yy_Assignment(G))  goto l355;
+  if (!yy_Assignment(G))  goto l337;
   yyprintf((stderr, "  ok   BinaryOperation"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l355:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOperation"));
+  l337:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BinaryOperation"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9272,12 +9047,12 @@ YY_RULE(int) yy_BinaryOperation(GREG *G)
 YY_RULE(int) yy_DoubleArrow(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "DoubleArrow"));
-  if (!yy_Assignment(G))  goto l356;
+  if (!yy_Assignment(G))  goto l338;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DOUBLE_ARROW(G))  goto l356;
+  if (!yy_DOUBLE_ARROW(G))  goto l338;
   yyDo(G, yy_1_DoubleArrow, G->begin, G->end, "yy_1_DoubleArrow");
-  if (!yy_WS(G))  goto l356;
-  if (!yy_Expr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=>") ; } goto l356; }
+  if (!yy_WS(G))  goto l338;
+  if (!yy_Expr(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;   missingOp("=>") ; } goto l338; }
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_DoubleArrow, G->begin, G->end, "yy_2_DoubleArrow");
   yyprintf((stderr, "  ok   DoubleArrow"));
@@ -9285,7 +9060,7 @@ YY_RULE(int) yy_DoubleArrow(GREG *G)
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l356:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DoubleArrow"));
+  l338:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DoubleArrow"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9293,13 +9068,13 @@ YY_RULE(int) yy_DoubleArrow(GREG *G)
 }
 YY_RULE(int) yy_RETURN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "RETURN_KW"));
-  if (!yymatchString(G, "return")) goto l357;
+  if (!yymatchString(G, "return")) goto l339;
   yyprintf((stderr, "  ok   RETURN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l357:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RETURN_KW"));
+  l339:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RETURN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9307,13 +9082,13 @@ YY_RULE(int) yy_RETURN_KW(GREG *G)
 }
 YY_RULE(int) yy_WHILE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "WHILE_KW"));
-  if (!yymatchString(G, "while")) goto l358;
+  if (!yymatchString(G, "while")) goto l340;
   yyprintf((stderr, "  ok   WHILE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l358:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "WHILE_KW"));
+  l340:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "WHILE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9321,13 +9096,13 @@ YY_RULE(int) yy_WHILE_KW(GREG *G)
 }
 YY_RULE(int) yy_IN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IN_KW"));
-  if (!yymatchString(G, "in")) goto l359;
+  if (!yymatchString(G, "in")) goto l341;
   yyprintf((stderr, "  ok   IN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l359:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IN_KW"));
+  l341:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9335,13 +9110,13 @@ YY_RULE(int) yy_IN_KW(GREG *G)
 }
 YY_RULE(int) yy_FOR_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FOR_KW"));
-  if (!yymatchString(G, "for")) goto l360;
+  if (!yymatchString(G, "for")) goto l342;
   yyprintf((stderr, "  ok   FOR_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l360:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FOR_KW"));
+  l342:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FOR_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9351,25 +9126,25 @@ YY_RULE(int) yy_ImplicitDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ImplicitDecl"));
 
-  {  int yypos362= G->pos, yythunkpos362= G->thunkpos;  if (!yy_VariableDecl(G))  goto l363;
+  {  int yypos344= G->pos, yythunkpos344= G->thunkpos;  if (!yy_VariableDecl(G))  goto l345;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_ImplicitDecl, G->begin, G->end, "yy_1_ImplicitDecl");
-  goto l362;
-  l363:;	  G->pos= yypos362; G->thunkpos= yythunkpos362;  if (!yy_Tuple(G))  goto l364;
+  goto l344;
+  l345:;	  G->pos= yypos344; G->thunkpos= yythunkpos344;  if (!yy_Tuple(G))  goto l346;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_ImplicitDecl, G->begin, G->end, "yy_2_ImplicitDecl");
-  goto l362;
-  l364:;	  G->pos= yypos362; G->thunkpos= yythunkpos362;  if (!yy_IDENT(G))  goto l361;
+  goto l344;
+  l346:;	  G->pos= yypos344; G->thunkpos= yythunkpos344;  if (!yy_IDENT(G))  goto l343;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_ImplicitDecl, G->begin, G->end, "yy_3_ImplicitDecl");
 
   }
-  l362:;	  yyprintf((stderr, "  ok   ImplicitDecl"));
+  l344:;	  yyprintf((stderr, "  ok   ImplicitDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l361:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImplicitDecl"));
+  l343:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImplicitDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9377,13 +9152,13 @@ YY_RULE(int) yy_ImplicitDecl(GREG *G)
 }
 YY_RULE(int) yy_CONTINUE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CONTINUE_KW"));
-  if (!yymatchString(G, "continue")) goto l365;
+  if (!yymatchString(G, "continue")) goto l347;
   yyprintf((stderr, "  ok   CONTINUE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l365:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONTINUE_KW"));
+  l347:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONTINUE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9391,13 +9166,13 @@ YY_RULE(int) yy_CONTINUE_KW(GREG *G)
 }
 YY_RULE(int) yy_BREAK_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "BREAK_KW"));
-  if (!yymatchString(G, "break")) goto l366;
+  if (!yymatchString(G, "break")) goto l348;
   yyprintf((stderr, "  ok   BREAK_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l366:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BREAK_KW"));
+  l348:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "BREAK_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9405,14 +9180,14 @@ YY_RULE(int) yy_BREAK_KW(GREG *G)
 }
 YY_RULE(int) yy_Continue(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Continue"));
-  if (!yy_CONTINUE_KW(G))  goto l367;
+  if (!yy_CONTINUE_KW(G))  goto l349;
   yyDo(G, yy_1_Continue, G->begin, G->end, "yy_1_Continue");
   yyprintf((stderr, "  ok   Continue"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l367:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Continue"));
+  l349:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Continue"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9420,14 +9195,14 @@ YY_RULE(int) yy_Continue(GREG *G)
 }
 YY_RULE(int) yy_Break(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Break"));
-  if (!yy_BREAK_KW(G))  goto l368;
+  if (!yy_BREAK_KW(G))  goto l350;
   yyDo(G, yy_1_Break, G->begin, G->end, "yy_1_Break");
   yyprintf((stderr, "  ok   Break"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l368:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Break"));
+  l350:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Break"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9436,27 +9211,27 @@ YY_RULE(int) yy_Break(GREG *G)
 YY_RULE(int) yy_While(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "While"));
-  if (!yy_WHILE_KW(G))  goto l369;
+  if (!yy_WHILE_KW(G))  goto l351;
   yyDo(G, yy_1_While, G->begin, G->end, "yy_1_While");
-  if (!yy_WS(G))  goto l369;
-  if (!yymatchChar(G, '(')) goto l369;
-  if (!yy_WS(G))  goto l369;
-  if (!yy__(G))  goto l369;
-  if (!yy_Expr(G))  goto l369;
+  if (!yy_WS(G))  goto l351;
+  if (!yymatchChar(G, '(')) goto l351;
+  if (!yy_WS(G))  goto l351;
+  if (!yy__(G))  goto l351;
+  if (!yy_Expr(G))  goto l351;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l369;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed while! Expected ')' to close condition.\n"); ; } goto l369; }
+  if (!yy_WS(G))  goto l351;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed while! Expected ')' to close condition.\n"); ; } goto l351; }
   yyDo(G, yy_2_While, G->begin, G->end, "yy_2_While");
-  if (!yy__(G))  goto l369;
-  if (!yy_Body(G))  goto l369;
-  if (!yy__(G))  goto l369;
+  if (!yy__(G))  goto l351;
+  if (!yy_Body(G))  goto l351;
+  if (!yy__(G))  goto l351;
   yyDo(G, yy_3_While, G->begin, G->end, "yy_3_While");
   yyprintf((stderr, "  ok   While"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l369:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "While"));
+  l351:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "While"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9465,32 +9240,32 @@ YY_RULE(int) yy_While(GREG *G)
 YY_RULE(int) yy_Foreach(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Foreach"));
-  if (!yy_FOR_KW(G))  goto l370;
+  if (!yy_FOR_KW(G))  goto l352;
   yyDo(G, yy_1_Foreach, G->begin, G->end, "yy_1_Foreach");
-  if (!yy_WS(G))  goto l370;
-  if (!yymatchChar(G, '(')) goto l370;
-  if (!yy_WS(G))  goto l370;
-  if (!yy__(G))  goto l370;
-  if (!yy_ImplicitDecl(G))  goto l370;
+  if (!yy_WS(G))  goto l352;
+  if (!yymatchChar(G, '(')) goto l352;
+  if (!yy_WS(G))  goto l352;
+  if (!yy__(G))  goto l352;
+  if (!yy_ImplicitDecl(G))  goto l352;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l370;
-  if (!yy_IN_KW(G))  goto l370;
-  if (!yy__(G))  goto l370;
-  if (!yy_Expr(G))  goto l370;
+  if (!yy__(G))  goto l352;
+  if (!yy_IN_KW(G))  goto l352;
+  if (!yy__(G))  goto l352;
+  if (!yy_Expr(G))  goto l352;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l370;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed foreach, expected ')' to close condition!\n") ; } goto l370; }
+  if (!yy_WS(G))  goto l352;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed foreach, expected ')' to close condition!\n") ; } goto l352; }
   yyDo(G, yy_2_Foreach, G->begin, G->end, "yy_2_Foreach");
-  if (!yy__(G))  goto l370;
-  if (!yy_Body(G))  goto l370;
-  if (!yy__(G))  goto l370;
+  if (!yy__(G))  goto l352;
+  if (!yy_Body(G))  goto l352;
+  if (!yy__(G))  goto l352;
   yyDo(G, yy_3_Foreach, G->begin, G->end, "yy_3_Foreach");
   yyprintf((stderr, "  ok   Foreach"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l370:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Foreach"));
+  l352:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Foreach"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9498,13 +9273,13 @@ YY_RULE(int) yy_Foreach(GREG *G)
 }
 YY_RULE(int) yy_CATCH_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CATCH_KW"));
-  if (!yymatchString(G, "catch")) goto l371;
+  if (!yymatchString(G, "catch")) goto l353;
   yyprintf((stderr, "  ok   CATCH_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l371:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CATCH_KW"));
+  l353:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CATCH_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9513,36 +9288,36 @@ YY_RULE(int) yy_CATCH_KW(GREG *G)
 YY_RULE(int) yy_Catch(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Catch"));
-  if (!yy_CATCH_KW(G))  goto l372;
+  if (!yy_CATCH_KW(G))  goto l354;
   yyDo(G, yy_1_Catch, G->begin, G->end, "yy_1_Catch");
 
-  {  int yypos373= G->pos, yythunkpos373= G->thunkpos;  if (!yy__(G))  goto l373;
-  if (!yy_Expr(G))  goto l373;
+  {  int yypos355= G->pos, yythunkpos355= G->thunkpos;  if (!yy__(G))  goto l355;
+  if (!yy_Expr(G))  goto l355;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_Catch, G->begin, G->end, "yy_2_Catch");
-  goto l374;
-  l373:;	  G->pos= yypos373; G->thunkpos= yythunkpos373;
+  goto l356;
+  l355:;	  G->pos= yypos355; G->thunkpos= yythunkpos355;
   }
-  l374:;	  if (!yy_WS(G))  goto l372;
-  if (!yymatchChar(G, '{')) goto l372;
+  l356:;	  if (!yy_WS(G))  goto l354;
+  if (!yymatchChar(G, '{')) goto l354;
 
-  l375:;	
-  {  int yypos376= G->pos, yythunkpos376= G->thunkpos;  if (!yy_WS(G))  goto l376;
-  if (!yy_Stmt(G))  goto l376;
+  l357:;	
+  {  int yypos358= G->pos, yythunkpos358= G->thunkpos;  if (!yy_WS(G))  goto l358;
+  if (!yy_Stmt(G))  goto l358;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l376;
+  if (!yy_WS(G))  goto l358;
   yyDo(G, yy_3_Catch, G->begin, G->end, "yy_3_Catch");
-  goto l375;
-  l376:;	  G->pos= yypos376; G->thunkpos= yythunkpos376;
-  }  if (!yy_WS(G))  goto l372;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close catch block."); ; } goto l372; }
+  goto l357;
+  l358:;	  G->pos= yypos358; G->thunkpos= yythunkpos358;
+  }  if (!yy_WS(G))  goto l354;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close catch block."); ; } goto l354; }
   yyDo(G, yy_4_Catch, G->begin, G->end, "yy_4_Catch");
   yyprintf((stderr, "  ok   Catch"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l372:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Catch"));
+  l354:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Catch"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9550,13 +9325,13 @@ YY_RULE(int) yy_Catch(GREG *G)
 }
 YY_RULE(int) yy_TRY_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "TRY_KW"));
-  if (!yymatchString(G, "try")) goto l377;
+  if (!yymatchString(G, "try")) goto l359;
   yyprintf((stderr, "  ok   TRY_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l377:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TRY_KW"));
+  l359:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TRY_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9566,73 +9341,73 @@ YY_RULE(int) yy_Value(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Value"));
 
-  {  int yypos379= G->pos, yythunkpos379= G->thunkpos;  if (!yymatchChar(G, '-')) goto l380;
-  if (!yy__(G))  goto l380;
-  if (!yymatchChar(G, '(')) goto l380;
+  {  int yypos361= G->pos, yythunkpos361= G->thunkpos;  if (!yymatchChar(G, '-')) goto l362;
+  if (!yy__(G))  goto l362;
+  if (!yymatchChar(G, '(')) goto l362;
   yyDo(G, yy_1_Value, G->begin, G->end, "yy_1_Value");
-  if (!yy_WS(G))  goto l380;
-  if (!yy_Expr(G))  goto l380;
+  if (!yy_WS(G))  goto l362;
+  if (!yy_Expr(G))  goto l362;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l380;
-  if (!yymatchChar(G, ')')) goto l380;
+  if (!yy_WS(G))  goto l362;
+  if (!yymatchChar(G, ')')) goto l362;
   yyDo(G, yy_2_Value, G->begin, G->end, "yy_2_Value");
-  if (!yy__(G))  goto l380;
-  goto l379;
-  l380:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;  if (!yymatchChar(G, '+')) goto l381;
-  if (!yy__(G))  goto l381;
-  if (!yymatchChar(G, '(')) goto l381;
+  if (!yy__(G))  goto l362;
+  goto l361;
+  l362:;	  G->pos= yypos361; G->thunkpos= yythunkpos361;  if (!yymatchChar(G, '+')) goto l363;
+  if (!yy__(G))  goto l363;
+  if (!yymatchChar(G, '(')) goto l363;
   yyDo(G, yy_3_Value, G->begin, G->end, "yy_3_Value");
-  if (!yy_WS(G))  goto l381;
-  if (!yy_Expr(G))  goto l381;
+  if (!yy_WS(G))  goto l363;
+  if (!yy_Expr(G))  goto l363;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l381;
-  if (!yymatchChar(G, ')')) goto l381;
+  if (!yy_WS(G))  goto l363;
+  if (!yymatchChar(G, ')')) goto l363;
   yyDo(G, yy_4_Value, G->begin, G->end, "yy_4_Value");
-  if (!yy__(G))  goto l381;
-  goto l379;
-  l381:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;  if (!yymatchChar(G, '-')) goto l382;
-  if (!yy__(G))  goto l382;
+  if (!yy__(G))  goto l363;
+  goto l361;
+  l363:;	  G->pos= yypos361; G->thunkpos= yythunkpos361;  if (!yymatchChar(G, '-')) goto l364;
+  if (!yy__(G))  goto l364;
   yyDo(G, yy_5_Value, G->begin, G->end, "yy_5_Value");
-  if (!yy_SafeNavAccess(G))  goto l382;
+  if (!yy_Access(G))  goto l364;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_Value, G->begin, G->end, "yy_6_Value");
-  goto l379;
-  l382:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;  if (!yymatchChar(G, '+')) goto l383;
-  if (!yy__(G))  goto l383;
+  goto l361;
+  l364:;	  G->pos= yypos361; G->thunkpos= yythunkpos361;  if (!yymatchChar(G, '+')) goto l365;
+  if (!yy__(G))  goto l365;
   yyDo(G, yy_7_Value, G->begin, G->end, "yy_7_Value");
-  if (!yy_SafeNavAccess(G))  goto l383;
+  if (!yy_Access(G))  goto l365;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_8_Value, G->begin, G->end, "yy_8_Value");
-  goto l379;
-  l383:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;  if (!yymatchChar(G, '(')) goto l384;
+  goto l361;
+  l365:;	  G->pos= yypos361; G->thunkpos= yythunkpos361;  if (!yymatchChar(G, '(')) goto l366;
   yyDo(G, yy_9_Value, G->begin, G->end, "yy_9_Value");
-  if (!yy_WS(G))  goto l384;
-  if (!yy_Expr(G))  goto l384;
+  if (!yy_WS(G))  goto l366;
+  if (!yy_Expr(G))  goto l366;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l384;
-  if (!yymatchChar(G, ')')) goto l384;
+  if (!yy_WS(G))  goto l366;
+  if (!yymatchChar(G, ')')) goto l366;
   yyDo(G, yy_10_Value, G->begin, G->end, "yy_10_Value");
 
-  {  int yypos385= G->pos, yythunkpos385= G->thunkpos;  if (!yymatchChar(G, '&')) goto l385;
+  {  int yypos367= G->pos, yythunkpos367= G->thunkpos;  if (!yymatchChar(G, '&')) goto l367;
 
-  {  int yypos387= G->pos, yythunkpos387= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l387;
-  goto l385;
-  l387:;	  G->pos= yypos387; G->thunkpos= yythunkpos387;
+  {  int yypos369= G->pos, yythunkpos369= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\100\000\000\040\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "&=")) goto l369;
+  goto l367;
+  l369:;	  G->pos= yypos369; G->thunkpos= yythunkpos369;
   }  yyDo(G, yy_11_Value, G->begin, G->end, "yy_11_Value");
-  goto l386;
-  l385:;	  G->pos= yypos385; G->thunkpos= yythunkpos385;
+  goto l368;
+  l367:;	  G->pos= yypos367; G->thunkpos= yythunkpos367;
   }
-  l386:;	  if (!yy__(G))  goto l384;
-  goto l379;
-  l384:;	  G->pos= yypos379; G->thunkpos= yythunkpos379;  if (!yy_ValueCore(G))  goto l378;
+  l368:;	  if (!yy__(G))  goto l366;
+  goto l361;
+  l366:;	  G->pos= yypos361; G->thunkpos= yythunkpos361;  if (!yy_ValueCore(G))  goto l360;
 
   }
-  l379:;	  yyprintf((stderr, "  ok   Value"));
+  l361:;	  yyprintf((stderr, "  ok   Value"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l378:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Value"));
+  l360:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Value"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9640,13 +9415,13 @@ YY_RULE(int) yy_Value(GREG *G)
 }
 YY_RULE(int) yy_MATCH_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MATCH_KW"));
-  if (!yymatchString(G, "match")) goto l388;
+  if (!yymatchString(G, "match")) goto l370;
   yyprintf((stderr, "  ok   MATCH_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l388:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MATCH_KW"));
+  l370:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MATCH_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9654,13 +9429,13 @@ YY_RULE(int) yy_MATCH_KW(GREG *G)
 }
 YY_RULE(int) yy_DOUBLE_ARROW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOUBLE_ARROW"));
-  if (!yymatchString(G, "=>")) goto l389;
+  if (!yymatchString(G, "=>")) goto l371;
   yyprintf((stderr, "  ok   DOUBLE_ARROW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l389:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_ARROW"));
+  l371:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOUBLE_ARROW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9670,40 +9445,40 @@ YY_RULE(int) yy_CaseExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "CaseExpr"));
 
-  {  int yypos391= G->pos, yythunkpos391= G->thunkpos;  if (!yy_VariableDecl(G))  goto l392;
+  {  int yypos373= G->pos, yythunkpos373= G->thunkpos;  if (!yy_VariableDecl(G))  goto l374;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l392;
-  goto l391;
-  l392:;	  G->pos= yypos391; G->thunkpos= yythunkpos391;  if (!yy_BinaryOperation(G))  goto l393;
+  if (!yy__(G))  goto l374;
+  goto l373;
+  l374:;	  G->pos= yypos373; G->thunkpos= yythunkpos373;  if (!yy_BinaryOperation(G))  goto l375;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l393;
+  if (!yy__(G))  goto l375;
 
-  l394:;	
-  {  int yypos395= G->pos, yythunkpos395= G->thunkpos;  if (!yy__(G))  goto l395;
-  if (!yymatchChar(G, '.')) goto l395;
+  l376:;	
+  {  int yypos377= G->pos, yythunkpos377= G->thunkpos;  if (!yy__(G))  goto l377;
+  if (!yymatchChar(G, '.')) goto l377;
   yyDo(G, yy_1_CaseExpr, G->begin, G->end, "yy_1_CaseExpr");
-  if (!yy_WS(G))  goto l395;
-  if (!yy_FunctionCall(G))  goto l395;
+  if (!yy_WS(G))  goto l377;
+  if (!yy_FunctionCall(G))  goto l377;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_CaseExpr, G->begin, G->end, "yy_2_CaseExpr");
-  goto l394;
-  l395:;	  G->pos= yypos395; G->thunkpos= yythunkpos395;
-  }  goto l391;
-  l393:;	  G->pos= yypos391; G->thunkpos= yythunkpos391;  if (!yy_AnonymousFunctionDecl(G))  goto l396;
-  goto l391;
-  l396:;	  G->pos= yypos391; G->thunkpos= yythunkpos391;  if (!yymatchChar(G, '(')) goto l390;
-  if (!yy__(G))  goto l390;
-  if (!yy_Expr(G))  goto l390;
-  if (!yy__(G))  goto l390;
-  if (!yymatchChar(G, ')')) goto l390;
+  goto l376;
+  l377:;	  G->pos= yypos377; G->thunkpos= yythunkpos377;
+  }  goto l373;
+  l375:;	  G->pos= yypos373; G->thunkpos= yythunkpos373;  if (!yy_AnonymousFunctionDecl(G))  goto l378;
+  goto l373;
+  l378:;	  G->pos= yypos373; G->thunkpos= yythunkpos373;  if (!yymatchChar(G, '(')) goto l372;
+  if (!yy__(G))  goto l372;
+  if (!yy_Expr(G))  goto l372;
+  if (!yy__(G))  goto l372;
+  if (!yymatchChar(G, ')')) goto l372;
 
   }
-  l391:;	  yyprintf((stderr, "  ok   CaseExpr"));
+  l373:;	  yyprintf((stderr, "  ok   CaseExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l390:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CaseExpr"));
+  l372:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CaseExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9711,13 +9486,13 @@ YY_RULE(int) yy_CaseExpr(GREG *G)
 }
 YY_RULE(int) yy_CASE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CASE_KW"));
-  if (!yymatchString(G, "case")) goto l397;
+  if (!yymatchString(G, "case")) goto l379;
   yyprintf((stderr, "  ok   CASE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l397:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CASE_KW"));
+  l379:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CASE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9726,35 +9501,35 @@ YY_RULE(int) yy_CASE_KW(GREG *G)
 YY_RULE(int) yy_Case(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Case"));
-  if (!yy_CASE_KW(G))  goto l398;
+  if (!yy_CASE_KW(G))  goto l380;
   yyDo(G, yy_1_Case, G->begin, G->end, "yy_1_Case");
 
-  {  int yypos399= G->pos, yythunkpos399= G->thunkpos;  if (!yy__(G))  goto l399;
-  if (!yy_CaseExpr(G))  goto l399;
+  {  int yypos381= G->pos, yythunkpos381= G->thunkpos;  if (!yy__(G))  goto l381;
+  if (!yy_CaseExpr(G))  goto l381;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_Case, G->begin, G->end, "yy_2_Case");
-  goto l400;
-  l399:;	  G->pos= yypos399; G->thunkpos= yythunkpos399;
+  goto l382;
+  l381:;	  G->pos= yypos381; G->thunkpos= yythunkpos381;
   }
-  l400:;	  if (!yy_WS(G))  goto l398;
-  if (!yy_DOUBLE_ARROW(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_DOUBLE_ARROW, "Expected double arrow after case expression!\n"); ; } goto l398; }
+  l382:;	  if (!yy_WS(G))  goto l380;
+  if (!yy_DOUBLE_ARROW(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_DOUBLE_ARROW, "Expected double arrow after case expression!\n"); ; } goto l380; }
 
-  l401:;	
-  {  int yypos402= G->pos, yythunkpos402= G->thunkpos;  if (!yy_WS(G))  goto l402;
-  if (!yy_Stmt(G))  goto l402;
+  l383:;	
+  {  int yypos384= G->pos, yythunkpos384= G->thunkpos;  if (!yy_WS(G))  goto l384;
+  if (!yy_Stmt(G))  goto l384;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_Case, G->begin, G->end, "yy_3_Case");
-  if (!yy_WS(G))  goto l402;
-  goto l401;
-  l402:;	  G->pos= yypos402; G->thunkpos= yythunkpos402;
-  }  if (!yy_WS(G))  goto l398;
+  if (!yy_WS(G))  goto l384;
+  goto l383;
+  l384:;	  G->pos= yypos384; G->thunkpos= yythunkpos384;
+  }  if (!yy_WS(G))  goto l380;
   yyDo(G, yy_4_Case, G->begin, G->end, "yy_4_Case");
   yyprintf((stderr, "  ok   Case"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l398:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Case"));
+  l380:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Case"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9762,13 +9537,13 @@ YY_RULE(int) yy_Case(GREG *G)
 }
 YY_RULE(int) yy_ELSE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ELSE_KW"));
-  if (!yymatchString(G, "else")) goto l403;
+  if (!yymatchString(G, "else")) goto l385;
   yyprintf((stderr, "  ok   ELSE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l403:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ELSE_KW"));
+  l385:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ELSE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9778,30 +9553,30 @@ YY_RULE(int) yy_Body(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Body"));
 
-  {  int yypos405= G->pos, yythunkpos405= G->thunkpos;  if (!yymatchChar(G, '{')) goto l406;
+  {  int yypos387= G->pos, yythunkpos387= G->thunkpos;  if (!yymatchChar(G, '{')) goto l388;
 
-  l407:;	
-  {  int yypos408= G->pos, yythunkpos408= G->thunkpos;  if (!yy_WS(G))  goto l408;
-  if (!yy_Stmt(G))  goto l408;
+  l389:;	
+  {  int yypos390= G->pos, yythunkpos390= G->thunkpos;  if (!yy_WS(G))  goto l390;
+  if (!yy_Stmt(G))  goto l390;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_Body, G->begin, G->end, "yy_1_Body");
-  if (!yy_WS(G))  goto l408;
-  goto l407;
-  l408:;	  G->pos= yypos408; G->thunkpos= yythunkpos408;
-  }  if (!yy_WS(G))  goto l406;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Expected statement or '"_CSBRACK"' to close body.!\n") ; } goto l406; }
-  goto l405;
-  l406:;	  G->pos= yypos405; G->thunkpos= yythunkpos405;  if (!yy_Stmt(G))  goto l404;
+  if (!yy_WS(G))  goto l390;
+  goto l389;
+  l390:;	  G->pos= yypos390; G->thunkpos= yythunkpos390;
+  }  if (!yy_WS(G))  goto l388;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Expected statement or '"_CSBRACK"' to close body.!\n") ; } goto l388; }
+  goto l387;
+  l388:;	  G->pos= yypos387; G->thunkpos= yythunkpos387;  if (!yy_Stmt(G))  goto l386;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Body, G->begin, G->end, "yy_2_Body");
 
   }
-  l405:;	  yyprintf((stderr, "  ok   Body"));
+  l387:;	  yyprintf((stderr, "  ok   Body"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l404:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Body"));
+  l386:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Body"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9809,13 +9584,13 @@ YY_RULE(int) yy_Body(GREG *G)
 }
 YY_RULE(int) yy_IF_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IF_KW"));
-  if (!yymatchString(G, "if")) goto l409;
+  if (!yymatchString(G, "if")) goto l391;
   yyprintf((stderr, "  ok   IF_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l409:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IF_KW"));
+  l391:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IF_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9823,18 +9598,18 @@ YY_RULE(int) yy_IF_KW(GREG *G)
 }
 YY_RULE(int) yy_Else(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Else"));
-  if (!yy_ELSE_KW(G))  goto l410;
+  if (!yy_ELSE_KW(G))  goto l392;
   yyDo(G, yy_1_Else, G->begin, G->end, "yy_1_Else");
   yyDo(G, yy_2_Else, G->begin, G->end, "yy_2_Else");
-  if (!yy__(G))  goto l410;
-  if (!yy_Body(G))  goto l410;
+  if (!yy__(G))  goto l392;
+  if (!yy_Body(G))  goto l392;
   yyDo(G, yy_3_Else, G->begin, G->end, "yy_3_Else");
   yyprintf((stderr, "  ok   Else"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l410:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Else"));
+  l392:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Else"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9843,26 +9618,26 @@ YY_RULE(int) yy_Else(GREG *G)
 YY_RULE(int) yy_If(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "If"));
-  if (!yy_IF_KW(G))  goto l411;
+  if (!yy_IF_KW(G))  goto l393;
   yyDo(G, yy_1_If, G->begin, G->end, "yy_1_If");
-  if (!yy_WS(G))  goto l411;
-  if (!yymatchChar(G, '(')) goto l411;
-  if (!yy_WS(G))  goto l411;
-  if (!yy__(G))  goto l411;
-  if (!yy_Expr(G))  goto l411;
+  if (!yy_WS(G))  goto l393;
+  if (!yymatchChar(G, '(')) goto l393;
+  if (!yy_WS(G))  goto l393;
+  if (!yy__(G))  goto l393;
+  if (!yy_Expr(G))  goto l393;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_If, G->begin, G->end, "yy_2_If");
-  if (!yy_WS(G))  goto l411;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected if condition or ')'.") ; } goto l411; }
-  if (!yy__(G))  goto l411;
-  if (!yy_Body(G))  goto l411;
+  if (!yy_WS(G))  goto l393;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected if condition or ')'.") ; } goto l393; }
+  if (!yy__(G))  goto l393;
+  if (!yy_Body(G))  goto l393;
   yyDo(G, yy_3_If, G->begin, G->end, "yy_3_If");
   yyprintf((stderr, "  ok   If"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l411:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "If"));
+  l393:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "If"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9872,31 +9647,31 @@ YY_RULE(int) yy_Return(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Return"));
 
-  {  int yypos413= G->pos, yythunkpos413= G->thunkpos;  if (!yy_RETURN_KW(G))  goto l414;
+  {  int yypos395= G->pos, yythunkpos395= G->thunkpos;  if (!yy_RETURN_KW(G))  goto l396;
 
-  {  int yypos415= G->pos, yythunkpos415= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l414;
-  G->pos= yypos415; G->thunkpos= yythunkpos415;
+  {  int yypos397= G->pos, yythunkpos397= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l396;
+  G->pos= yypos397; G->thunkpos= yythunkpos397;
   }  yyDo(G, yy_1_Return, G->begin, G->end, "yy_1_Return");
-  if (!yy__(G))  goto l414;
-  if (!yy_Expr(G))  goto l414;
+  if (!yy__(G))  goto l396;
+  if (!yy_Expr(G))  goto l396;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Return, G->begin, G->end, "yy_2_Return");
-  goto l413;
-  l414:;	  G->pos= yypos413; G->thunkpos= yythunkpos413;  if (!yy_RETURN_KW(G))  goto l412;
+  goto l395;
+  l396:;	  G->pos= yypos395; G->thunkpos= yythunkpos395;  if (!yy_RETURN_KW(G))  goto l394;
 
-  {  int yypos416= G->pos, yythunkpos416= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l412;
-  G->pos= yypos416; G->thunkpos= yythunkpos416;
+  {  int yypos398= G->pos, yythunkpos398= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\377\377\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_")) goto l394;
+  G->pos= yypos398; G->thunkpos= yythunkpos398;
   }  yyDo(G, yy_3_Return, G->begin, G->end, "yy_3_Return");
-  if (!yy__(G))  goto l412;
+  if (!yy__(G))  goto l394;
   yyDo(G, yy_4_Return, G->begin, G->end, "yy_4_Return");
 
   }
-  l413:;	  yyprintf((stderr, "  ok   Return"));
+  l395:;	  yyprintf((stderr, "  ok   Return"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l412:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Return"));
+  l394:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Return"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9904,24 +9679,24 @@ YY_RULE(int) yy_Return(GREG *G)
 }
 YY_RULE(int) yy_Try(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Try"));
-  if (!yy_TRY_KW(G))  goto l417;
+  if (!yy_TRY_KW(G))  goto l399;
   yyDo(G, yy_1_Try, G->begin, G->end, "yy_1_Try");
-  if (!yy__(G))  goto l417;
-  if (!yy_Body(G))  goto l417;
+  if (!yy__(G))  goto l399;
+  if (!yy_Body(G))  goto l399;
 
-  l418:;	
-  {  int yypos419= G->pos, yythunkpos419= G->thunkpos;  if (!yy_WS(G))  goto l419;
-  if (!yy_Catch(G))  goto l419;
-  if (!yy_WS(G))  goto l419;
-  goto l418;
-  l419:;	  G->pos= yypos419; G->thunkpos= yythunkpos419;
+  l400:;	
+  {  int yypos401= G->pos, yythunkpos401= G->thunkpos;  if (!yy_WS(G))  goto l401;
+  if (!yy_Catch(G))  goto l401;
+  if (!yy_WS(G))  goto l401;
+  goto l400;
+  l401:;	  G->pos= yypos401; G->thunkpos= yythunkpos401;
   }  yyDo(G, yy_2_Try, G->begin, G->end, "yy_2_Try");
   yyprintf((stderr, "  ok   Try"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l417:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Try"));
+  l399:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Try"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9930,34 +9705,34 @@ YY_RULE(int) yy_Try(GREG *G)
 YY_RULE(int) yy_Match(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Match"));
-  if (!yy_MATCH_KW(G))  goto l420;
+  if (!yy_MATCH_KW(G))  goto l402;
   yyDo(G, yy_1_Match, G->begin, G->end, "yy_1_Match");
 
-  {  int yypos421= G->pos, yythunkpos421= G->thunkpos;  if (!yy__(G))  goto l421;
-  if (!yy_Value(G))  goto l421;
+  {  int yypos403= G->pos, yythunkpos403= G->thunkpos;  if (!yy__(G))  goto l403;
+  if (!yy_Value(G))  goto l403;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Match, G->begin, G->end, "yy_2_Match");
-  goto l422;
-  l421:;	  G->pos= yypos421; G->thunkpos= yythunkpos421;
+  goto l404;
+  l403:;	  G->pos= yypos403; G->thunkpos= yythunkpos403;
   }
-  l422:;	  if (!yy_WS(G))  goto l420;
-  if (!yymatchChar(G, '{')) goto l420;
+  l404:;	  if (!yy_WS(G))  goto l402;
+  if (!yymatchChar(G, '{')) goto l402;
 
-  l423:;	
-  {  int yypos424= G->pos, yythunkpos424= G->thunkpos;  if (!yy_WS(G))  goto l424;
-  if (!yy_Case(G))  goto l424;
-  if (!yy_WS(G))  goto l424;
-  goto l423;
-  l424:;	  G->pos= yypos424; G->thunkpos= yythunkpos424;
-  }  if (!yy_WS(G))  goto l420;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CASE_IN_MATCH, "Expected case or '"_CSBRACK"' to close match block.") ; } goto l420; }
+  l405:;	
+  {  int yypos406= G->pos, yythunkpos406= G->thunkpos;  if (!yy_WS(G))  goto l406;
+  if (!yy_Case(G))  goto l406;
+  if (!yy_WS(G))  goto l406;
+  goto l405;
+  l406:;	  G->pos= yypos406; G->thunkpos= yythunkpos406;
+  }  if (!yy_WS(G))  goto l402;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CASE_IN_MATCH, "Expected case or '"_CSBRACK"' to close match block.") ; } goto l402; }
   yyDo(G, yy_3_Match, G->begin, G->end, "yy_3_Match");
   yyprintf((stderr, "  ok   Match"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l420:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Match"));
+  l402:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Match"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9966,21 +9741,21 @@ YY_RULE(int) yy_Match(GREG *G)
 YY_RULE(int) yy_FlowControl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FlowControl"));
 
-  {  int yypos426= G->pos, yythunkpos426= G->thunkpos;  if (!yy_Foreach(G))  goto l427;
-  goto l426;
-  l427:;	  G->pos= yypos426; G->thunkpos= yythunkpos426;  if (!yy_While(G))  goto l428;
-  goto l426;
-  l428:;	  G->pos= yypos426; G->thunkpos= yythunkpos426;  if (!yy_Break(G))  goto l429;
-  goto l426;
-  l429:;	  G->pos= yypos426; G->thunkpos= yythunkpos426;  if (!yy_Continue(G))  goto l425;
+  {  int yypos408= G->pos, yythunkpos408= G->thunkpos;  if (!yy_Foreach(G))  goto l409;
+  goto l408;
+  l409:;	  G->pos= yypos408; G->thunkpos= yythunkpos408;  if (!yy_While(G))  goto l410;
+  goto l408;
+  l410:;	  G->pos= yypos408; G->thunkpos= yythunkpos408;  if (!yy_Break(G))  goto l411;
+  goto l408;
+  l411:;	  G->pos= yypos408; G->thunkpos= yythunkpos408;  if (!yy_Continue(G))  goto l407;
 
   }
-  l426:;	  yyprintf((stderr, "  ok   FlowControl"));
+  l408:;	  yyprintf((stderr, "  ok   FlowControl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l425:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FlowControl"));
+  l407:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FlowControl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -9989,26 +9764,26 @@ YY_RULE(int) yy_FlowControl(GREG *G)
 YY_RULE(int) yy_Block(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Block"));
-  if (!yymatchChar(G, '{')) goto l430;
+  if (!yymatchChar(G, '{')) goto l412;
   yyDo(G, yy_1_Block, G->begin, G->end, "yy_1_Block");
 
-  l431:;	
-  {  int yypos432= G->pos, yythunkpos432= G->thunkpos;  if (!yy_WS(G))  goto l432;
-  if (!yy_Stmt(G))  goto l432;
+  l413:;	
+  {  int yypos414= G->pos, yythunkpos414= G->thunkpos;  if (!yy_WS(G))  goto l414;
+  if (!yy_Stmt(G))  goto l414;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Block, G->begin, G->end, "yy_2_Block");
-  if (!yy_WS(G))  goto l432;
-  goto l431;
-  l432:;	  G->pos= yypos432; G->thunkpos= yythunkpos432;
-  }  if (!yy_WS(G))  goto l430;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close block."); ; } goto l430; }
+  if (!yy_WS(G))  goto l414;
+  goto l413;
+  l414:;	  G->pos= yypos414; G->thunkpos= yythunkpos414;
+  }  if (!yy_WS(G))  goto l412;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected statement or '"_CSBRACK"' to close block."); ; } goto l412; }
   yyDo(G, yy_3_Block, G->begin, G->end, "yy_3_Block");
   yyprintf((stderr, "  ok   Block"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l430:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Block"));
+  l412:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Block"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10017,68 +9792,22 @@ YY_RULE(int) yy_Block(GREG *G)
 YY_RULE(int) yy_Conditional(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Conditional"));
-  if (!yy_If(G))  goto l433;
+  if (!yy_If(G))  goto l415;
   yyDo(G, yySet, -2, 0, "yySet");
 
-  {  int yypos434= G->pos, yythunkpos434= G->thunkpos;  if (!yy_WS(G))  goto l434;
-  if (!yy_Else(G))  goto l434;
+  {  int yypos416= G->pos, yythunkpos416= G->thunkpos;  if (!yy_WS(G))  goto l416;
+  if (!yy_Else(G))  goto l416;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_Conditional, G->begin, G->end, "yy_1_Conditional");
-  goto l435;
-  l434:;	  G->pos= yypos434; G->thunkpos= yythunkpos434;
+  goto l417;
+  l416:;	  G->pos= yypos416; G->thunkpos= yythunkpos416;
   }
-  l435:;	  yyprintf((stderr, "  ok   Conditional"));
+  l417:;	  yyprintf((stderr, "  ok   Conditional"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l433:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Conditional"));
-  yyprintfvGcontext;
-  yyprintfv((stderr, "\n"));
-
-  return 0;
-}
-YY_RULE(int) yy_PreprocessorEndRegion(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PreprocessorEndRegion"));
-  if (!yymatchString(G, "#endregion")) goto l436;
-
-  l437:;	
-  {  int yypos438= G->pos, yythunkpos438= G->thunkpos;
-  {  int yypos439= G->pos, yythunkpos439= G->thunkpos;  if (!yy_EOL(G))  goto l439;
-  goto l438;
-  l439:;	  G->pos= yypos439; G->thunkpos= yythunkpos439;
-  }  if (!yymatchDot(G)) goto l438;  goto l437;
-  l438:;	  G->pos= yypos438; G->thunkpos= yythunkpos438;
-  }  if (!yy_EOL(G))  goto l436;
-  yyprintf((stderr, "  ok   PreprocessorEndRegion"));
-  yyprintfGcontext;
-  yyprintf((stderr, "\n"));
-
-  return 1;
-  l436:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PreprocessorEndRegion"));
-  yyprintfvGcontext;
-  yyprintfv((stderr, "\n"));
-
-  return 0;
-}
-YY_RULE(int) yy_PreprocessorBeginRegion(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PreprocessorBeginRegion"));
-  if (!yymatchString(G, "#region")) goto l440;
-
-  l441:;	
-  {  int yypos442= G->pos, yythunkpos442= G->thunkpos;
-  {  int yypos443= G->pos, yythunkpos443= G->thunkpos;  if (!yy_EOL(G))  goto l443;
-  goto l442;
-  l443:;	  G->pos= yypos443; G->thunkpos= yythunkpos443;
-  }  if (!yymatchDot(G)) goto l442;  goto l441;
-  l442:;	  G->pos= yypos442; G->thunkpos= yythunkpos442;
-  }  if (!yy_EOL(G))  goto l440;
-  yyprintf((stderr, "  ok   PreprocessorBeginRegion"));
-  yyprintfGcontext;
-  yyprintf((stderr, "\n"));
-
-  return 1;
-  l440:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PreprocessorBeginRegion"));
+  l415:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Conditional"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10086,22 +9815,22 @@ YY_RULE(int) yy_PreprocessorBeginRegion(GREG *G)
 }
 YY_RULE(int) yy_CommentLine(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CommentLine"));
-  if (!yymatchString(G, "//")) goto l444;
+  if (!yymatchString(G, "//")) goto l418;
 
-  l445:;	
-  {  int yypos446= G->pos, yythunkpos446= G->thunkpos;
-  {  int yypos447= G->pos, yythunkpos447= G->thunkpos;  if (!yy_EOL(G))  goto l447;
-  goto l446;
-  l447:;	  G->pos= yypos447; G->thunkpos= yythunkpos447;
-  }  if (!yymatchDot(G)) goto l446;  goto l445;
-  l446:;	  G->pos= yypos446; G->thunkpos= yythunkpos446;
-  }  if (!yy_EOL(G))  goto l444;
+  l419:;	
+  {  int yypos420= G->pos, yythunkpos420= G->thunkpos;
+  {  int yypos421= G->pos, yythunkpos421= G->thunkpos;  if (!yy_EOL(G))  goto l421;
+  goto l420;
+  l421:;	  G->pos= yypos421; G->thunkpos= yythunkpos421;
+  }  if (!yymatchDot(G)) goto l420;  goto l419;
+  l420:;	  G->pos= yypos420; G->thunkpos= yythunkpos420;
+  }  if (!yy_EOL(G))  goto l418;
   yyprintf((stderr, "  ok   CommentLine"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l444:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CommentLine"));
+  l418:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CommentLine"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10110,22 +9839,22 @@ YY_RULE(int) yy_CommentLine(GREG *G)
 YY_RULE(int) yy_EoledStatement(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EoledStatement"));
 
-  {  int yypos449= G->pos, yythunkpos449= G->thunkpos;  if (!yy_WS(G))  goto l450;
-  if (!yy_Return(G))  goto l450;
-  goto l449;
-  l450:;	  G->pos= yypos449; G->thunkpos= yythunkpos449;  if (!yy_WS(G))  goto l451;
-  if (!yy_VariableDecl(G))  goto l451;
-  goto l449;
-  l451:;	  G->pos= yypos449; G->thunkpos= yythunkpos449;  if (!yy_WS(G))  goto l448;
-  if (!yy_Expr(G))  goto l448;
+  {  int yypos423= G->pos, yythunkpos423= G->thunkpos;  if (!yy_WS(G))  goto l424;
+  if (!yy_Return(G))  goto l424;
+  goto l423;
+  l424:;	  G->pos= yypos423; G->thunkpos= yythunkpos423;  if (!yy_WS(G))  goto l425;
+  if (!yy_VariableDecl(G))  goto l425;
+  goto l423;
+  l425:;	  G->pos= yypos423; G->thunkpos= yythunkpos423;  if (!yy_WS(G))  goto l422;
+  if (!yy_Expr(G))  goto l422;
 
   }
-  l449:;	  yyprintf((stderr, "  ok   EoledStatement"));
+  l423:;	  yyprintf((stderr, "  ok   EoledStatement"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l448:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EoledStatement"));
+  l422:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EoledStatement"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10135,80 +9864,72 @@ YY_RULE(int) yy_StmtCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 6, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "StmtCore"));
 
-  {  int yypos453= G->pos, yythunkpos453= G->thunkpos;  if (!yy_EoledStatement(G))  goto l454;
+  {  int yypos427= G->pos, yythunkpos427= G->thunkpos;  if (!yy_EoledStatement(G))  goto l428;
   yyDo(G, yySet, 0, 0, "yySet");
 
-  {  int yypos455= G->pos, yythunkpos455= G->thunkpos;  if (!yy_Terminator(G))  goto l456;
+  {  int yypos429= G->pos, yythunkpos429= G->thunkpos;  if (!yy_Terminator(G))  goto l430;
 
-  l457:;	
-  {  int yypos458= G->pos, yythunkpos458= G->thunkpos;  if (!yy_Terminator(G))  goto l458;
-  goto l457;
-  l458:;	  G->pos= yypos458; G->thunkpos= yythunkpos458;
-  }  goto l455;
-  l456:;	  G->pos= yypos455; G->thunkpos= yythunkpos455;  if (!yy_WS(G))  goto l459;
+  l431:;	
+  {  int yypos432= G->pos, yythunkpos432= G->thunkpos;  if (!yy_Terminator(G))  goto l432;
+  goto l431;
+  l432:;	  G->pos= yypos432; G->thunkpos= yythunkpos432;
+  }  goto l429;
+  l430:;	  G->pos= yypos429; G->thunkpos= yythunkpos429;  if (!yy_WS(G))  goto l433;
 
-  {  int yypos460= G->pos, yythunkpos460= G->thunkpos;  if (!yymatchChar(G, '}')) goto l459;
-  G->pos= yypos460; G->thunkpos= yythunkpos460;
-  }  goto l455;
-  l459:;	  G->pos= yypos455; G->thunkpos= yythunkpos455;  if (!yy_WS(G))  goto l461;
+  {  int yypos434= G->pos, yythunkpos434= G->thunkpos;  if (!yymatchChar(G, '}')) goto l433;
+  G->pos= yypos434; G->thunkpos= yythunkpos434;
+  }  goto l429;
+  l433:;	  G->pos= yypos429; G->thunkpos= yythunkpos429;  if (!yy_WS(G))  goto l435;
 
-  {  int yypos462= G->pos, yythunkpos462= G->thunkpos;  if (!yymatchChar(G, ')')) goto l461;
-  G->pos= yypos462; G->thunkpos= yythunkpos462;
-  }  goto l455;
-  l461:;	  G->pos= yypos455; G->thunkpos= yythunkpos455;  if (!yy_WS(G))  goto l463;
+  {  int yypos436= G->pos, yythunkpos436= G->thunkpos;  if (!yymatchChar(G, ')')) goto l435;
+  G->pos= yypos436; G->thunkpos= yythunkpos436;
+  }  goto l429;
+  l435:;	  G->pos= yypos429; G->thunkpos= yythunkpos429;  if (!yy_WS(G))  goto l437;
 
-  {  int yypos464= G->pos, yythunkpos464= G->thunkpos;  if (!yymatchChar(G, ',')) goto l463;
-  G->pos= yypos464; G->thunkpos= yythunkpos464;
-  }  goto l455;
-  l463:;	  G->pos= yypos455; G->thunkpos= yythunkpos455;
-  {  int yypos466= G->pos, yythunkpos466= G->thunkpos;  if (!yy_CommentLine(G))  goto l465;
-  G->pos= yypos466; G->thunkpos= yythunkpos466;
-  }  goto l455;
-  l465:;	  G->pos= yypos455; G->thunkpos= yythunkpos455;
-  {  int yypos468= G->pos, yythunkpos468= G->thunkpos;  if (!yy_PreprocessorBeginRegion(G))  goto l467;
-  G->pos= yypos468; G->thunkpos= yythunkpos468;
-  }  goto l455;
-  l467:;	  G->pos= yypos455; G->thunkpos= yythunkpos455;
-  {  int yypos469= G->pos, yythunkpos469= G->thunkpos;  if (!yy_PreprocessorEndRegion(G))  goto l454;
-  G->pos= yypos469; G->thunkpos= yythunkpos469;
+  {  int yypos438= G->pos, yythunkpos438= G->thunkpos;  if (!yymatchChar(G, ',')) goto l437;
+  G->pos= yypos438; G->thunkpos= yythunkpos438;
+  }  goto l429;
+  l437:;	  G->pos= yypos429; G->thunkpos= yythunkpos429;
+  {  int yypos439= G->pos, yythunkpos439= G->thunkpos;  if (!yy_CommentLine(G))  goto l428;
+  G->pos= yypos439; G->thunkpos= yythunkpos439;
   }
   }
-  l455:;	  goto l453;
-  l454:;	  G->pos= yypos453; G->thunkpos= yythunkpos453;
-  {  int yypos470= G->pos, yythunkpos470= G->thunkpos;  if (!yy_WS(G))  goto l471;
-  if (!yy_Conditional(G))  goto l471;
+  l429:;	  goto l427;
+  l428:;	  G->pos= yypos427; G->thunkpos= yythunkpos427;
+  {  int yypos440= G->pos, yythunkpos440= G->thunkpos;  if (!yy_WS(G))  goto l441;
+  if (!yy_Conditional(G))  goto l441;
   yyDo(G, yySet, 0, 0, "yySet");
-  goto l470;
-  l471:;	  G->pos= yypos470; G->thunkpos= yythunkpos470;  if (!yy_WS(G))  goto l472;
-  if (!yy_Block(G))  goto l472;
+  goto l440;
+  l441:;	  G->pos= yypos440; G->thunkpos= yythunkpos440;  if (!yy_WS(G))  goto l442;
+  if (!yy_Block(G))  goto l442;
   yyDo(G, yySet, 0, 0, "yySet");
-  goto l470;
-  l472:;	  G->pos= yypos470; G->thunkpos= yythunkpos470;  if (!yy_WS(G))  goto l473;
-  if (!yy_FlowControl(G))  goto l473;
+  goto l440;
+  l442:;	  G->pos= yypos440; G->thunkpos= yythunkpos440;  if (!yy_WS(G))  goto l443;
+  if (!yy_FlowControl(G))  goto l443;
   yyDo(G, yySet, 0, 0, "yySet");
 
-  l474:;	
-  {  int yypos475= G->pos, yythunkpos475= G->thunkpos;  if (!yy_Terminator(G))  goto l475;
-  goto l474;
-  l475:;	  G->pos= yypos475; G->thunkpos= yythunkpos475;
-  }  goto l470;
-  l473:;	  G->pos= yypos470; G->thunkpos= yythunkpos470;  if (!yy_WS(G))  goto l476;
-  if (!yy_Match(G))  goto l476;
+  l444:;	
+  {  int yypos445= G->pos, yythunkpos445= G->thunkpos;  if (!yy_Terminator(G))  goto l445;
+  goto l444;
+  l445:;	  G->pos= yypos445; G->thunkpos= yythunkpos445;
+  }  goto l440;
+  l443:;	  G->pos= yypos440; G->thunkpos= yythunkpos440;  if (!yy_WS(G))  goto l446;
+  if (!yy_Match(G))  goto l446;
   yyDo(G, yySet, 0, 0, "yySet");
-  goto l470;
-  l476:;	  G->pos= yypos470; G->thunkpos= yythunkpos470;  if (!yy_WS(G))  goto l452;
-  if (!yy_Try(G))  goto l452;
+  goto l440;
+  l446:;	  G->pos= yypos440; G->thunkpos= yythunkpos440;  if (!yy_WS(G))  goto l426;
+  if (!yy_Try(G))  goto l426;
   yyDo(G, yySet, 0, 0, "yySet");
 
   }
-  l470:;	
+  l440:;	
   }
-  l453:;	  yyprintf((stderr, "  ok   StmtCore"));
+  l427:;	  yyprintf((stderr, "  ok   StmtCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 6, 0, "yyPop");
   return 1;
-  l452:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "StmtCore"));
+  l426:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "StmtCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10216,17 +9937,17 @@ YY_RULE(int) yy_StmtCore(GREG *G)
 }
 YY_RULE(int) yy_FuncTypeCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FuncTypeCore"));
-  if (!yymatchString(G, "Func")) goto l477;
+  if (!yymatchString(G, "Func")) goto l447;
 
-  {  int yypos478= G->pos, yythunkpos478= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z0-9_")) goto l477;
-  G->pos= yypos478; G->thunkpos= yythunkpos478;
+  {  int yypos448= G->pos, yythunkpos448= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z0-9_")) goto l447;
+  G->pos= yypos448; G->thunkpos= yythunkpos448;
   }  yyDo(G, yy_1_FuncTypeCore, G->begin, G->end, "yy_1_FuncTypeCore");
   yyprintf((stderr, "  ok   FuncTypeCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l477:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncTypeCore"));
+  l447:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncTypeCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10240,7 +9961,7 @@ YY_RULE(int) yy_TypeListCore(GREG *G)
   yyprintf((stderr, "\n"));
 
   return 1;
-  l479:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeListCore"));
+  l449:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeListCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10249,32 +9970,32 @@ YY_RULE(int) yy_TypeListCore(GREG *G)
 YY_RULE(int) yy_TypeList(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "TypeList"));
-  if (!yymatchChar(G, '(')) goto l480;
-  if (!yy_WS(G))  goto l480;
-  if (!yy_TypeListCore(G))  goto l480;
+  if (!yymatchChar(G, '(')) goto l450;
+  if (!yy_WS(G))  goto l450;
+  if (!yy_TypeListCore(G))  goto l450;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_Type(G))  goto l480;
+  if (!yy_Type(G))  goto l450;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_TypeList, G->begin, G->end, "yy_1_TypeList");
 
-  l481:;	
-  {  int yypos482= G->pos, yythunkpos482= G->thunkpos;  if (!yy_WS(G))  goto l482;
-  if (!yymatchChar(G, ',')) goto l482;
-  if (!yy_WS(G))  goto l482;
-  if (!yy_Type(G))  goto l482;
+  l451:;	
+  {  int yypos452= G->pos, yythunkpos452= G->thunkpos;  if (!yy_WS(G))  goto l452;
+  if (!yymatchChar(G, ',')) goto l452;
+  if (!yy_WS(G))  goto l452;
+  if (!yy_Type(G))  goto l452;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_TypeList, G->begin, G->end, "yy_2_TypeList");
-  goto l481;
-  l482:;	  G->pos= yypos482; G->thunkpos= yythunkpos482;
-  }  if (!yymatchChar(G, ')')) goto l480;
-  if (!yy__(G))  goto l480;
+  goto l451;
+  l452:;	  G->pos= yypos452; G->thunkpos= yythunkpos452;
+  }  if (!yymatchChar(G, ')')) goto l450;
+  if (!yy__(G))  goto l450;
   yyDo(G, yy_3_TypeList, G->begin, G->end, "yy_3_TypeList");
   yyprintf((stderr, "  ok   TypeList"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l480:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeList"));
+  l450:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeList"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10288,7 +10009,7 @@ YY_RULE(int) yy_Old(GREG *G)
   yyprintf((stderr, "\n"));
 
   return 1;
-  l483:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Old"));
+  l453:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Old"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10298,123 +10019,123 @@ YY_RULE(int) yy_GenericType(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "GenericType"));
 
-  {  int yypos485= G->pos, yythunkpos485= G->thunkpos;  if (!yy_Old(G))  goto l486;
+  {  int yypos455= G->pos, yythunkpos455= G->thunkpos;  if (!yy_Old(G))  goto l456;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy__(G))  goto l486;
-  if (!yy_IDENT(G))  goto l486;
+  if (!yy__(G))  goto l456;
+  if (!yy_IDENT(G))  goto l456;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_1_GenericType, G->begin, G->end, "yy_1_GenericType");
-  if (!yy__(G))  goto l486;
-  if (!yy_TypeBase(G))  goto l486;
+  if (!yy__(G))  goto l456;
+  if (!yy_TypeBase(G))  goto l456;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos487= G->pos, yythunkpos487= G->thunkpos;  if (!yy_FuncType(G))  goto l487;
-  goto l486;
-  l487:;	  G->pos= yypos487; G->thunkpos= yythunkpos487;
+  {  int yypos457= G->pos, yythunkpos457= G->thunkpos;  if (!yy_FuncType(G))  goto l457;
+  goto l456;
+  l457:;	  G->pos= yypos457; G->thunkpos= yythunkpos457;
   }  yyDo(G, yy_2_GenericType, G->begin, G->end, "yy_2_GenericType");
-  if (!yy__(G))  goto l486;
-  if (!yymatchChar(G, '<')) goto l486;
-  if (!yy__(G))  goto l486;
-  if (!yy_Type(G))  goto l486;
+  if (!yy__(G))  goto l456;
+  if (!yymatchChar(G, '<')) goto l456;
+  if (!yy__(G))  goto l456;
+  if (!yy_Type(G))  goto l456;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_GenericType, G->begin, G->end, "yy_3_GenericType");
 
-  l488:;	
-  {  int yypos489= G->pos, yythunkpos489= G->thunkpos;  if (!yy__(G))  goto l489;
-  if (!yymatchChar(G, ',')) goto l489;
-  if (!yy__(G))  goto l489;
-  if (!yy_Type(G))  goto l489;
+  l458:;	
+  {  int yypos459= G->pos, yythunkpos459= G->thunkpos;  if (!yy__(G))  goto l459;
+  if (!yymatchChar(G, ',')) goto l459;
+  if (!yy__(G))  goto l459;
+  if (!yy_Type(G))  goto l459;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_GenericType, G->begin, G->end, "yy_4_GenericType");
-  goto l488;
-  l489:;	  G->pos= yypos489; G->thunkpos= yythunkpos489;
-  }  if (!yy__(G))  goto l486;
-  if (!yymatchChar(G, '>')) goto l486;
-  if (!yy__(G))  goto l486;
+  goto l458;
+  l459:;	  G->pos= yypos459; G->thunkpos= yythunkpos459;
+  }  if (!yy__(G))  goto l456;
+  if (!yymatchChar(G, '>')) goto l456;
+  if (!yy__(G))  goto l456;
 
-  l490:;	
-  {  int yypos491= G->pos, yythunkpos491= G->thunkpos;
-  {  int yypos492= G->pos, yythunkpos492= G->thunkpos;  if (!yymatchChar(G, '*')) goto l493;
+  l460:;	
+  {  int yypos461= G->pos, yythunkpos461= G->thunkpos;
+  {  int yypos462= G->pos, yythunkpos462= G->thunkpos;  if (!yymatchChar(G, '*')) goto l463;
   yyDo(G, yy_5_GenericType, G->begin, G->end, "yy_5_GenericType");
-  goto l492;
-  l493:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;  if (!yymatchChar(G, '@')) goto l494;
+  goto l462;
+  l463:;	  G->pos= yypos462; G->thunkpos= yythunkpos462;  if (!yymatchChar(G, '@')) goto l464;
   yyDo(G, yy_6_GenericType, G->begin, G->end, "yy_6_GenericType");
-  goto l492;
-  l494:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;  if (!yymatchChar(G, '[')) goto l491;
-  if (!yy_WS(G))  goto l491;
+  goto l462;
+  l464:;	  G->pos= yypos462; G->thunkpos= yythunkpos462;  if (!yymatchChar(G, '[')) goto l461;
+  if (!yy_WS(G))  goto l461;
   yyDo(G, yy_7_GenericType, G->begin, G->end, "yy_7_GenericType");
-  if (!yy__(G))  goto l491;
+  if (!yy__(G))  goto l461;
 
-  {  int yypos495= G->pos, yythunkpos495= G->thunkpos;  if (!yy_Expr(G))  goto l495;
+  {  int yypos465= G->pos, yythunkpos465= G->thunkpos;  if (!yy_Expr(G))  goto l465;
   yyDo(G, yySet, -1, 0, "yySet");
-  goto l496;
-  l495:;	  G->pos= yypos495; G->thunkpos= yythunkpos495;
+  goto l466;
+  l465:;	  G->pos= yypos465; G->thunkpos= yythunkpos465;
   }
-  l496:;	  if (!yymatchChar(G, ']')) goto l491;
+  l466:;	  if (!yymatchChar(G, ']')) goto l461;
   yyDo(G, yy_8_GenericType, G->begin, G->end, "yy_8_GenericType");
 
   }
-  l492:;	  goto l490;
-  l491:;	  G->pos= yypos491; G->thunkpos= yythunkpos491;
-  }  if (!yy__(G))  goto l486;
+  l462:;	  goto l460;
+  l461:;	  G->pos= yypos461; G->thunkpos= yythunkpos461;
+  }  if (!yy__(G))  goto l456;
   yyDo(G, yy_9_GenericType, G->begin, G->end, "yy_9_GenericType");
-  goto l485;
-  l486:;	  G->pos= yypos485; G->thunkpos= yythunkpos485;  if (!yy_TypeBase(G))  goto l484;
+  goto l455;
+  l456:;	  G->pos= yypos455; G->thunkpos= yythunkpos455;  if (!yy_TypeBase(G))  goto l454;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l484;
-  if (!yymatchChar(G, '<')) goto l484;
-  if (!yy__(G))  goto l484;
-  if (!yy_Type(G))  goto l484;
+  if (!yy__(G))  goto l454;
+  if (!yymatchChar(G, '<')) goto l454;
+  if (!yy__(G))  goto l454;
+  if (!yy_Type(G))  goto l454;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_10_GenericType, G->begin, G->end, "yy_10_GenericType");
 
-  l497:;	
-  {  int yypos498= G->pos, yythunkpos498= G->thunkpos;  if (!yy__(G))  goto l498;
-  if (!yymatchChar(G, ',')) goto l498;
-  if (!yy__(G))  goto l498;
-  if (!yy_Type(G))  goto l498;
+  l467:;	
+  {  int yypos468= G->pos, yythunkpos468= G->thunkpos;  if (!yy__(G))  goto l468;
+  if (!yymatchChar(G, ',')) goto l468;
+  if (!yy__(G))  goto l468;
+  if (!yy_Type(G))  goto l468;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_11_GenericType, G->begin, G->end, "yy_11_GenericType");
-  goto l497;
-  l498:;	  G->pos= yypos498; G->thunkpos= yythunkpos498;
-  }  if (!yy__(G))  goto l484;
-  if (!yymatchChar(G, '>')) goto l484;
-  if (!yy__(G))  goto l484;
+  goto l467;
+  l468:;	  G->pos= yypos468; G->thunkpos= yythunkpos468;
+  }  if (!yy__(G))  goto l454;
+  if (!yymatchChar(G, '>')) goto l454;
+  if (!yy__(G))  goto l454;
 
-  l499:;	
-  {  int yypos500= G->pos, yythunkpos500= G->thunkpos;
-  {  int yypos501= G->pos, yythunkpos501= G->thunkpos;  if (!yymatchChar(G, '*')) goto l502;
+  l469:;	
+  {  int yypos470= G->pos, yythunkpos470= G->thunkpos;
+  {  int yypos471= G->pos, yythunkpos471= G->thunkpos;  if (!yymatchChar(G, '*')) goto l472;
   yyDo(G, yy_12_GenericType, G->begin, G->end, "yy_12_GenericType");
-  goto l501;
-  l502:;	  G->pos= yypos501; G->thunkpos= yythunkpos501;  if (!yymatchChar(G, '@')) goto l503;
+  goto l471;
+  l472:;	  G->pos= yypos471; G->thunkpos= yythunkpos471;  if (!yymatchChar(G, '@')) goto l473;
   yyDo(G, yy_13_GenericType, G->begin, G->end, "yy_13_GenericType");
-  goto l501;
-  l503:;	  G->pos= yypos501; G->thunkpos= yythunkpos501;  if (!yymatchChar(G, '[')) goto l500;
-  if (!yy_WS(G))  goto l500;
+  goto l471;
+  l473:;	  G->pos= yypos471; G->thunkpos= yythunkpos471;  if (!yymatchChar(G, '[')) goto l470;
+  if (!yy_WS(G))  goto l470;
   yyDo(G, yy_14_GenericType, G->begin, G->end, "yy_14_GenericType");
-  if (!yy__(G))  goto l500;
+  if (!yy__(G))  goto l470;
 
-  {  int yypos504= G->pos, yythunkpos504= G->thunkpos;  if (!yy_Expr(G))  goto l504;
+  {  int yypos474= G->pos, yythunkpos474= G->thunkpos;  if (!yy_Expr(G))  goto l474;
   yyDo(G, yySet, -1, 0, "yySet");
-  goto l505;
-  l504:;	  G->pos= yypos504; G->thunkpos= yythunkpos504;
+  goto l475;
+  l474:;	  G->pos= yypos474; G->thunkpos= yythunkpos474;
   }
-  l505:;	  if (!yymatchChar(G, ']')) goto l500;
+  l475:;	  if (!yymatchChar(G, ']')) goto l470;
   yyDo(G, yy_15_GenericType, G->begin, G->end, "yy_15_GenericType");
 
   }
-  l501:;	  goto l499;
-  l500:;	  G->pos= yypos500; G->thunkpos= yythunkpos500;
-  }  if (!yy__(G))  goto l484;
+  l471:;	  goto l469;
+  l470:;	  G->pos= yypos470; G->thunkpos= yythunkpos470;
+  }  if (!yy__(G))  goto l454;
   yyDo(G, yy_16_GenericType, G->begin, G->end, "yy_16_GenericType");
 
   }
-  l485:;	  yyprintf((stderr, "  ok   GenericType"));
+  l455:;	  yyprintf((stderr, "  ok   GenericType"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l484:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericType"));
+  l454:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericType"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10423,79 +10144,79 @@ YY_RULE(int) yy_GenericType(GREG *G)
 YY_RULE(int) yy_FuncType(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FuncType"));
-  if (!yy_FuncTypeCore(G))  goto l506;
+  if (!yy_FuncTypeCore(G))  goto l476;
   yyDo(G, yySet, -4, 0, "yySet");
 
-  {  int yypos507= G->pos, yythunkpos507= G->thunkpos;  if (!yy__(G))  goto l507;
-  if (!yymatchChar(G, '<')) goto l507;
-  if (!yy__(G))  goto l507;
-  if (!yy_IDENT(G))  goto l507;
+  {  int yypos477= G->pos, yythunkpos477= G->thunkpos;  if (!yy__(G))  goto l477;
+  if (!yymatchChar(G, '<')) goto l477;
+  if (!yy__(G))  goto l477;
+  if (!yy_IDENT(G))  goto l477;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_FuncType, G->begin, G->end, "yy_1_FuncType");
 
-  l509:;	
-  {  int yypos510= G->pos, yythunkpos510= G->thunkpos;  if (!yy__(G))  goto l510;
-  if (!yymatchChar(G, ',')) goto l510;
-  if (!yy__(G))  goto l510;
-  if (!yy_IDENT(G))  goto l510;
+  l479:;	
+  {  int yypos480= G->pos, yythunkpos480= G->thunkpos;  if (!yy__(G))  goto l480;
+  if (!yymatchChar(G, ',')) goto l480;
+  if (!yy__(G))  goto l480;
+  if (!yy_IDENT(G))  goto l480;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_2_FuncType, G->begin, G->end, "yy_2_FuncType");
-  goto l509;
-  l510:;	  G->pos= yypos510; G->thunkpos= yythunkpos510;
-  }  if (!yy__(G))  goto l507;
-  if (!yymatchChar(G, '>')) goto l507;
-  goto l508;
-  l507:;	  G->pos= yypos507; G->thunkpos= yythunkpos507;
+  goto l479;
+  l480:;	  G->pos= yypos480; G->thunkpos= yythunkpos480;
+  }  if (!yy__(G))  goto l477;
+  if (!yymatchChar(G, '>')) goto l477;
+  goto l478;
+  l477:;	  G->pos= yypos477; G->thunkpos= yythunkpos477;
   }
-  l508:;	
-  {  int yypos511= G->pos, yythunkpos511= G->thunkpos;  if (!yy__(G))  goto l511;
-  if (!yymatchChar(G, '(')) goto l511;
+  l478:;	
+  {  int yypos481= G->pos, yythunkpos481= G->thunkpos;  if (!yy__(G))  goto l481;
+  if (!yymatchChar(G, '(')) goto l481;
 
-  {  int yypos513= G->pos, yythunkpos513= G->thunkpos;  if (!yy__(G))  goto l513;
-  if (!yy_Type(G))  goto l513;
+  {  int yypos483= G->pos, yythunkpos483= G->thunkpos;  if (!yy__(G))  goto l483;
+  if (!yy_Type(G))  goto l483;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_FuncType, G->begin, G->end, "yy_3_FuncType");
 
-  l515:;	
-  {  int yypos516= G->pos, yythunkpos516= G->thunkpos;  if (!yymatchChar(G, ',')) goto l516;
-  if (!yy__(G))  goto l516;
-  if (!yy_Type(G))  goto l516;
+  l485:;	
+  {  int yypos486= G->pos, yythunkpos486= G->thunkpos;  if (!yymatchChar(G, ',')) goto l486;
+  if (!yy__(G))  goto l486;
+  if (!yy_Type(G))  goto l486;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_FuncType, G->begin, G->end, "yy_4_FuncType");
-  goto l515;
-  l516:;	  G->pos= yypos516; G->thunkpos= yythunkpos516;
-  }  goto l514;
-  l513:;	  G->pos= yypos513; G->thunkpos= yythunkpos513;
+  goto l485;
+  l486:;	  G->pos= yypos486; G->thunkpos= yythunkpos486;
+  }  goto l484;
+  l483:;	  G->pos= yypos483; G->thunkpos= yythunkpos483;
   }
-  l514:;	
-  {  int yypos517= G->pos, yythunkpos517= G->thunkpos;  if (!yymatchString(G, "...")) goto l517;
-  if (!yy__(G))  goto l517;
+  l484:;	
+  {  int yypos487= G->pos, yythunkpos487= G->thunkpos;  if (!yymatchString(G, "...")) goto l487;
+  if (!yy__(G))  goto l487;
   yyDo(G, yy_5_FuncType, G->begin, G->end, "yy_5_FuncType");
-  goto l518;
-  l517:;	  G->pos= yypos517; G->thunkpos= yythunkpos517;
+  goto l488;
+  l487:;	  G->pos= yypos487; G->thunkpos= yythunkpos487;
   }
-  l518:;	  if (!yy__(G))  goto l511;
-  if (!yymatchChar(G, ')')) goto l511;
-  goto l512;
-  l511:;	  G->pos= yypos511; G->thunkpos= yythunkpos511;
+  l488:;	  if (!yy__(G))  goto l481;
+  if (!yymatchChar(G, ')')) goto l481;
+  goto l482;
+  l481:;	  G->pos= yypos481; G->thunkpos= yythunkpos481;
   }
-  l512:;	
-  {  int yypos519= G->pos, yythunkpos519= G->thunkpos;  if (!yy__(G))  goto l519;
-  if (!yymatchString(G, "->")) goto l519;
-  if (!yy__(G))  goto l519;
-  if (!yy_Type(G))  goto l519;
+  l482:;	
+  {  int yypos489= G->pos, yythunkpos489= G->thunkpos;  if (!yy__(G))  goto l489;
+  if (!yymatchString(G, "->")) goto l489;
+  if (!yy__(G))  goto l489;
+  if (!yy_Type(G))  goto l489;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_FuncType, G->begin, G->end, "yy_6_FuncType");
-  goto l520;
-  l519:;	  G->pos= yypos519; G->thunkpos= yythunkpos519;
+  goto l490;
+  l489:;	  G->pos= yypos489; G->thunkpos= yythunkpos489;
   }
-  l520:;	  yyDo(G, yy_7_FuncType, G->begin, G->end, "yy_7_FuncType");
+  l490:;	  yyDo(G, yy_7_FuncType, G->begin, G->end, "yy_7_FuncType");
   yyprintf((stderr, "  ok   FuncType"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l506:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncType"));
+  l476:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FuncType"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10505,65 +10226,65 @@ YY_RULE(int) yy_TypeBase(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "TypeBase"));
 
-  {  int yypos522= G->pos, yythunkpos522= G->thunkpos;  if (!yy_FuncType(G))  goto l523;
-  goto l522;
-  l523:;	  G->pos= yypos522; G->thunkpos= yythunkpos522;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l521;  yyDo(G, yy_1_TypeBase, G->begin, G->end, "yy_1_TypeBase");
+  {  int yypos492= G->pos, yythunkpos492= G->thunkpos;  if (!yy_FuncType(G))  goto l493;
+  goto l492;
+  l493:;	  G->pos= yypos492; G->thunkpos= yythunkpos492;  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l491;  yyDo(G, yy_1_TypeBase, G->begin, G->end, "yy_1_TypeBase");
 
-  {  int yypos524= G->pos, yythunkpos524= G->thunkpos;  if (!yy_CONST_KW(G))  goto l524;
-  if (!yy__(G))  goto l524;
-  goto l525;
-  l524:;	  G->pos= yypos524; G->thunkpos= yythunkpos524;
+  {  int yypos494= G->pos, yythunkpos494= G->thunkpos;  if (!yy_CONST_KW(G))  goto l494;
+  if (!yy__(G))  goto l494;
+  goto l495;
+  l494:;	  G->pos= yypos494; G->thunkpos= yythunkpos494;
   }
-  l525:;	
-  l526:;	
-  {  int yypos527= G->pos, yythunkpos527= G->thunkpos;
-  {  int yypos528= G->pos, yythunkpos528= G->thunkpos;  if (!yymatchString(G, "unsigned")) goto l529;
+  l495:;	
+  l496:;	
+  {  int yypos497= G->pos, yythunkpos497= G->thunkpos;
+  {  int yypos498= G->pos, yythunkpos498= G->thunkpos;  if (!yymatchString(G, "unsigned")) goto l499;
   yyDo(G, yy_2_TypeBase, G->begin, G->end, "yy_2_TypeBase");
-  if (!yy__(G))  goto l529;
-  goto l528;
-  l529:;	  G->pos= yypos528; G->thunkpos= yythunkpos528;  if (!yymatchString(G, "signed")) goto l530;
+  if (!yy__(G))  goto l499;
+  goto l498;
+  l499:;	  G->pos= yypos498; G->thunkpos= yythunkpos498;  if (!yymatchString(G, "signed")) goto l500;
   yyDo(G, yy_3_TypeBase, G->begin, G->end, "yy_3_TypeBase");
-  if (!yy__(G))  goto l530;
-  goto l528;
-  l530:;	  G->pos= yypos528; G->thunkpos= yythunkpos528;  if (!yymatchString(G, "long")) goto l531;
+  if (!yy__(G))  goto l500;
+  goto l498;
+  l500:;	  G->pos= yypos498; G->thunkpos= yythunkpos498;  if (!yymatchString(G, "long")) goto l501;
 
-  {  int yypos532= G->pos, yythunkpos532= G->thunkpos;  if (!yy__(G))  goto l531;
+  {  int yypos502= G->pos, yythunkpos502= G->thunkpos;  if (!yy__(G))  goto l501;
 
-  {  int yypos533= G->pos, yythunkpos533= G->thunkpos;  if (!yymatchString(G, "long")) goto l534;
-  goto l533;
-  l534:;	  G->pos= yypos533; G->thunkpos= yythunkpos533;  if (!yymatchString(G, "double")) goto l535;
-  goto l533;
-  l535:;	  G->pos= yypos533; G->thunkpos= yythunkpos533;  if (!yymatchString(G, "int")) goto l531;
+  {  int yypos503= G->pos, yythunkpos503= G->thunkpos;  if (!yymatchString(G, "long")) goto l504;
+  goto l503;
+  l504:;	  G->pos= yypos503; G->thunkpos= yythunkpos503;  if (!yymatchString(G, "double")) goto l505;
+  goto l503;
+  l505:;	  G->pos= yypos503; G->thunkpos= yythunkpos503;  if (!yymatchString(G, "int")) goto l501;
 
   }
-  l533:;	  G->pos= yypos532; G->thunkpos= yythunkpos532;
+  l503:;	  G->pos= yypos502; G->thunkpos= yythunkpos502;
   }  yyDo(G, yy_4_TypeBase, G->begin, G->end, "yy_4_TypeBase");
-  if (!yy__(G))  goto l531;
-  goto l528;
-  l531:;	  G->pos= yypos528; G->thunkpos= yythunkpos528;  if (!yymatchString(G, "struct")) goto l536;
+  if (!yy__(G))  goto l501;
+  goto l498;
+  l501:;	  G->pos= yypos498; G->thunkpos= yythunkpos498;  if (!yymatchString(G, "struct")) goto l506;
   yyDo(G, yy_5_TypeBase, G->begin, G->end, "yy_5_TypeBase");
-  if (!yy__(G))  goto l536;
-  goto l528;
-  l536:;	  G->pos= yypos528; G->thunkpos= yythunkpos528;  if (!yymatchString(G, "union")) goto l527;
+  if (!yy__(G))  goto l506;
+  goto l498;
+  l506:;	  G->pos= yypos498; G->thunkpos= yythunkpos498;  if (!yymatchString(G, "union")) goto l497;
   yyDo(G, yy_6_TypeBase, G->begin, G->end, "yy_6_TypeBase");
-  if (!yy__(G))  goto l527;
+  if (!yy__(G))  goto l497;
 
   }
-  l528:;	  if (!yy__(G))  goto l527;
-  goto l526;
-  l527:;	  G->pos= yypos527; G->thunkpos= yythunkpos527;
-  }  if (!yy_IDENT(G))  goto l521;
+  l498:;	  if (!yy__(G))  goto l497;
+  goto l496;
+  l497:;	  G->pos= yypos497; G->thunkpos= yythunkpos497;
+  }  if (!yy_IDENT(G))  goto l491;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_7_TypeBase, G->begin, G->end, "yy_7_TypeBase");
-  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l521;  yyDo(G, yy_8_TypeBase, G->begin, G->end, "yy_8_TypeBase");
+  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l491;  yyDo(G, yy_8_TypeBase, G->begin, G->end, "yy_8_TypeBase");
 
   }
-  l522:;	  yyprintf((stderr, "  ok   TypeBase"));
+  l492:;	  yyprintf((stderr, "  ok   TypeBase"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l521:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeBase"));
+  l491:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TypeBase"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10571,13 +10292,13 @@ YY_RULE(int) yy_TypeBase(GREG *G)
 }
 YY_RULE(int) yy_SET_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "SET_KW"));
-  if (!yymatchString(G, "set")) goto l537;
+  if (!yymatchString(G, "set")) goto l507;
   yyprintf((stderr, "  ok   SET_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l537:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SET_KW"));
+  l507:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SET_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10585,13 +10306,13 @@ YY_RULE(int) yy_SET_KW(GREG *G)
 }
 YY_RULE(int) yy_GET_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "GET_KW"));
-  if (!yymatchString(G, "get")) goto l538;
+  if (!yymatchString(G, "get")) goto l508;
   yyprintf((stderr, "  ok   GET_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l538:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GET_KW"));
+  l508:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GET_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10600,59 +10321,59 @@ YY_RULE(int) yy_GET_KW(GREG *G)
 YY_RULE(int) yy_PropertyDeclSetter(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclSetter"));
-  if (!yy_OocDoc(G))  goto l539;
+  if (!yy_OocDoc(G))  goto l509;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclSetter, G->begin, G->end, "yy_1_PropertyDeclSetter");
-  if (!yy_WS(G))  goto l539;
-  if (!yy_SET_KW(G))  goto l539;
-  if (!yy_WS(G))  goto l539;
+  if (!yy_WS(G))  goto l509;
+  if (!yy_SET_KW(G))  goto l509;
+  if (!yy_WS(G))  goto l509;
 
-  {  int yypos540= G->pos, yythunkpos540= G->thunkpos;  if (!yy_COLON(G))  goto l540;
-  if (!yy_WS(G))  goto l540;
-  if (!yy_ExternName(G))  goto l540;
+  {  int yypos510= G->pos, yythunkpos510= G->thunkpos;  if (!yy_COLON(G))  goto l510;
+  if (!yy_WS(G))  goto l510;
+  if (!yy_ExternName(G))  goto l510;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_PropertyDeclSetter, G->begin, G->end, "yy_2_PropertyDeclSetter");
-  goto l541;
-  l540:;	  G->pos= yypos540; G->thunkpos= yythunkpos540;
+  goto l511;
+  l510:;	  G->pos= yypos510; G->thunkpos= yythunkpos510;
   }
-  l541:;	
-  {  int yypos542= G->pos, yythunkpos542= G->thunkpos;  if (!yymatchChar(G, '(')) goto l542;
-  if (!yy_WS(G))  goto l542;
+  l511:;	
+  {  int yypos512= G->pos, yythunkpos512= G->thunkpos;  if (!yymatchChar(G, '(')) goto l512;
+  if (!yy_WS(G))  goto l512;
 
-  {  int yypos544= G->pos, yythunkpos544= G->thunkpos;  if (!yy_IDENT(G))  goto l545;
+  {  int yypos514= G->pos, yythunkpos514= G->thunkpos;  if (!yy_IDENT(G))  goto l515;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclSetter, G->begin, G->end, "yy_3_PropertyDeclSetter");
-  goto l544;
-  l545:;	  G->pos= yypos544; G->thunkpos= yythunkpos544;  if (!yy_ASS(G))  goto l542;
-  if (!yy_IDENT(G))  goto l542;
+  goto l514;
+  l515:;	  G->pos= yypos514; G->thunkpos= yythunkpos514;  if (!yy_ASS(G))  goto l512;
+  if (!yy_IDENT(G))  goto l512;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l542;
+  if (!yy__(G))  goto l512;
   yyDo(G, yy_4_PropertyDeclSetter, G->begin, G->end, "yy_4_PropertyDeclSetter");
 
   }
-  l544:;	  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected ')' to close property setter argument list.\n"); ; } goto l542; }
-  if (!yy_WS(G))  goto l542;
-  if (!yymatchChar(G, '{')) goto l542;
+  l514:;	  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Expected ')' to close property setter argument list.\n"); ; } goto l512; }
+  if (!yy_WS(G))  goto l512;
+  if (!yymatchChar(G, '{')) goto l512;
 
-  l546:;	
-  {  int yypos547= G->pos, yythunkpos547= G->thunkpos;  if (!yy_WS(G))  goto l547;
-  if (!yy_Stmt(G))  goto l547;
+  l516:;	
+  {  int yypos517= G->pos, yythunkpos517= G->thunkpos;  if (!yy_WS(G))  goto l517;
+  if (!yy_Stmt(G))  goto l517;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_5_PropertyDeclSetter, G->begin, G->end, "yy_5_PropertyDeclSetter");
-  if (!yy_WS(G))  goto l547;
-  goto l546;
-  l547:;	  G->pos= yypos547; G->thunkpos= yythunkpos547;
-  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '??<' to close property setter body.\n"); ; } goto l542; }
-  goto l543;
-  l542:;	  G->pos= yypos542; G->thunkpos= yythunkpos542;
+  if (!yy_WS(G))  goto l517;
+  goto l516;
+  l517:;	  G->pos= yypos517; G->thunkpos= yythunkpos517;
+  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '??<' to close property setter body.\n"); ; } goto l512; }
+  goto l513;
+  l512:;	  G->pos= yypos512; G->thunkpos= yythunkpos512;
   }
-  l543:;	  yyDo(G, yy_6_PropertyDeclSetter, G->begin, G->end, "yy_6_PropertyDeclSetter");
+  l513:;	  yyDo(G, yy_6_PropertyDeclSetter, G->begin, G->end, "yy_6_PropertyDeclSetter");
   yyprintf((stderr, "  ok   PropertyDeclSetter"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l539:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclSetter"));
+  l509:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclSetter"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10661,43 +10382,43 @@ YY_RULE(int) yy_PropertyDeclSetter(GREG *G)
 YY_RULE(int) yy_PropertyDeclGetter(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclGetter"));
-  if (!yy_OocDoc(G))  goto l548;
+  if (!yy_OocDoc(G))  goto l518;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclGetter, G->begin, G->end, "yy_1_PropertyDeclGetter");
-  if (!yy_WS(G))  goto l548;
-  if (!yy_GET_KW(G))  goto l548;
-  if (!yy_WS(G))  goto l548;
+  if (!yy_WS(G))  goto l518;
+  if (!yy_GET_KW(G))  goto l518;
+  if (!yy_WS(G))  goto l518;
 
-  {  int yypos549= G->pos, yythunkpos549= G->thunkpos;  if (!yy_COLON(G))  goto l549;
-  if (!yy_WS(G))  goto l549;
-  if (!yy_ExternName(G))  goto l549;
+  {  int yypos519= G->pos, yythunkpos519= G->thunkpos;  if (!yy_COLON(G))  goto l519;
+  if (!yy_WS(G))  goto l519;
+  if (!yy_ExternName(G))  goto l519;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_PropertyDeclGetter, G->begin, G->end, "yy_2_PropertyDeclGetter");
-  goto l550;
-  l549:;	  G->pos= yypos549; G->thunkpos= yythunkpos549;
+  goto l520;
+  l519:;	  G->pos= yypos519; G->thunkpos= yythunkpos519;
   }
-  l550:;	
-  {  int yypos551= G->pos, yythunkpos551= G->thunkpos;  if (!yymatchChar(G, '{')) goto l551;
+  l520:;	
+  {  int yypos521= G->pos, yythunkpos521= G->thunkpos;  if (!yymatchChar(G, '{')) goto l521;
 
-  l553:;	
-  {  int yypos554= G->pos, yythunkpos554= G->thunkpos;  if (!yy_WS(G))  goto l554;
-  if (!yy_Stmt(G))  goto l554;
+  l523:;	
+  {  int yypos524= G->pos, yythunkpos524= G->thunkpos;  if (!yy_WS(G))  goto l524;
+  if (!yy_Stmt(G))  goto l524;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclGetter, G->begin, G->end, "yy_3_PropertyDeclGetter");
-  if (!yy_WS(G))  goto l554;
-  goto l553;
-  l554:;	  G->pos= yypos554; G->thunkpos= yythunkpos554;
-  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property getter\n"); ; } goto l551; }
-  goto l552;
-  l551:;	  G->pos= yypos551; G->thunkpos= yythunkpos551;
+  if (!yy_WS(G))  goto l524;
+  goto l523;
+  l524:;	  G->pos= yypos524; G->thunkpos= yythunkpos524;
+  }  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property getter\n"); ; } goto l521; }
+  goto l522;
+  l521:;	  G->pos= yypos521; G->thunkpos= yythunkpos521;
   }
-  l552:;	  yyDo(G, yy_4_PropertyDeclGetter, G->begin, G->end, "yy_4_PropertyDeclGetter");
+  l522:;	  yyDo(G, yy_4_PropertyDeclGetter, G->begin, G->end, "yy_4_PropertyDeclGetter");
   yyprintf((stderr, "  ok   PropertyDeclGetter"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l548:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclGetter"));
+  l518:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclGetter"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10705,14 +10426,14 @@ YY_RULE(int) yy_PropertyDeclGetter(GREG *G)
 }
 YY_RULE(int) yy_PROPASS_DECL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PROPASS_DECL"));
-  if (!yymatchString(G, "::=")) goto l555;
-  if (!yy__(G))  goto l555;
+  if (!yymatchString(G, "::=")) goto l525;
+  if (!yy__(G))  goto l525;
   yyprintf((stderr, "  ok   PROPASS_DECL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l555:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROPASS_DECL"));
+  l525:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROPASS_DECL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10721,15 +10442,15 @@ YY_RULE(int) yy_PROPASS_DECL(GREG *G)
 YY_RULE(int) yy_PropertyDeclCore(GREG *G)
 {  yyprintfv((stderr, "%s\n", "PropertyDeclCore"));
 
-  l557:;	
-  {  int yypos558= G->pos, yythunkpos558= G->thunkpos;
-  {  int yypos559= G->pos, yythunkpos559= G->thunkpos;  if (!yy_PropertyDeclGetter(G))  goto l560;
-  goto l559;
-  l560:;	  G->pos= yypos559; G->thunkpos= yythunkpos559;  if (!yy_PropertyDeclSetter(G))  goto l558;
+  l527:;	
+  {  int yypos528= G->pos, yythunkpos528= G->thunkpos;
+  {  int yypos529= G->pos, yythunkpos529= G->thunkpos;  if (!yy_PropertyDeclGetter(G))  goto l530;
+  goto l529;
+  l530:;	  G->pos= yypos529; G->thunkpos= yythunkpos529;  if (!yy_PropertyDeclSetter(G))  goto l528;
 
   }
-  l559:;	  goto l557;
-  l558:;	  G->pos= yypos558; G->thunkpos= yythunkpos558;
+  l529:;	  goto l527;
+  l528:;	  G->pos= yypos528; G->thunkpos= yythunkpos528;
   }  yyprintf((stderr, "  ok   PropertyDeclCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -10739,37 +10460,37 @@ YY_RULE(int) yy_PropertyDeclCore(GREG *G)
 YY_RULE(int) yy_ConventionalPropertyDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ConventionalPropertyDecl"));
-  if (!yy_OocDoc(G))  goto l561;
+  if (!yy_OocDoc(G))  goto l531;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_IDENT(G))  goto l561;
+  if (!yy_IDENT(G))  goto l531;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_ConventionalPropertyDecl, G->begin, G->end, "yy_1_ConventionalPropertyDecl");
-  if (!yy_WS(G))  goto l561;
-  if (!yy_COLON(G))  goto l561;
-  if (!yy_WS(G))  goto l561;
+  if (!yy_WS(G))  goto l531;
+  if (!yy_COLON(G))  goto l531;
+  if (!yy_WS(G))  goto l531;
 
-  {  int yypos562= G->pos, yythunkpos562= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l562;
+  {  int yypos532= G->pos, yythunkpos532= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l532;
   yyDo(G, yy_2_ConventionalPropertyDecl, G->begin, G->end, "yy_2_ConventionalPropertyDecl");
-  goto l563;
-  l562:;	  G->pos= yypos562; G->thunkpos= yythunkpos562;
+  goto l533;
+  l532:;	  G->pos= yypos532; G->thunkpos= yythunkpos532;
   }
-  l563:;	  if (!yy_WS(G))  goto l561;
-  if (!yy_Type(G))  goto l561;
+  l533:;	  if (!yy_WS(G))  goto l531;
+  if (!yy_Type(G))  goto l531;
   yyDo(G, yy_3_ConventionalPropertyDecl, G->begin, G->end, "yy_3_ConventionalPropertyDecl");
-  if (!yy_WS(G))  goto l561;
-  if (!yymatchChar(G, '{')) goto l561;
-  if (!yy_WS(G))  goto l561;
-  if (!yy_PropertyDeclCore(G))  goto l561;
-  if (!yy_WS(G))  goto l561;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property decl!\n"); ; } goto l561; }
-  if (!yy_WS(G))  goto l561;
+  if (!yy_WS(G))  goto l531;
+  if (!yymatchChar(G, '{')) goto l531;
+  if (!yy_WS(G))  goto l531;
+  if (!yy_PropertyDeclCore(G))  goto l531;
+  if (!yy_WS(G))  goto l531;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_BRACK, "Expected '"_CSBRACK"' to close property decl!\n"); ; } goto l531; }
+  if (!yy_WS(G))  goto l531;
   yyDo(G, yy_4_ConventionalPropertyDecl, G->begin, G->end, "yy_4_ConventionalPropertyDecl");
   yyprintf((stderr, "  ok   ConventionalPropertyDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l561:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalPropertyDecl"));
+  l531:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalPropertyDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10778,35 +10499,35 @@ YY_RULE(int) yy_ConventionalPropertyDecl(GREG *G)
 YY_RULE(int) yy_PropertyDeclFromExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDeclFromExpr"));
-  if (!yy_OocDoc(G))  goto l564;
+  if (!yy_OocDoc(G))  goto l534;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy_IDENT(G))  goto l564;
+  if (!yy_IDENT(G))  goto l534;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_1_PropertyDeclFromExpr, G->begin, G->end, "yy_1_PropertyDeclFromExpr");
-  if (!yy__(G))  goto l564;
-  if (!yy_PROPASS_DECL(G))  goto l564;
+  if (!yy__(G))  goto l534;
+  if (!yy_PROPASS_DECL(G))  goto l534;
 
-  l565:;	
-  {  int yypos566= G->pos, yythunkpos566= G->thunkpos;  if (!yy__(G))  goto l566;
-  if (!yy_STATIC_KW(G))  goto l566;
+  l535:;	
+  {  int yypos536= G->pos, yythunkpos536= G->thunkpos;  if (!yy__(G))  goto l536;
+  if (!yy_STATIC_KW(G))  goto l536;
   yyDo(G, yy_2_PropertyDeclFromExpr, G->begin, G->end, "yy_2_PropertyDeclFromExpr");
 
-  {  int yypos567= G->pos, yythunkpos567= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l566;
-  G->pos= yypos567; G->thunkpos= yythunkpos567;
-  }  goto l565;
-  l566:;	  G->pos= yypos566; G->thunkpos= yythunkpos566;
-  }  if (!yy__(G))  goto l564;
-  if (!yy_Expr(G))  goto l564;
+  {  int yypos537= G->pos, yythunkpos537= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l536;
+  G->pos= yypos537; G->thunkpos= yythunkpos537;
+  }  goto l535;
+  l536:;	  G->pos= yypos536; G->thunkpos= yythunkpos536;
+  }  if (!yy__(G))  goto l534;
+  if (!yy_Expr(G))  goto l534;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_PropertyDeclFromExpr, G->begin, G->end, "yy_3_PropertyDeclFromExpr");
-  if (!yy__(G))  goto l564;
+  if (!yy__(G))  goto l534;
   yyDo(G, yy_4_PropertyDeclFromExpr, G->begin, G->end, "yy_4_PropertyDeclFromExpr");
   yyprintf((stderr, "  ok   PropertyDeclFromExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l564:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclFromExpr"));
+  l534:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDeclFromExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10816,105 +10537,88 @@ YY_RULE(int) yy_ConventionalVarDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ConventionalVarDecl"));
   yyDo(G, yy_1_ConventionalVarDecl, G->begin, G->end, "yy_1_ConventionalVarDecl");
-  if (!yy_OocDoc(G))  goto l568;
+  if (!yy_OocDoc(G))  goto l538;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_IDENT(G))  goto l568;
+  if (!yy_IDENT(G))  goto l538;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_ConventionalVarDecl, G->begin, G->end, "yy_2_ConventionalVarDecl");
 
-  {  int yypos569= G->pos, yythunkpos569= G->thunkpos;  if (!yy__(G))  goto l569;
-  if (!yy_ASS(G))  goto l569;
-  if (!yy__(G))  goto l569;
-  if (!yy_Expr(G))  goto l569;
+  {  int yypos539= G->pos, yythunkpos539= G->thunkpos;  if (!yy__(G))  goto l539;
+  if (!yy_ASS(G))  goto l539;
+  if (!yy__(G))  goto l539;
+  if (!yy_Expr(G))  goto l539;
   yyDo(G, yy_3_ConventionalVarDecl, G->begin, G->end, "yy_3_ConventionalVarDecl");
-  goto l570;
-  l569:;	  G->pos= yypos569; G->thunkpos= yythunkpos569;
+  goto l540;
+  l539:;	  G->pos= yypos539; G->thunkpos= yythunkpos539;
   }
-  l570:;	
-  l571:;	
-  {  int yypos572= G->pos, yythunkpos572= G->thunkpos;  if (!yy__(G))  goto l572;
-  if (!yymatchChar(G, ',')) goto l572;
-  if (!yy_OocDoc(G))  goto l572;
+  l540:;	
+  l541:;	
+  {  int yypos542= G->pos, yythunkpos542= G->thunkpos;  if (!yy__(G))  goto l542;
+  if (!yymatchChar(G, ',')) goto l542;
+  if (!yy_OocDoc(G))  goto l542;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_WS(G))  goto l572;
-  if (!yy_IDENT(G))  goto l572;
+  if (!yy_WS(G))  goto l542;
+  if (!yy_IDENT(G))  goto l542;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_4_ConventionalVarDecl, G->begin, G->end, "yy_4_ConventionalVarDecl");
 
-  {  int yypos573= G->pos, yythunkpos573= G->thunkpos;  if (!yy__(G))  goto l573;
-  if (!yy_ASS(G))  goto l573;
-  if (!yy__(G))  goto l573;
-  if (!yy_Expr(G))  goto l573;
+  {  int yypos543= G->pos, yythunkpos543= G->thunkpos;  if (!yy__(G))  goto l543;
+  if (!yy_ASS(G))  goto l543;
+  if (!yy__(G))  goto l543;
+  if (!yy_Expr(G))  goto l543;
   yyDo(G, yy_5_ConventionalVarDecl, G->begin, G->end, "yy_5_ConventionalVarDecl");
-  goto l574;
-  l573:;	  G->pos= yypos573; G->thunkpos= yythunkpos573;
+  goto l544;
+  l543:;	  G->pos= yypos543; G->thunkpos= yythunkpos543;
   }
-  l574:;	  if (!yy__(G))  goto l572;
-  goto l571;
-  l572:;	  G->pos= yypos572; G->thunkpos= yythunkpos572;
-  }  if (!yy_WS(G))  goto l568;
-  if (!yy_COLON(G))  goto l568;
-  if (!yy_WS(G))  goto l568;
+  l544:;	  if (!yy__(G))  goto l542;
+  goto l541;
+  l542:;	  G->pos= yypos542; G->thunkpos= yythunkpos542;
+  }  if (!yy_WS(G))  goto l538;
+  if (!yy_COLON(G))  goto l538;
+  if (!yy_WS(G))  goto l538;
 
-  l575:;	
-  {  int yypos576= G->pos, yythunkpos576= G->thunkpos;  if (!yy__(G))  goto l576;
+  l545:;	
+  {  int yypos546= G->pos, yythunkpos546= G->thunkpos;  if (!yy__(G))  goto l546;
 
-  {  int yypos577= G->pos, yythunkpos577= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l578;
+  {  int yypos547= G->pos, yythunkpos547= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l548;
   yyDo(G, yy_6_ConventionalVarDecl, G->begin, G->end, "yy_6_ConventionalVarDecl");
-  goto l577;
-  l578:;	  G->pos= yypos577; G->thunkpos= yythunkpos577;  if (!yy_CONST_KW(G))  goto l579;
+  goto l547;
+  l548:;	  G->pos= yypos547; G->thunkpos= yythunkpos547;  if (!yy_CONST_KW(G))  goto l549;
   yyDo(G, yy_7_ConventionalVarDecl, G->begin, G->end, "yy_7_ConventionalVarDecl");
-  goto l577;
-  l579:;	  G->pos= yypos577; G->thunkpos= yythunkpos577;  if (!yy_PROTO_KW(G))  goto l580;
+  goto l547;
+  l549:;	  G->pos= yypos547; G->thunkpos= yythunkpos547;  if (!yy_PROTO_KW(G))  goto l550;
   yyDo(G, yy_8_ConventionalVarDecl, G->begin, G->end, "yy_8_ConventionalVarDecl");
-  goto l577;
-  l580:;	  G->pos= yypos577; G->thunkpos= yythunkpos577;  if (!yy_ExternName(G))  goto l581;
+  goto l547;
+  l550:;	  G->pos= yypos547; G->thunkpos= yythunkpos547;  if (!yy_ExternName(G))  goto l551;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_9_ConventionalVarDecl, G->begin, G->end, "yy_9_ConventionalVarDecl");
-  goto l577;
-  l581:;	  G->pos= yypos577; G->thunkpos= yythunkpos577;  if (!yy_UnmangledName(G))  goto l582;
+  goto l547;
+  l551:;	  G->pos= yypos547; G->thunkpos= yythunkpos547;  if (!yy_UnmangledName(G))  goto l546;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_ConventionalVarDecl, G->begin, G->end, "yy_10_ConventionalVarDecl");
-  goto l577;
-  l582:;	  G->pos= yypos577; G->thunkpos= yythunkpos577;  if (!yy_FORCEDMALLOC_KW(G))  goto l576;
+
+  }
+  l547:;	  goto l545;
+  l546:;	  G->pos= yypos546; G->thunkpos= yythunkpos546;
+  }  if (!yy_WS(G))  goto l538;
+  if (!yy_Type(G))  goto l538;
   yyDo(G, yy_11_ConventionalVarDecl, G->begin, G->end, "yy_11_ConventionalVarDecl");
 
-  }
-  l577:;	  goto l575;
-  l576:;	  G->pos= yypos576; G->thunkpos= yythunkpos576;
-  }  if (!yy_WS(G))  goto l568;
-  if (!yy_Type(G))  goto l568;
+  {  int yypos552= G->pos, yythunkpos552= G->thunkpos;  if (!yy__(G))  goto l552;
+  if (!yy_ASS(G))  goto l552;
+  if (!yy__(G))  goto l552;
+  if (!yy_Expr(G))  goto l552;
   yyDo(G, yy_12_ConventionalVarDecl, G->begin, G->end, "yy_12_ConventionalVarDecl");
-
-  {  int yypos583= G->pos, yythunkpos583= G->thunkpos;  if (!yy__(G))  goto l583;
-  if (!yy_ASS(G))  goto l583;
-  if (!yy__(G))  goto l583;
-  if (!yy_Expr(G))  goto l583;
-  yyDo(G, yy_13_ConventionalVarDecl, G->begin, G->end, "yy_13_ConventionalVarDecl");
-  goto l584;
-  l583:;	  G->pos= yypos583; G->thunkpos= yythunkpos583;
+  goto l553;
+  l552:;	  G->pos= yypos552; G->thunkpos= yythunkpos552;
   }
-  l584:;	  yyDo(G, yy_14_ConventionalVarDecl, G->begin, G->end, "yy_14_ConventionalVarDecl");
+  l553:;	  yyDo(G, yy_13_ConventionalVarDecl, G->begin, G->end, "yy_13_ConventionalVarDecl");
   yyprintf((stderr, "  ok   ConventionalVarDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l568:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalVarDecl"));
-  yyprintfvGcontext;
-  yyprintfv((stderr, "\n"));
-
-  return 0;
-}
-YY_RULE(int) yy_FORCEDMALLOC_KW(GREG *G)
-{  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FORCEDMALLOC_KW"));
-  if (!yymatchString(G, "__onheap__")) goto l585;
-  yyprintf((stderr, "  ok   FORCEDMALLOC_KW"));
-  yyprintfGcontext;
-  yyprintf((stderr, "\n"));
-
-  return 1;
-  l585:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FORCEDMALLOC_KW"));
+  l538:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ConventionalVarDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10922,13 +10626,13 @@ YY_RULE(int) yy_FORCEDMALLOC_KW(GREG *G)
 }
 YY_RULE(int) yy_CONST_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CONST_KW"));
-  if (!yymatchString(G, "const")) goto l586;
+  if (!yymatchString(G, "const")) goto l554;
   yyprintf((stderr, "  ok   CONST_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l586:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONST_KW"));
+  l554:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CONST_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10936,14 +10640,14 @@ YY_RULE(int) yy_CONST_KW(GREG *G)
 }
 YY_RULE(int) yy_ASS_DECL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS_DECL"));
-  if (!yymatchString(G, ":=")) goto l587;
-  if (!yy__(G))  goto l587;
+  if (!yymatchString(G, ":=")) goto l555;
+  if (!yy__(G))  goto l555;
   yyprintf((stderr, "  ok   ASS_DECL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l587:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DECL"));
+  l555:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS_DECL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10952,41 +10656,41 @@ YY_RULE(int) yy_ASS_DECL(GREG *G)
 YY_RULE(int) yy_Tuple(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Tuple"));
-  if (!yymatchChar(G, '(')) goto l588;
+  if (!yymatchChar(G, '(')) goto l556;
   yyDo(G, yy_1_Tuple, G->begin, G->end, "yy_1_Tuple");
-  if (!yy_WS(G))  goto l588;
+  if (!yy_WS(G))  goto l556;
   yyDo(G, yy_2_Tuple, G->begin, G->end, "yy_2_Tuple");
 
-  {  int yypos589= G->pos, yythunkpos589= G->thunkpos;  if (!yy_Expr(G))  goto l589;
+  {  int yypos557= G->pos, yythunkpos557= G->thunkpos;  if (!yy_Expr(G))  goto l557;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_Tuple, G->begin, G->end, "yy_3_Tuple");
 
-  l591:;	
-  {  int yypos592= G->pos, yythunkpos592= G->thunkpos;
-  {  int yypos593= G->pos, yythunkpos593= G->thunkpos;  if (!yy_WS(G))  goto l594;
-  if (!yymatchChar(G, ',')) goto l594;
-  goto l593;
-  l594:;	  G->pos= yypos593; G->thunkpos= yythunkpos593;  if (!yy_EOL(G))  goto l592;
+  l559:;	
+  {  int yypos560= G->pos, yythunkpos560= G->thunkpos;
+  {  int yypos561= G->pos, yythunkpos561= G->thunkpos;  if (!yy_WS(G))  goto l562;
+  if (!yymatchChar(G, ',')) goto l562;
+  goto l561;
+  l562:;	  G->pos= yypos561; G->thunkpos= yythunkpos561;  if (!yy_EOL(G))  goto l560;
 
   }
-  l593:;	  if (!yy_WS(G))  goto l592;
-  if (!yy_Expr(G))  goto l592;
+  l561:;	  if (!yy_WS(G))  goto l560;
+  if (!yy_Expr(G))  goto l560;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_Tuple, G->begin, G->end, "yy_4_Tuple");
-  goto l591;
-  l592:;	  G->pos= yypos592; G->thunkpos= yythunkpos592;
-  }  goto l590;
-  l589:;	  G->pos= yypos589; G->thunkpos= yythunkpos589;
+  goto l559;
+  l560:;	  G->pos= yypos560; G->thunkpos= yythunkpos560;
+  }  goto l558;
+  l557:;	  G->pos= yypos557; G->thunkpos= yythunkpos557;
   }
-  l590:;	  if (!yy_WS(G))  goto l588;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed tuple! Expected ')' to close.\n"); ; } goto l588; }
+  l558:;	  if (!yy_WS(G))  goto l556;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_CLOSING_SQUAR, "Malformed tuple! Expected ')' to close.\n"); ; } goto l556; }
   yyDo(G, yy_5_Tuple, G->begin, G->end, "yy_5_Tuple");
   yyprintf((stderr, "  ok   Tuple"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l588:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Tuple"));
+  l556:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Tuple"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -10995,54 +10699,51 @@ YY_RULE(int) yy_Tuple(GREG *G)
 YY_RULE(int) yy_VarDeclFromExpr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VarDeclFromExpr"));
-  if (!yy_OocDoc(G))  goto l595;
+  if (!yy_OocDoc(G))  goto l563;
   yyDo(G, yySet, -4, 0, "yySet");
 
-  {  int yypos596= G->pos, yythunkpos596= G->thunkpos;  if (!yy_IDENT(G))  goto l597;
+  {  int yypos564= G->pos, yythunkpos564= G->thunkpos;  if (!yy_IDENT(G))  goto l565;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_VarDeclFromExpr, G->begin, G->end, "yy_1_VarDeclFromExpr");
-  goto l596;
-  l597:;	  G->pos= yypos596; G->thunkpos= yythunkpos596;  if (!yy_Tuple(G))  goto l595;
+  goto l564;
+  l565:;	  G->pos= yypos564; G->thunkpos= yythunkpos564;  if (!yy_Tuple(G))  goto l563;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_VarDeclFromExpr, G->begin, G->end, "yy_2_VarDeclFromExpr");
 
   }
-  l596:;	  if (!yy__(G))  goto l595;
-  if (!yy_ASS_DECL(G))  goto l595;
+  l564:;	  if (!yy__(G))  goto l563;
+  if (!yy_ASS_DECL(G))  goto l563;
 
-  l598:;	
-  {  int yypos599= G->pos, yythunkpos599= G->thunkpos;  if (!yy__(G))  goto l599;
+  l566:;	
+  {  int yypos567= G->pos, yythunkpos567= G->thunkpos;  if (!yy__(G))  goto l567;
 
-  {  int yypos600= G->pos, yythunkpos600= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l601;
+  {  int yypos568= G->pos, yythunkpos568= G->thunkpos;  if (!yy_STATIC_KW(G))  goto l569;
   yyDo(G, yy_3_VarDeclFromExpr, G->begin, G->end, "yy_3_VarDeclFromExpr");
-  goto l600;
-  l601:;	  G->pos= yypos600; G->thunkpos= yythunkpos600;  if (!yy_CONST_KW(G))  goto l602;
+  goto l568;
+  l569:;	  G->pos= yypos568; G->thunkpos= yythunkpos568;  if (!yy_CONST_KW(G))  goto l570;
   yyDo(G, yy_4_VarDeclFromExpr, G->begin, G->end, "yy_4_VarDeclFromExpr");
-  goto l600;
-  l602:;	  G->pos= yypos600; G->thunkpos= yythunkpos600;  if (!yy_PROTO_KW(G))  goto l603;
+  goto l568;
+  l570:;	  G->pos= yypos568; G->thunkpos= yythunkpos568;  if (!yy_PROTO_KW(G))  goto l567;
   yyDo(G, yy_5_VarDeclFromExpr, G->begin, G->end, "yy_5_VarDeclFromExpr");
-  goto l600;
-  l603:;	  G->pos= yypos600; G->thunkpos= yythunkpos600;  if (!yy_FORCEDMALLOC_KW(G))  goto l599;
-  yyDo(G, yy_6_VarDeclFromExpr, G->begin, G->end, "yy_6_VarDeclFromExpr");
 
   }
-  l600:;	
-  {  int yypos604= G->pos, yythunkpos604= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l599;
-  G->pos= yypos604; G->thunkpos= yythunkpos604;
-  }  goto l598;
-  l599:;	  G->pos= yypos599; G->thunkpos= yythunkpos599;
-  }  if (!yy__(G))  goto l595;
-  if (!yy_Expr(G))  goto l595;
+  l568:;	
+  {  int yypos571= G->pos, yythunkpos571= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\377\377\377\377\377\377\000\374\001\000\000\170\001\000\000\370\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377", "^A-Za-z_0-9")) goto l567;
+  G->pos= yypos571; G->thunkpos= yythunkpos571;
+  }  goto l566;
+  l567:;	  G->pos= yypos567; G->thunkpos= yythunkpos567;
+  }  if (!yy__(G))  goto l563;
+  if (!yy_Expr(G))  goto l563;
   yyDo(G, yySet, -1, 0, "yySet");
+  yyDo(G, yy_6_VarDeclFromExpr, G->begin, G->end, "yy_6_VarDeclFromExpr");
+  if (!yy__(G))  goto l563;
   yyDo(G, yy_7_VarDeclFromExpr, G->begin, G->end, "yy_7_VarDeclFromExpr");
-  if (!yy__(G))  goto l595;
-  yyDo(G, yy_8_VarDeclFromExpr, G->begin, G->end, "yy_8_VarDeclFromExpr");
   yyprintf((stderr, "  ok   VarDeclFromExpr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l595:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VarDeclFromExpr"));
+  l563:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VarDeclFromExpr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11050,13 +10751,13 @@ YY_RULE(int) yy_VarDeclFromExpr(GREG *G)
 }
 YY_RULE(int) yy_UNMANGLED_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "UNMANGLED_KW"));
-  if (!yymatchString(G, "unmangled")) goto l605;
+  if (!yymatchString(G, "unmangled")) goto l572;
   yyprintf((stderr, "  ok   UNMANGLED_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l605:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UNMANGLED_KW"));
+  l572:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UNMANGLED_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11064,13 +10765,13 @@ YY_RULE(int) yy_UNMANGLED_KW(GREG *G)
 }
 YY_RULE(int) yy_EXTERN_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXTERN_KW"));
-  if (!yymatchString(G, "extern")) goto l606;
+  if (!yymatchString(G, "extern")) goto l573;
   yyprintf((stderr, "  ok   EXTERN_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l606:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTERN_KW"));
+  l573:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTERN_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11078,13 +10779,13 @@ YY_RULE(int) yy_EXTERN_KW(GREG *G)
 }
 YY_RULE(int) yy_INTERFACE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INTERFACE_KW"));
-  if (!yymatchString(G, "interface")) goto l607;
+  if (!yymatchString(G, "interface")) goto l574;
   yyprintf((stderr, "  ok   INTERFACE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l607:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTERFACE_KW"));
+  l574:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTERFACE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11092,13 +10793,13 @@ YY_RULE(int) yy_INTERFACE_KW(GREG *G)
 }
 YY_RULE(int) yy_COVER_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "COVER_KW"));
-  if (!yymatchString(G, "cover")) goto l608;
+  if (!yymatchString(G, "cover")) goto l575;
   yyprintf((stderr, "  ok   COVER_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l608:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COVER_KW"));
+  l575:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COVER_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11106,18 +10807,18 @@ YY_RULE(int) yy_COVER_KW(GREG *G)
 }
 YY_RULE(int) yy_PLUS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PLUS"));
-  if (!yymatchChar(G, '+')) goto l609;
+  if (!yymatchChar(G, '+')) goto l576;
 
-  {  int yypos610= G->pos, yythunkpos610= G->thunkpos;  if (!yymatchChar(G, '=')) goto l610;
-  goto l609;
-  l610:;	  G->pos= yypos610; G->thunkpos= yythunkpos610;
-  }  if (!yy__(G))  goto l609;
+  {  int yypos577= G->pos, yythunkpos577= G->thunkpos;  if (!yymatchChar(G, '=')) goto l577;
+  goto l576;
+  l577:;	  G->pos= yypos577; G->thunkpos= yythunkpos577;
+  }  if (!yy__(G))  goto l576;
   yyprintf((stderr, "  ok   PLUS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l609:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PLUS"));
+  l576:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PLUS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11125,18 +10826,18 @@ YY_RULE(int) yy_PLUS(GREG *G)
 }
 YY_RULE(int) yy_STAR(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "STAR"));
-  if (!yymatchChar(G, '*')) goto l611;
+  if (!yymatchChar(G, '*')) goto l578;
 
-  {  int yypos612= G->pos, yythunkpos612= G->thunkpos;  if (!yymatchChar(G, '=')) goto l612;
-  goto l611;
-  l612:;	  G->pos= yypos612; G->thunkpos= yythunkpos612;
-  }  if (!yy__(G))  goto l611;
+  {  int yypos579= G->pos, yythunkpos579= G->thunkpos;  if (!yymatchChar(G, '=')) goto l579;
+  goto l578;
+  l579:;	  G->pos= yypos579; G->thunkpos= yythunkpos579;
+  }  if (!yy__(G))  goto l578;
   yyprintf((stderr, "  ok   STAR"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l611:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STAR"));
+  l578:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STAR"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11146,38 +10847,38 @@ YY_RULE(int) yy_Expr(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Expr"));
 
-  {  int yypos614= G->pos, yythunkpos614= G->thunkpos;  if (!yy_VariableDecl(G))  goto l615;
+  {  int yypos581= G->pos, yythunkpos581= G->thunkpos;  if (!yy_VariableDecl(G))  goto l582;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy__(G))  goto l615;
-  goto l614;
-  l615:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_DoubleArrow(G))  goto l616;
+  if (!yy__(G))  goto l582;
+  goto l581;
+  l582:;	  G->pos= yypos581; G->thunkpos= yythunkpos581;  if (!yy_DoubleArrow(G))  goto l583;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l616;
-  goto l614;
-  l616:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_BinaryOperation(G))  goto l617;
+  if (!yy__(G))  goto l583;
+  goto l581;
+  l583:;	  G->pos= yypos581; G->thunkpos= yythunkpos581;  if (!yy_BinaryOperation(G))  goto l584;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l617;
+  if (!yy__(G))  goto l584;
 
-  l618:;	
-  {  int yypos619= G->pos, yythunkpos619= G->thunkpos;  if (!yy__(G))  goto l619;
-  if (!yymatchChar(G, '.')) goto l619;
+  l585:;	
+  {  int yypos586= G->pos, yythunkpos586= G->thunkpos;  if (!yy__(G))  goto l586;
+  if (!yymatchChar(G, '.')) goto l586;
   yyDo(G, yy_1_Expr, G->begin, G->end, "yy_1_Expr");
-  if (!yy_WS(G))  goto l619;
-  if (!yy_FunctionCall(G))  goto l619;
+  if (!yy_WS(G))  goto l586;
+  if (!yy_FunctionCall(G))  goto l586;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_Expr, G->begin, G->end, "yy_2_Expr");
-  goto l618;
-  l619:;	  G->pos= yypos619; G->thunkpos= yythunkpos619;
-  }  goto l614;
-  l617:;	  G->pos= yypos614; G->thunkpos= yythunkpos614;  if (!yy_AnonymousFunctionDecl(G))  goto l613;
+  goto l585;
+  l586:;	  G->pos= yypos586; G->thunkpos= yythunkpos586;
+  }  goto l581;
+  l584:;	  G->pos= yypos581; G->thunkpos= yythunkpos581;  if (!yy_AnonymousFunctionDecl(G))  goto l580;
 
   }
-  l614:;	  yyprintf((stderr, "  ok   Expr"));
+  l581:;	  yyprintf((stderr, "  ok   Expr"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l613:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Expr"));
+  l580:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Expr"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11186,36 +10887,36 @@ YY_RULE(int) yy_Expr(GREG *G)
 YY_RULE(int) yy_EnumElement(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "EnumElement"));
-  if (!yy_OocDoc(G))  goto l620;
+  if (!yy_OocDoc(G))  goto l587;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l620;
+  if (!yy_IDENT(G))  goto l587;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_EnumElement, G->begin, G->end, "yy_1_EnumElement");
-  if (!yy__(G))  goto l620;
+  if (!yy__(G))  goto l587;
 
-  {  int yypos621= G->pos, yythunkpos621= G->thunkpos;
-  {  int yypos623= G->pos, yythunkpos623= G->thunkpos;  if (!yy_ASS(G))  goto l624;
-  if (!yy_Expr(G))  goto l624;
+  {  int yypos588= G->pos, yythunkpos588= G->thunkpos;
+  {  int yypos590= G->pos, yythunkpos590= G->thunkpos;  if (!yy_ASS(G))  goto l591;
+  if (!yy_Expr(G))  goto l591;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_EnumElement, G->begin, G->end, "yy_2_EnumElement");
-  goto l623;
-  l624:;	  G->pos= yypos623; G->thunkpos= yythunkpos623;  if (!yy_COLON(G))  goto l621;
-  if (!yy__(G))  goto l621;
-  if (!yy_ExternName(G))  goto l621;
+  goto l590;
+  l591:;	  G->pos= yypos590; G->thunkpos= yythunkpos590;  if (!yy_COLON(G))  goto l588;
+  if (!yy__(G))  goto l588;
+  if (!yy_ExternName(G))  goto l588;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_EnumElement, G->begin, G->end, "yy_3_EnumElement");
 
   }
-  l623:;	  goto l622;
-  l621:;	  G->pos= yypos621; G->thunkpos= yythunkpos621;
+  l590:;	  goto l589;
+  l588:;	  G->pos= yypos588; G->thunkpos= yythunkpos588;
   }
-  l622:;	  yyDo(G, yy_4_EnumElement, G->begin, G->end, "yy_4_EnumElement");
+  l589:;	  yyDo(G, yy_4_EnumElement, G->begin, G->end, "yy_4_EnumElement");
   yyprintf((stderr, "  ok   EnumElement"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l620:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumElement"));
+  l587:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumElement"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11225,28 +10926,28 @@ YY_RULE(int) yy_IntLiteral(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IntLiteral"));
 
-  {  int yypos626= G->pos, yythunkpos626= G->thunkpos;  if (!yy_OCT_LIT(G))  goto l627;
+  {  int yypos593= G->pos, yythunkpos593= G->thunkpos;  if (!yy_OCT_LIT(G))  goto l594;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy__(G))  goto l627;
+  if (!yy__(G))  goto l594;
   yyDo(G, yy_1_IntLiteral, G->begin, G->end, "yy_1_IntLiteral");
-  goto l626;
-  l627:;	  G->pos= yypos626; G->thunkpos= yythunkpos626;  if (!yy_HEX_LIT(G))  goto l628;
+  goto l593;
+  l594:;	  G->pos= yypos593; G->thunkpos= yythunkpos593;  if (!yy_HEX_LIT(G))  goto l595;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l628;
+  if (!yy__(G))  goto l595;
   yyDo(G, yy_2_IntLiteral, G->begin, G->end, "yy_2_IntLiteral");
-  goto l626;
-  l628:;	  G->pos= yypos626; G->thunkpos= yythunkpos626;  if (!yy_DEC_LIT(G))  goto l625;
+  goto l593;
+  l595:;	  G->pos= yypos593; G->thunkpos= yythunkpos593;  if (!yy_DEC_LIT(G))  goto l592;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l625;
+  if (!yy__(G))  goto l592;
   yyDo(G, yy_3_IntLiteral, G->begin, G->end, "yy_3_IntLiteral");
 
   }
-  l626:;	  yyprintf((stderr, "  ok   IntLiteral"));
+  l593:;	  yyprintf((stderr, "  ok   IntLiteral"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l625:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IntLiteral"));
+  l592:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IntLiteral"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11255,19 +10956,19 @@ YY_RULE(int) yy_IntLiteral(GREG *G)
 YY_RULE(int) yy_EnumIncrementOper(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EnumIncrementOper"));
 
-  {  int yypos630= G->pos, yythunkpos630= G->thunkpos;  if (!yy_STAR(G))  goto l631;
+  {  int yypos597= G->pos, yythunkpos597= G->thunkpos;  if (!yy_STAR(G))  goto l598;
   yyDo(G, yy_1_EnumIncrementOper, G->begin, G->end, "yy_1_EnumIncrementOper");
-  goto l630;
-  l631:;	  G->pos= yypos630; G->thunkpos= yythunkpos630;  if (!yy_PLUS(G))  goto l629;
+  goto l597;
+  l598:;	  G->pos= yypos597; G->thunkpos= yythunkpos597;  if (!yy_PLUS(G))  goto l596;
   yyDo(G, yy_2_EnumIncrementOper, G->begin, G->end, "yy_2_EnumIncrementOper");
 
   }
-  l630:;	  yyprintf((stderr, "  ok   EnumIncrementOper"));
+  l597:;	  yyprintf((stderr, "  ok   EnumIncrementOper"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l629:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumIncrementOper"));
+  l596:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumIncrementOper"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11275,13 +10976,13 @@ YY_RULE(int) yy_EnumIncrementOper(GREG *G)
 }
 YY_RULE(int) yy_FROM_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FROM_KW"));
-  if (!yymatchString(G, "from")) goto l632;
+  if (!yymatchString(G, "from")) goto l599;
   yyprintf((stderr, "  ok   FROM_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l632:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FROM_KW"));
+  l599:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FROM_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11289,13 +10990,13 @@ YY_RULE(int) yy_FROM_KW(GREG *G)
 }
 YY_RULE(int) yy_ENUM_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ENUM_KW"));
-  if (!yymatchString(G, "enum")) goto l633;
+  if (!yymatchString(G, "enum")) goto l600;
   yyprintf((stderr, "  ok   ENUM_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l633:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ENUM_KW"));
+  l600:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ENUM_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11303,13 +11004,13 @@ YY_RULE(int) yy_ENUM_KW(GREG *G)
 }
 YY_RULE(int) yy_IMPLEMENTS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IMPLEMENTS_KW"));
-  if (!yymatchString(G, "implements")) goto l634;
+  if (!yymatchString(G, "implements")) goto l601;
   yyprintf((stderr, "  ok   IMPLEMENTS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l634:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPLEMENTS_KW"));
+  l601:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPLEMENTS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11317,13 +11018,13 @@ YY_RULE(int) yy_IMPLEMENTS_KW(GREG *G)
 }
 YY_RULE(int) yy_EXTENDS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EXTENDS_KW"));
-  if (!yymatchString(G, "extends")) goto l635;
+  if (!yymatchString(G, "extends")) goto l602;
   yyprintf((stderr, "  ok   EXTENDS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l635:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTENDS_KW"));
+  l602:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EXTENDS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11331,13 +11032,13 @@ YY_RULE(int) yy_EXTENDS_KW(GREG *G)
 }
 YY_RULE(int) yy_CLASS_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLASS_KW"));
-  if (!yymatchString(G, "class")) goto l636;
+  if (!yymatchString(G, "class")) goto l603;
   yyprintf((stderr, "  ok   CLASS_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l636:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLASS_KW"));
+  l603:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLASS_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11346,17 +11047,17 @@ YY_RULE(int) yy_CLASS_KW(GREG *G)
 YY_RULE(int) yy_ASS(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ASS"));
 
-  {  int yypos638= G->pos, yythunkpos638= G->thunkpos;  if (!yy_DOUBLE_ARROW(G))  goto l638;
-  goto l637;
-  l638:;	  G->pos= yypos638; G->thunkpos= yythunkpos638;
-  }  if (!yymatchChar(G, '=')) goto l637;
-  if (!yy__(G))  goto l637;
+  {  int yypos605= G->pos, yythunkpos605= G->thunkpos;  if (!yy_DOUBLE_ARROW(G))  goto l605;
+  goto l604;
+  l605:;	  G->pos= yypos605; G->thunkpos= yythunkpos605;
+  }  if (!yymatchChar(G, '=')) goto l604;
+  if (!yy__(G))  goto l604;
   yyprintf((stderr, "  ok   ASS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l637:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS"));
+  l604:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ASS"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11365,16 +11066,16 @@ YY_RULE(int) yy_ASS(GREG *G)
 YY_RULE(int) yy_DOT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DOT"));
 
-  {  int yypos640= G->pos, yythunkpos640= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l640;
-  goto l639;
-  l640:;	  G->pos= yypos640; G->thunkpos= yythunkpos640;
-  }  if (!yymatchChar(G, '.')) goto l639;
+  {  int yypos607= G->pos, yythunkpos607= G->thunkpos;  if (!yy_DOUBLE_DOT(G))  goto l607;
+  goto l606;
+  l607:;	  G->pos= yypos607; G->thunkpos= yythunkpos607;
+  }  if (!yymatchChar(G, '.')) goto l606;
   yyprintf((stderr, "  ok   DOT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l639:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOT"));
+  l606:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DOT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11384,137 +11085,137 @@ YY_RULE(int) yy_Type(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 6, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Type"));
 
-  {  int yypos642= G->pos, yythunkpos642= G->thunkpos;  if (!yy_TypeList(G))  goto l643;
+  {  int yypos609= G->pos, yythunkpos609= G->thunkpos;  if (!yy_TypeList(G))  goto l610;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_1_Type, G->begin, G->end, "yy_1_Type");
-  goto l642;
-  l643:;	  G->pos= yypos642; G->thunkpos= yythunkpos642;  if (!yy_TypeBase(G))  goto l644;
+  goto l609;
+  l610:;	  G->pos= yypos609; G->thunkpos= yythunkpos609;  if (!yy_TypeBase(G))  goto l611;
   yyDo(G, yySet, -5, 0, "yySet");
 
-  {  int yypos645= G->pos, yythunkpos645= G->thunkpos;  if (!yy__(G))  goto l645;
-  if (!yymatchChar(G, '<')) goto l645;
-  if (!yy__(G))  goto l645;
-  if (!yy_Type(G))  goto l645;
+  {  int yypos612= G->pos, yythunkpos612= G->thunkpos;  if (!yy__(G))  goto l612;
+  if (!yymatchChar(G, '<')) goto l612;
+  if (!yy__(G))  goto l612;
+  if (!yy_Type(G))  goto l612;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_2_Type, G->begin, G->end, "yy_2_Type");
 
-  l647:;	
-  {  int yypos648= G->pos, yythunkpos648= G->thunkpos;  if (!yy__(G))  goto l648;
-  if (!yymatchChar(G, ',')) goto l648;
-  if (!yy__(G))  goto l648;
-  if (!yy_Type(G))  goto l648;
+  l614:;	
+  {  int yypos615= G->pos, yythunkpos615= G->thunkpos;  if (!yy__(G))  goto l615;
+  if (!yymatchChar(G, ',')) goto l615;
+  if (!yy__(G))  goto l615;
+  if (!yy_Type(G))  goto l615;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_3_Type, G->begin, G->end, "yy_3_Type");
-  goto l647;
-  l648:;	  G->pos= yypos648; G->thunkpos= yythunkpos648;
-  }  if (!yy__(G))  goto l645;
-  if (!yymatchChar(G, '>')) goto l645;
-  goto l646;
-  l645:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;
+  goto l614;
+  l615:;	  G->pos= yypos615; G->thunkpos= yythunkpos615;
+  }  if (!yy__(G))  goto l612;
+  if (!yymatchChar(G, '>')) goto l612;
+  goto l613;
+  l612:;	  G->pos= yypos612; G->thunkpos= yythunkpos612;
   }
-  l646:;	  if (!yy__(G))  goto l644;
+  l613:;	  if (!yy__(G))  goto l611;
 
-  l649:;	
-  {  int yypos650= G->pos, yythunkpos650= G->thunkpos;
-  {  int yypos651= G->pos, yythunkpos651= G->thunkpos;  if (!yy_STAR(G))  goto l652;
+  l616:;	
+  {  int yypos617= G->pos, yythunkpos617= G->thunkpos;
+  {  int yypos618= G->pos, yythunkpos618= G->thunkpos;  if (!yy_STAR(G))  goto l619;
   yyDo(G, yy_4_Type, G->begin, G->end, "yy_4_Type");
-  goto l651;
-  l652:;	  G->pos= yypos651; G->thunkpos= yythunkpos651;  if (!yymatchChar(G, '@')) goto l653;
+  goto l618;
+  l619:;	  G->pos= yypos618; G->thunkpos= yythunkpos618;  if (!yymatchChar(G, '@')) goto l620;
   yyDo(G, yy_5_Type, G->begin, G->end, "yy_5_Type");
-  goto l651;
-  l653:;	  G->pos= yypos651; G->thunkpos= yythunkpos651;  if (!yymatchChar(G, '[')) goto l650;
-  if (!yy_WS(G))  goto l650;
+  goto l618;
+  l620:;	  G->pos= yypos618; G->thunkpos= yythunkpos618;  if (!yymatchChar(G, '[')) goto l617;
+  if (!yy_WS(G))  goto l617;
   yyDo(G, yy_6_Type, G->begin, G->end, "yy_6_Type");
-  if (!yy__(G))  goto l650;
+  if (!yy__(G))  goto l617;
 
-  {  int yypos654= G->pos, yythunkpos654= G->thunkpos;  if (!yy_Expr(G))  goto l654;
+  {  int yypos621= G->pos, yythunkpos621= G->thunkpos;  if (!yy_Expr(G))  goto l621;
   yyDo(G, yySet, -3, 0, "yySet");
-  goto l655;
-  l654:;	  G->pos= yypos654; G->thunkpos= yythunkpos654;
+  goto l622;
+  l621:;	  G->pos= yypos621; G->thunkpos= yythunkpos621;
   }
-  l655:;	  if (!yymatchChar(G, ']')) goto l650;
+  l622:;	  if (!yymatchChar(G, ']')) goto l617;
   yyDo(G, yy_7_Type, G->begin, G->end, "yy_7_Type");
 
   }
-  l651:;	  goto l649;
-  l650:;	  G->pos= yypos650; G->thunkpos= yythunkpos650;
-  }  if (!yy__(G))  goto l644;
+  l618:;	  goto l616;
+  l617:;	  G->pos= yypos617; G->thunkpos= yythunkpos617;
+  }  if (!yy__(G))  goto l611;
   yyDo(G, yy_8_Type, G->begin, G->end, "yy_8_Type");
-  goto l642;
-  l644:;	  G->pos= yypos642; G->thunkpos= yythunkpos642;  if (!yymatchChar(G, '(')) goto l641;
-  if (!yy_Old(G))  goto l641;
+  goto l609;
+  l611:;	  G->pos= yypos609; G->thunkpos= yythunkpos609;  if (!yymatchChar(G, '(')) goto l608;
+  if (!yy_Old(G))  goto l608;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l641;
-  if (!yy_IDENT(G))  goto l641;
+  if (!yy__(G))  goto l608;
+  if (!yy_IDENT(G))  goto l608;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_9_Type, G->begin, G->end, "yy_9_Type");
-  if (!yy__(G))  goto l641;
-  if (!yy_TypeBase(G))  goto l641;
+  if (!yy__(G))  goto l608;
+  if (!yy_TypeBase(G))  goto l608;
   yyDo(G, yySet, -5, 0, "yySet");
 
-  {  int yypos656= G->pos, yythunkpos656= G->thunkpos;  if (!yy_FuncType(G))  goto l656;
-  goto l641;
-  l656:;	  G->pos= yypos656; G->thunkpos= yythunkpos656;
+  {  int yypos623= G->pos, yythunkpos623= G->thunkpos;  if (!yy_FuncType(G))  goto l623;
+  goto l608;
+  l623:;	  G->pos= yypos623; G->thunkpos= yythunkpos623;
   }  yyDo(G, yy_10_Type, G->begin, G->end, "yy_10_Type");
 
-  {  int yypos657= G->pos, yythunkpos657= G->thunkpos;  if (!yy__(G))  goto l657;
-  if (!yymatchChar(G, '<')) goto l657;
-  if (!yy__(G))  goto l657;
-  if (!yy_Type(G))  goto l657;
+  {  int yypos624= G->pos, yythunkpos624= G->thunkpos;  if (!yy__(G))  goto l624;
+  if (!yymatchChar(G, '<')) goto l624;
+  if (!yy__(G))  goto l624;
+  if (!yy_Type(G))  goto l624;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_11_Type, G->begin, G->end, "yy_11_Type");
 
-  l659:;	
-  {  int yypos660= G->pos, yythunkpos660= G->thunkpos;  if (!yy__(G))  goto l660;
-  if (!yymatchChar(G, ',')) goto l660;
-  if (!yy__(G))  goto l660;
-  if (!yy_Type(G))  goto l660;
+  l626:;	
+  {  int yypos627= G->pos, yythunkpos627= G->thunkpos;  if (!yy__(G))  goto l627;
+  if (!yymatchChar(G, ',')) goto l627;
+  if (!yy__(G))  goto l627;
+  if (!yy_Type(G))  goto l627;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_12_Type, G->begin, G->end, "yy_12_Type");
-  goto l659;
-  l660:;	  G->pos= yypos660; G->thunkpos= yythunkpos660;
-  }  if (!yy__(G))  goto l657;
-  if (!yymatchChar(G, '>')) goto l657;
-  goto l658;
-  l657:;	  G->pos= yypos657; G->thunkpos= yythunkpos657;
+  goto l626;
+  l627:;	  G->pos= yypos627; G->thunkpos= yythunkpos627;
+  }  if (!yy__(G))  goto l624;
+  if (!yymatchChar(G, '>')) goto l624;
+  goto l625;
+  l624:;	  G->pos= yypos624; G->thunkpos= yythunkpos624;
   }
-  l658:;	  if (!yy__(G))  goto l641;
+  l625:;	  if (!yy__(G))  goto l608;
 
-  l661:;	
-  {  int yypos662= G->pos, yythunkpos662= G->thunkpos;
-  {  int yypos663= G->pos, yythunkpos663= G->thunkpos;  if (!yy_STAR(G))  goto l664;
+  l628:;	
+  {  int yypos629= G->pos, yythunkpos629= G->thunkpos;
+  {  int yypos630= G->pos, yythunkpos630= G->thunkpos;  if (!yy_STAR(G))  goto l631;
   yyDo(G, yy_13_Type, G->begin, G->end, "yy_13_Type");
-  goto l663;
-  l664:;	  G->pos= yypos663; G->thunkpos= yythunkpos663;  if (!yymatchChar(G, '@')) goto l665;
+  goto l630;
+  l631:;	  G->pos= yypos630; G->thunkpos= yythunkpos630;  if (!yymatchChar(G, '@')) goto l632;
   yyDo(G, yy_14_Type, G->begin, G->end, "yy_14_Type");
-  goto l663;
-  l665:;	  G->pos= yypos663; G->thunkpos= yythunkpos663;  if (!yymatchChar(G, '[')) goto l662;
-  if (!yy_WS(G))  goto l662;
+  goto l630;
+  l632:;	  G->pos= yypos630; G->thunkpos= yythunkpos630;  if (!yymatchChar(G, '[')) goto l629;
+  if (!yy_WS(G))  goto l629;
   yyDo(G, yy_15_Type, G->begin, G->end, "yy_15_Type");
-  if (!yy__(G))  goto l662;
+  if (!yy__(G))  goto l629;
 
-  {  int yypos666= G->pos, yythunkpos666= G->thunkpos;  if (!yy_Expr(G))  goto l666;
+  {  int yypos633= G->pos, yythunkpos633= G->thunkpos;  if (!yy_Expr(G))  goto l633;
   yyDo(G, yySet, -3, 0, "yySet");
-  goto l667;
-  l666:;	  G->pos= yypos666; G->thunkpos= yythunkpos666;
+  goto l634;
+  l633:;	  G->pos= yypos633; G->thunkpos= yythunkpos633;
   }
-  l667:;	  if (!yymatchChar(G, ']')) goto l662;
+  l634:;	  if (!yymatchChar(G, ']')) goto l629;
   yyDo(G, yy_16_Type, G->begin, G->end, "yy_16_Type");
 
   }
-  l663:;	  goto l661;
-  l662:;	  G->pos= yypos662; G->thunkpos= yythunkpos662;
-  }  if (!yy__(G))  goto l641;
+  l630:;	  goto l628;
+  l629:;	  G->pos= yypos629; G->thunkpos= yythunkpos629;
+  }  if (!yy__(G))  goto l608;
   yyDo(G, yy_17_Type, G->begin, G->end, "yy_17_Type");
-  if (!yymatchChar(G, ')')) goto l641;
+  if (!yymatchChar(G, ')')) goto l608;
 
   }
-  l642:;	  yyprintf((stderr, "  ok   Type"));
+  l609:;	  yyprintf((stderr, "  ok   Type"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 6, 0, "yyPop");
   return 1;
-  l641:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Type"));
+  l608:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Type"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11522,13 +11223,13 @@ YY_RULE(int) yy_Type(GREG *G)
 }
 YY_RULE(int) yy_R_ARROW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "R_ARROW"));
-  if (!yymatchString(G, "->")) goto l668;
+  if (!yymatchString(G, "->")) goto l635;
   yyprintf((stderr, "  ok   R_ARROW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l668:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "R_ARROW"));
+  l635:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "R_ARROW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11538,45 +11239,45 @@ YY_RULE(int) yy_Argument(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Argument"));
 
-  {  int yypos670= G->pos, yythunkpos670= G->thunkpos;  if (!yy_DOT(G))  goto l671;
-  if (!yy_IDENT(G))  goto l671;
+  {  int yypos637= G->pos, yythunkpos637= G->thunkpos;  if (!yy_DOT(G))  goto l638;
+  if (!yy_IDENT(G))  goto l638;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy__(G))  goto l671;
+  if (!yy__(G))  goto l638;
   yyDo(G, yy_1_Argument, G->begin, G->end, "yy_1_Argument");
-  goto l670;
-  l671:;	  G->pos= yypos670; G->thunkpos= yythunkpos670;  if (!yy_ASS(G))  goto l672;
-  if (!yy_IDENT(G))  goto l672;
+  goto l637;
+  l638:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yy_ASS(G))  goto l639;
+  if (!yy_IDENT(G))  goto l639;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy__(G))  goto l672;
+  if (!yy__(G))  goto l639;
   yyDo(G, yy_2_Argument, G->begin, G->end, "yy_2_Argument");
-  goto l670;
-  l672:;	  G->pos= yypos670; G->thunkpos= yythunkpos670;  if (!yy_VariableDecl(G))  goto l673;
+  goto l637;
+  l639:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yy_VariableDecl(G))  goto l640;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_3_Argument, G->begin, G->end, "yy_3_Argument");
-  goto l670;
-  l673:;	  G->pos= yypos670; G->thunkpos= yythunkpos670;  if (!yy_IDENT(G))  goto l674;
+  goto l637;
+  l640:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yy_IDENT(G))  goto l641;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l674;
-  if (!yymatchChar(G, ':')) goto l674;
-  if (!yy__(G))  goto l674;
-  if (!yymatchString(G, "...")) goto l674;
-  if (!yy__(G))  goto l674;
+  if (!yy__(G))  goto l641;
+  if (!yymatchChar(G, ':')) goto l641;
+  if (!yy__(G))  goto l641;
+  if (!yymatchString(G, "...")) goto l641;
+  if (!yy__(G))  goto l641;
   yyDo(G, yy_4_Argument, G->begin, G->end, "yy_4_Argument");
-  goto l670;
-  l674:;	  G->pos= yypos670; G->thunkpos= yythunkpos670;  if (!yy_Type(G))  goto l675;
+  goto l637;
+  l641:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yy_Type(G))  goto l642;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_5_Argument, G->begin, G->end, "yy_5_Argument");
-  goto l670;
-  l675:;	  G->pos= yypos670; G->thunkpos= yythunkpos670;  if (!yymatchString(G, "...")) goto l669;
+  goto l637;
+  l642:;	  G->pos= yypos637; G->thunkpos= yythunkpos637;  if (!yymatchString(G, "...")) goto l636;
   yyDo(G, yy_6_Argument, G->begin, G->end, "yy_6_Argument");
 
   }
-  l670:;	  yyprintf((stderr, "  ok   Argument"));
+  l637:;	  yyprintf((stderr, "  ok   Argument"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l669:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Argument"));
+  l636:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Argument"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11585,13 +11286,13 @@ YY_RULE(int) yy_Argument(GREG *G)
 YY_RULE(int) yy_AnonymousFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "AnonymousFunctionDecl"));
   yyDo(G, yy_1_AnonymousFunctionDecl, G->begin, G->end, "yy_1_AnonymousFunctionDecl");
-  if (!yy_FunctionDeclCore(G))  goto l676;
+  if (!yy_FunctionDeclCore(G))  goto l643;
   yyprintf((stderr, "  ok   AnonymousFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l676:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "AnonymousFunctionDecl"));
+  l643:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "AnonymousFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11600,30 +11301,30 @@ YY_RULE(int) yy_AnonymousFunctionDecl(GREG *G)
 YY_RULE(int) yy_FunctionDeclCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionDeclCore"));
-  if (!yy__(G))  goto l677;
-  if (!yy_FUNC_KW(G))  goto l677;
+  if (!yy__(G))  goto l644;
+  if (!yy_FUNC_KW(G))  goto l644;
 
-  {  int yypos678= G->pos, yythunkpos678= G->thunkpos;  if (!yymatchChar(G, '@')) goto l678;
+  {  int yypos645= G->pos, yythunkpos645= G->thunkpos;  if (!yymatchChar(G, '@')) goto l645;
   yyDo(G, yy_1_FunctionDeclCore, G->begin, G->end, "yy_1_FunctionDeclCore");
-  goto l679;
-  l678:;	  G->pos= yypos678; G->thunkpos= yythunkpos678;
+  goto l646;
+  l645:;	  G->pos= yypos645; G->thunkpos= yythunkpos645;
   }
-  l679:;	
-  {  int yypos680= G->pos, yythunkpos680= G->thunkpos;  if (!yy__(G))  goto l680;
-  if (!yymatchChar(G, '~')) goto l680;
-  if (!yy_IDENT(G))  goto l680;
+  l646:;	
+  {  int yypos647= G->pos, yythunkpos647= G->thunkpos;  if (!yy__(G))  goto l647;
+  if (!yymatchChar(G, '~')) goto l647;
+  if (!yy_IDENT(G))  goto l647;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_FunctionDeclCore, G->begin, G->end, "yy_2_FunctionDeclCore");
-  goto l681;
-  l680:;	  G->pos= yypos680; G->thunkpos= yythunkpos680;
+  goto l648;
+  l647:;	  G->pos= yypos647; G->thunkpos= yythunkpos647;
   }
-  l681:;	  if (!yy_FunctionDeclBody(G))  goto l677;
+  l648:;	  if (!yy_FunctionDeclBody(G))  goto l644;
   yyprintf((stderr, "  ok   FunctionDeclCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l677:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclCore"));
+  l644:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11631,13 +11332,13 @@ YY_RULE(int) yy_FunctionDeclCore(GREG *G)
 }
 YY_RULE(int) yy_OVERRIDE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OVERRIDE_KW"));
-  if (!yymatchString(G, "override")) goto l682;
+  if (!yymatchString(G, "override")) goto l649;
   yyprintf((stderr, "  ok   OVERRIDE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l682:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OVERRIDE_KW"));
+  l649:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OVERRIDE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11645,13 +11346,13 @@ YY_RULE(int) yy_OVERRIDE_KW(GREG *G)
 }
 YY_RULE(int) yy_VIRTUAL_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "VIRTUAL_KW"));
-  if (!yymatchString(G, "virtual")) goto l683;
+  if (!yymatchString(G, "virtual")) goto l650;
   yyprintf((stderr, "  ok   VIRTUAL_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l683:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VIRTUAL_KW"));
+  l650:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VIRTUAL_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11659,13 +11360,13 @@ YY_RULE(int) yy_VIRTUAL_KW(GREG *G)
 }
 YY_RULE(int) yy_PROTO_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "PROTO_KW"));
-  if (!yymatchString(G, "proto")) goto l684;
+  if (!yymatchString(G, "proto")) goto l651;
   yyprintf((stderr, "  ok   PROTO_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l684:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROTO_KW"));
+  l651:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PROTO_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11673,13 +11374,13 @@ YY_RULE(int) yy_PROTO_KW(GREG *G)
 }
 YY_RULE(int) yy_FINAL_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FINAL_KW"));
-  if (!yymatchString(G, "final")) goto l685;
+  if (!yymatchString(G, "final")) goto l652;
   yyprintf((stderr, "  ok   FINAL_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l685:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FINAL_KW"));
+  l652:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FINAL_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11687,13 +11388,13 @@ YY_RULE(int) yy_FINAL_KW(GREG *G)
 }
 YY_RULE(int) yy_INLINE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INLINE_KW"));
-  if (!yymatchString(G, "inline")) goto l686;
+  if (!yymatchString(G, "inline")) goto l653;
   yyprintf((stderr, "  ok   INLINE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l686:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INLINE_KW"));
+  l653:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INLINE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11701,13 +11402,13 @@ YY_RULE(int) yy_INLINE_KW(GREG *G)
 }
 YY_RULE(int) yy_STATIC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "STATIC_KW"));
-  if (!yymatchString(G, "static")) goto l687;
+  if (!yymatchString(G, "static")) goto l654;
   yyprintf((stderr, "  ok   STATIC_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l687:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STATIC_KW"));
+  l654:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "STATIC_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11716,26 +11417,26 @@ YY_RULE(int) yy_STATIC_KW(GREG *G)
 YY_RULE(int) yy_UnmangledName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "UnmangledName"));
-  if (!yy_UNMANGLED_KW(G))  goto l688;
+  if (!yy_UNMANGLED_KW(G))  goto l655;
   yyDo(G, yy_1_UnmangledName, G->begin, G->end, "yy_1_UnmangledName");
 
-  {  int yypos689= G->pos, yythunkpos689= G->thunkpos;  if (!yy__(G))  goto l689;
-  if (!yymatchChar(G, '(')) goto l689;
-  if (!yy__(G))  goto l689;
-  if (!yy_IDENT(G))  goto l689;
+  {  int yypos656= G->pos, yythunkpos656= G->thunkpos;  if (!yy__(G))  goto l656;
+  if (!yymatchChar(G, '(')) goto l656;
+  if (!yy__(G))  goto l656;
+  if (!yy_IDENT(G))  goto l656;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_UnmangledName, G->begin, G->end, "yy_2_UnmangledName");
-  if (!yy__(G))  goto l689;
-  if (!yymatchChar(G, ')')) goto l689;
-  goto l690;
-  l689:;	  G->pos= yypos689; G->thunkpos= yythunkpos689;
+  if (!yy__(G))  goto l656;
+  if (!yymatchChar(G, ')')) goto l656;
+  goto l657;
+  l656:;	  G->pos= yypos656; G->thunkpos= yythunkpos656;
   }
-  l690:;	  yyprintf((stderr, "  ok   UnmangledName"));
+  l657:;	  yyprintf((stderr, "  ok   UnmangledName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l688:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UnmangledName"));
+  l655:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UnmangledName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11743,30 +11444,30 @@ YY_RULE(int) yy_UnmangledName(GREG *G)
 }
 YY_RULE(int) yy_ExternName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ExternName"));
-  if (!yy_EXTERN_KW(G))  goto l691;
+  if (!yy_EXTERN_KW(G))  goto l658;
   yyDo(G, yy_1_ExternName, G->begin, G->end, "yy_1_ExternName");
 
-  {  int yypos692= G->pos, yythunkpos692= G->thunkpos;  if (!yy__(G))  goto l692;
-  if (!yymatchChar(G, '(')) goto l692;
-  if (!yy__(G))  goto l692;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l692;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_")) goto l692;
+  {  int yypos659= G->pos, yythunkpos659= G->thunkpos;  if (!yy__(G))  goto l659;
+  if (!yymatchChar(G, '(')) goto l659;
+  if (!yy__(G))  goto l659;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l659;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_")) goto l659;
 
-  l694:;	
-  {  int yypos695= G->pos, yythunkpos695= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_")) goto l695;
-  goto l694;
-  l695:;	  G->pos= yypos695; G->thunkpos= yythunkpos695;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l692;  yyDo(G, yy_2_ExternName, G->begin, G->end, "yy_2_ExternName");
-  if (!yy__(G))  goto l692;
-  if (!yymatchChar(G, ')')) goto l692;
-  goto l693;
-  l692:;	  G->pos= yypos692; G->thunkpos= yythunkpos692;
+  l661:;	
+  {  int yypos662= G->pos, yythunkpos662= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_")) goto l662;
+  goto l661;
+  l662:;	  G->pos= yypos662; G->thunkpos= yythunkpos662;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l659;  yyDo(G, yy_2_ExternName, G->begin, G->end, "yy_2_ExternName");
+  if (!yy__(G))  goto l659;
+  if (!yymatchChar(G, ')')) goto l659;
+  goto l660;
+  l659:;	  G->pos= yypos659; G->thunkpos= yythunkpos659;
   }
-  l693:;	  yyprintf((stderr, "  ok   ExternName"));
+  l660:;	  yyprintf((stderr, "  ok   ExternName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l691:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExternName"));
+  l658:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExternName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11775,17 +11476,17 @@ YY_RULE(int) yy_ExternName(GREG *G)
 YY_RULE(int) yy_OocDoc(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OocDoc"));
 
-  {  int yypos697= G->pos, yythunkpos697= G->thunkpos;  if (!yy_OocDocCore(G))  goto l698;
-  goto l697;
-  l698:;	  G->pos= yypos697; G->thunkpos= yythunkpos697;  yyDo(G, yy_1_OocDoc, G->begin, G->end, "yy_1_OocDoc");
+  {  int yypos664= G->pos, yythunkpos664= G->thunkpos;  if (!yy_OocDocCore(G))  goto l665;
+  goto l664;
+  l665:;	  G->pos= yypos664; G->thunkpos= yythunkpos664;  yyDo(G, yy_1_OocDoc, G->begin, G->end, "yy_1_OocDoc");
 
   }
-  l697:;	  yyprintf((stderr, "  ok   OocDoc"));
+  l664:;	  yyprintf((stderr, "  ok   OocDoc"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l696:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDoc"));
+  l663:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDoc"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11793,13 +11494,13 @@ YY_RULE(int) yy_OocDoc(GREG *G)
 }
 YY_RULE(int) yy_FUNC_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FUNC_KW"));
-  if (!yymatchString(G, "func")) goto l699;
+  if (!yymatchString(G, "func")) goto l666;
   yyprintf((stderr, "  ok   FUNC_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l699:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FUNC_KW"));
+  l666:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FUNC_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11808,20 +11509,20 @@ YY_RULE(int) yy_FUNC_KW(GREG *G)
 YY_RULE(int) yy_COLON(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "COLON"));
 
-  {  int yypos701= G->pos, yythunkpos701= G->thunkpos;  if (!yy_ASS_DECL(G))  goto l701;
-  goto l700;
-  l701:;	  G->pos= yypos701; G->thunkpos= yythunkpos701;
+  {  int yypos668= G->pos, yythunkpos668= G->thunkpos;  if (!yy_ASS_DECL(G))  goto l668;
+  goto l667;
+  l668:;	  G->pos= yypos668; G->thunkpos= yythunkpos668;
   }
-  {  int yypos702= G->pos, yythunkpos702= G->thunkpos;  if (!yy_PROPASS_DECL(G))  goto l702;
-  goto l700;
-  l702:;	  G->pos= yypos702; G->thunkpos= yythunkpos702;
-  }  if (!yymatchChar(G, ':')) goto l700;
+  {  int yypos669= G->pos, yythunkpos669= G->thunkpos;  if (!yy_PROPASS_DECL(G))  goto l669;
+  goto l667;
+  l669:;	  G->pos= yypos669; G->thunkpos= yythunkpos669;
+  }  if (!yymatchChar(G, ':')) goto l667;
   yyprintf((stderr, "  ok   COLON"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l700:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COLON"));
+  l667:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "COLON"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11830,56 +11531,56 @@ YY_RULE(int) yy_COLON(GREG *G)
 YY_RULE(int) yy_RegularFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "RegularFunctionDecl"));
-  if (!yy_OocDoc(G))  goto l703;
+  if (!yy_OocDoc(G))  goto l670;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l703;
+  if (!yy_IDENT(G))  goto l670;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_RegularFunctionDecl, G->begin, G->end, "yy_1_RegularFunctionDecl");
-  if (!yy__(G))  goto l703;
-  if (!yy_COLON(G))  goto l703;
+  if (!yy__(G))  goto l670;
+  if (!yy_COLON(G))  goto l670;
 
-  l704:;	
-  {  int yypos705= G->pos, yythunkpos705= G->thunkpos;  if (!yy__(G))  goto l705;
+  l671:;	
+  {  int yypos672= G->pos, yythunkpos672= G->thunkpos;  if (!yy__(G))  goto l672;
 
-  {  int yypos706= G->pos, yythunkpos706= G->thunkpos;  if (!yy_ExternName(G))  goto l707;
+  {  int yypos673= G->pos, yythunkpos673= G->thunkpos;  if (!yy_ExternName(G))  goto l674;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_RegularFunctionDecl, G->begin, G->end, "yy_2_RegularFunctionDecl");
-  goto l706;
-  l707:;	  G->pos= yypos706; G->thunkpos= yythunkpos706;  if (!yy_UnmangledName(G))  goto l708;
+  goto l673;
+  l674:;	  G->pos= yypos673; G->thunkpos= yythunkpos673;  if (!yy_UnmangledName(G))  goto l675;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_RegularFunctionDecl, G->begin, G->end, "yy_3_RegularFunctionDecl");
-  goto l706;
-  l708:;	  G->pos= yypos706; G->thunkpos= yythunkpos706;  if (!yy_ABSTRACT_KW(G))  goto l709;
+  goto l673;
+  l675:;	  G->pos= yypos673; G->thunkpos= yythunkpos673;  if (!yy_ABSTRACT_KW(G))  goto l676;
   yyDo(G, yy_4_RegularFunctionDecl, G->begin, G->end, "yy_4_RegularFunctionDecl");
-  goto l706;
-  l709:;	  G->pos= yypos706; G->thunkpos= yythunkpos706;  if (!yy_STATIC_KW(G))  goto l710;
+  goto l673;
+  l676:;	  G->pos= yypos673; G->thunkpos= yythunkpos673;  if (!yy_STATIC_KW(G))  goto l677;
   yyDo(G, yy_5_RegularFunctionDecl, G->begin, G->end, "yy_5_RegularFunctionDecl");
-  goto l706;
-  l710:;	  G->pos= yypos706; G->thunkpos= yythunkpos706;  if (!yy_INLINE_KW(G))  goto l711;
+  goto l673;
+  l677:;	  G->pos= yypos673; G->thunkpos= yythunkpos673;  if (!yy_INLINE_KW(G))  goto l678;
   yyDo(G, yy_6_RegularFunctionDecl, G->begin, G->end, "yy_6_RegularFunctionDecl");
-  goto l706;
-  l711:;	  G->pos= yypos706; G->thunkpos= yythunkpos706;  if (!yy_FINAL_KW(G))  goto l712;
+  goto l673;
+  l678:;	  G->pos= yypos673; G->thunkpos= yythunkpos673;  if (!yy_FINAL_KW(G))  goto l679;
   yyDo(G, yy_7_RegularFunctionDecl, G->begin, G->end, "yy_7_RegularFunctionDecl");
-  goto l706;
-  l712:;	  G->pos= yypos706; G->thunkpos= yythunkpos706;  if (!yy_PROTO_KW(G))  goto l713;
+  goto l673;
+  l679:;	  G->pos= yypos673; G->thunkpos= yythunkpos673;  if (!yy_PROTO_KW(G))  goto l680;
   yyDo(G, yy_8_RegularFunctionDecl, G->begin, G->end, "yy_8_RegularFunctionDecl");
-  goto l706;
-  l713:;	  G->pos= yypos706; G->thunkpos= yythunkpos706;  if (!yy_VIRTUAL_KW(G))  goto l714;
+  goto l673;
+  l680:;	  G->pos= yypos673; G->thunkpos= yythunkpos673;  if (!yy_VIRTUAL_KW(G))  goto l681;
   yyDo(G, yy_9_RegularFunctionDecl, G->begin, G->end, "yy_9_RegularFunctionDecl");
-  goto l706;
-  l714:;	  G->pos= yypos706; G->thunkpos= yythunkpos706;  if (!yy_OVERRIDE_KW(G))  goto l705;
+  goto l673;
+  l681:;	  G->pos= yypos673; G->thunkpos= yythunkpos673;  if (!yy_OVERRIDE_KW(G))  goto l672;
   yyDo(G, yy_10_RegularFunctionDecl, G->begin, G->end, "yy_10_RegularFunctionDecl");
 
   }
-  l706:;	  goto l704;
-  l705:;	  G->pos= yypos705; G->thunkpos= yythunkpos705;
-  }  if (!yy_FunctionDeclCore(G))  goto l703;
+  l673:;	  goto l671;
+  l672:;	  G->pos= yypos672; G->thunkpos= yythunkpos672;
+  }  if (!yy_FunctionDeclCore(G))  goto l670;
   yyprintf((stderr, "  ok   RegularFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l703:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RegularFunctionDecl"));
+  l670:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "RegularFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11888,32 +11589,32 @@ YY_RULE(int) yy_RegularFunctionDecl(GREG *G)
 YY_RULE(int) yy_SuperFunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "SuperFunctionDecl"));
-  if (!yy_IDENT(G))  goto l715;
+  if (!yy_IDENT(G))  goto l682;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l715;
-  if (!yy_COLON(G))  goto l715;
-  if (!yy__(G))  goto l715;
-  if (!yymatchString(G, "super")) goto l715;
-  if (!yy__(G))  goto l715;
-  if (!yy_FUNC_KW(G))  goto l715;
-  if (!yy__(G))  goto l715;
+  if (!yy__(G))  goto l682;
+  if (!yy_COLON(G))  goto l682;
+  if (!yy__(G))  goto l682;
+  if (!yymatchString(G, "super")) goto l682;
+  if (!yy__(G))  goto l682;
+  if (!yy_FUNC_KW(G))  goto l682;
+  if (!yy__(G))  goto l682;
   yyDo(G, yy_1_SuperFunctionDecl, G->begin, G->end, "yy_1_SuperFunctionDecl");
 
-  {  int yypos716= G->pos, yythunkpos716= G->thunkpos;  if (!yy__(G))  goto l716;
-  if (!yymatchChar(G, '~')) goto l716;
-  if (!yy_IDENT(G))  goto l716;
+  {  int yypos683= G->pos, yythunkpos683= G->thunkpos;  if (!yy__(G))  goto l683;
+  if (!yymatchChar(G, '~')) goto l683;
+  if (!yy_IDENT(G))  goto l683;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_SuperFunctionDecl, G->begin, G->end, "yy_2_SuperFunctionDecl");
-  goto l717;
-  l716:;	  G->pos= yypos716; G->thunkpos= yythunkpos716;
+  goto l684;
+  l683:;	  G->pos= yypos683; G->thunkpos= yythunkpos683;
   }
-  l717:;	  yyDo(G, yy_3_SuperFunctionDecl, G->begin, G->end, "yy_3_SuperFunctionDecl");
+  l684:;	  yyDo(G, yy_3_SuperFunctionDecl, G->begin, G->end, "yy_3_SuperFunctionDecl");
   yyprintf((stderr, "  ok   SuperFunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l715:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SuperFunctionDecl"));
+  l682:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "SuperFunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -11923,87 +11624,87 @@ YY_RULE(int) yy_FunctionDeclBody(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "FunctionDeclBody"));
 
-  {  int yypos719= G->pos, yythunkpos719= G->thunkpos;  if (!yy_GenericArguments(G))  goto l719;
-  goto l720;
-  l719:;	  G->pos= yypos719; G->thunkpos= yythunkpos719;
+  {  int yypos686= G->pos, yythunkpos686= G->thunkpos;  if (!yy_GenericArguments(G))  goto l686;
+  goto l687;
+  l686:;	  G->pos= yypos686; G->thunkpos= yythunkpos686;
   }
-  l720:;	
-  {  int yypos721= G->pos, yythunkpos721= G->thunkpos;  if (!yy_WS(G))  goto l721;
-  if (!yymatchChar(G, '(')) goto l721;
+  l687:;	
+  {  int yypos688= G->pos, yythunkpos688= G->thunkpos;  if (!yy_WS(G))  goto l688;
+  if (!yymatchChar(G, '(')) goto l688;
   yyDo(G, yy_1_FunctionDeclBody, G->begin, G->end, "yy_1_FunctionDeclBody");
 
-  {  int yypos723= G->pos, yythunkpos723= G->thunkpos;  if (!yy_WS(G))  goto l723;
-  if (!yy_Argument(G))  goto l723;
-  if (!yy_WS(G))  goto l723;
+  {  int yypos690= G->pos, yythunkpos690= G->thunkpos;  if (!yy_WS(G))  goto l690;
+  if (!yy_Argument(G))  goto l690;
+  if (!yy_WS(G))  goto l690;
 
-  l725:;	
-  {  int yypos726= G->pos, yythunkpos726= G->thunkpos;  if (!yymatchChar(G, ',')) goto l726;
-  if (!yy_WS(G))  goto l726;
-  if (!yy_Argument(G))  goto l726;
-  if (!yy_WS(G))  goto l726;
-  goto l725;
-  l726:;	  G->pos= yypos726; G->thunkpos= yythunkpos726;
-  }  goto l724;
-  l723:;	  G->pos= yypos723; G->thunkpos= yythunkpos723;
+  l692:;	
+  {  int yypos693= G->pos, yythunkpos693= G->thunkpos;  if (!yymatchChar(G, ',')) goto l693;
+  if (!yy_WS(G))  goto l693;
+  if (!yy_Argument(G))  goto l693;
+  if (!yy_WS(G))  goto l693;
+  goto l692;
+  l693:;	  G->pos= yypos693; G->thunkpos= yythunkpos693;
+  }  goto l691;
+  l690:;	  G->pos= yypos690; G->thunkpos= yythunkpos690;
   }
-  l724:;	  if (!yy_WS(G))  goto l721;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ARG, "Malformed function argument (remember, it's `name: Type` in ooc, not `Type name`)\n") ; } goto l721; }
+  l691:;	  if (!yy_WS(G))  goto l688;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ARG, "Malformed function argument (remember, it's `name: Type` in ooc, not `Type name`)\n") ; } goto l688; }
   yyDo(G, yy_2_FunctionDeclBody, G->begin, G->end, "yy_2_FunctionDeclBody");
-  goto l722;
-  l721:;	  G->pos= yypos721; G->thunkpos= yythunkpos721;
+  goto l689;
+  l688:;	  G->pos= yypos688; G->thunkpos= yythunkpos688;
   }
-  l722:;	
-  {  int yypos727= G->pos, yythunkpos727= G->thunkpos;  if (!yy__(G))  goto l727;
-  if (!yymatchChar(G, '~')) goto l727;
-  if (!yy_IDENT(G))  goto l727;
+  l689:;	
+  {  int yypos694= G->pos, yythunkpos694= G->thunkpos;  if (!yy__(G))  goto l694;
+  if (!yymatchChar(G, '~')) goto l694;
+  if (!yy_IDENT(G))  goto l694;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_3_FunctionDeclBody, G->begin, G->end, "yy_3_FunctionDeclBody");
-  goto l728;
-  l727:;	  G->pos= yypos727; G->thunkpos= yythunkpos727;
+  goto l695;
+  l694:;	  G->pos= yypos694; G->thunkpos= yythunkpos694;
   }
-  l728:;	
-  {  int yypos729= G->pos, yythunkpos729= G->thunkpos;  if (!yy__(G))  goto l729;
-  if (!yy_R_ARROW(G))  goto l729;
-  if (!yy__(G))  goto l729;
-  if (!yy_Type(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_RET_TYPE, "Missing return type.\n") ; } goto l729; }
+  l695:;	
+  {  int yypos696= G->pos, yythunkpos696= G->thunkpos;  if (!yy__(G))  goto l696;
+  if (!yy_R_ARROW(G))  goto l696;
+  if (!yy__(G))  goto l696;
+  if (!yy_Type(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_RET_TYPE, "Missing return type.\n") ; } goto l696; }
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_FunctionDeclBody, G->begin, G->end, "yy_4_FunctionDeclBody");
-  goto l730;
-  l729:;	  G->pos= yypos729; G->thunkpos= yythunkpos729;
+  goto l697;
+  l696:;	  G->pos= yypos696; G->thunkpos= yythunkpos696;
   }
-  l730:;	
-  {  int yypos731= G->pos, yythunkpos731= G->thunkpos;  yyDo(G, yy_5_FunctionDeclBody, G->begin, G->end, "yy_5_FunctionDeclBody");
-  if (!yy_WS(G))  goto l731;
-  if (!yymatchChar(G, '{')) goto l731;
-  if (!yy_WS(G))  goto l731;
+  l697:;	
+  {  int yypos698= G->pos, yythunkpos698= G->thunkpos;  yyDo(G, yy_5_FunctionDeclBody, G->begin, G->end, "yy_5_FunctionDeclBody");
+  if (!yy_WS(G))  goto l698;
+  if (!yymatchChar(G, '{')) goto l698;
+  if (!yy_WS(G))  goto l698;
 
-  l733:;	
-  {  int yypos734= G->pos, yythunkpos734= G->thunkpos;  if (!yy_WS(G))  goto l734;
+  l700:;	
+  {  int yypos701= G->pos, yythunkpos701= G->thunkpos;  if (!yy_WS(G))  goto l701;
 
-  {  int yypos735= G->pos, yythunkpos735= G->thunkpos;  if (!yy_Stmt(G))  goto l736;
+  {  int yypos702= G->pos, yythunkpos702= G->thunkpos;  if (!yy_Stmt(G))  goto l703;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_6_FunctionDeclBody, G->begin, G->end, "yy_6_FunctionDeclBody");
-  goto l735;
-  l736:;	  G->pos= yypos735; G->thunkpos= yythunkpos735;  yyDo(G, yy_7_FunctionDeclBody, G->begin, G->end, "yy_7_FunctionDeclBody");
-  if (!yy_OocDocCore(G))  goto l734;
+  goto l702;
+  l703:;	  G->pos= yypos702; G->thunkpos= yythunkpos702;  yyDo(G, yy_7_FunctionDeclBody, G->begin, G->end, "yy_7_FunctionDeclBody");
+  if (!yy_OocDocCore(G))  goto l701;
   yyDo(G, yy_8_FunctionDeclBody, G->begin, G->end, "yy_8_FunctionDeclBody");
 
   }
-  l735:;	  if (!yy_WS(G))  goto l734;
-  goto l733;
-  l734:;	  G->pos= yypos734; G->thunkpos= yythunkpos734;
-  }  if (!yy_WS(G))  goto l731;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or closing bracket missing\n") ; } goto l731; }
-  goto l732;
-  l731:;	  G->pos= yypos731; G->thunkpos= yythunkpos731;
+  l702:;	  if (!yy_WS(G))  goto l701;
+  goto l700;
+  l701:;	  G->pos= yypos701; G->thunkpos= yythunkpos701;
+  }  if (!yy_WS(G))  goto l698;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or closing bracket missing\n") ; } goto l698; }
+  goto l699;
+  l698:;	  G->pos= yypos698; G->thunkpos= yythunkpos698;
   }
-  l732:;	  yyDo(G, yy_9_FunctionDeclBody, G->begin, G->end, "yy_9_FunctionDeclBody");
+  l699:;	  yyDo(G, yy_9_FunctionDeclBody, G->begin, G->end, "yy_9_FunctionDeclBody");
   yyprintf((stderr, "  ok   FunctionDeclBody"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l718:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclBody"));
+  l685:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDeclBody"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12011,13 +11712,13 @@ YY_RULE(int) yy_FunctionDeclBody(GREG *G)
 }
 YY_RULE(int) yy_ABSTRACT_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ABSTRACT_KW"));
-  if (!yymatchString(G, "abstract")) goto l737;
+  if (!yymatchString(G, "abstract")) goto l704;
   yyprintf((stderr, "  ok   ABSTRACT_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l737:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ABSTRACT_KW"));
+  l704:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ABSTRACT_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12025,13 +11726,13 @@ YY_RULE(int) yy_ABSTRACT_KW(GREG *G)
 }
 YY_RULE(int) yy_OPERATOR_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OPERATOR_KW"));
-  if (!yymatchString(G, "operator")) goto l738;
+  if (!yymatchString(G, "operator")) goto l705;
   yyprintf((stderr, "  ok   OPERATOR_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l738:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OPERATOR_KW"));
+  l705:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OPERATOR_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12039,18 +11740,18 @@ YY_RULE(int) yy_OPERATOR_KW(GREG *G)
 }
 YY_RULE(int) yy_TemplateDef(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "TemplateDef"));
-  if (!yy_WS(G))  goto l739;
-  if (!yymatchString(G, "template")) goto l739;
-  if (!yy_WS(G))  goto l739;
+  if (!yy_WS(G))  goto l706;
+  if (!yymatchString(G, "template")) goto l706;
+  if (!yy_WS(G))  goto l706;
   yyDo(G, yy_1_TemplateDef, G->begin, G->end, "yy_1_TemplateDef");
-  if (!yy_GenericArguments(G))  goto l739;
+  if (!yy_GenericArguments(G))  goto l706;
   yyDo(G, yy_2_TemplateDef, G->begin, G->end, "yy_2_TemplateDef");
   yyprintf((stderr, "  ok   TemplateDef"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l739:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TemplateDef"));
+  l706:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "TemplateDef"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12058,23 +11759,23 @@ YY_RULE(int) yy_TemplateDef(GREG *G)
 }
 YY_RULE(int) yy_MORETHAN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "MORETHAN"));
-  if (!yymatchChar(G, '>')) goto l740;
+  if (!yymatchChar(G, '>')) goto l707;
 
-  {  int yypos741= G->pos, yythunkpos741= G->thunkpos;
-  {  int yypos742= G->pos, yythunkpos742= G->thunkpos;  if (!yymatchChar(G, '=')) goto l743;
-  goto l742;
-  l743:;	  G->pos= yypos742; G->thunkpos= yythunkpos742;  if (!yymatchChar(G, '>')) goto l741;
+  {  int yypos708= G->pos, yythunkpos708= G->thunkpos;
+  {  int yypos709= G->pos, yythunkpos709= G->thunkpos;  if (!yymatchChar(G, '=')) goto l710;
+  goto l709;
+  l710:;	  G->pos= yypos709; G->thunkpos= yythunkpos709;  if (!yymatchChar(G, '>')) goto l708;
 
   }
-  l742:;	  goto l740;
-  l741:;	  G->pos= yypos741; G->thunkpos= yythunkpos741;
-  }  if (!yy__(G))  goto l740;
+  l709:;	  goto l707;
+  l708:;	  G->pos= yypos708; G->thunkpos= yythunkpos708;
+  }  if (!yy__(G))  goto l707;
   yyprintf((stderr, "  ok   MORETHAN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l740:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN"));
+  l707:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "MORETHAN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12082,23 +11783,23 @@ YY_RULE(int) yy_MORETHAN(GREG *G)
 }
 YY_RULE(int) yy_LESSTHAN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "LESSTHAN"));
-  if (!yymatchChar(G, '<')) goto l744;
+  if (!yymatchChar(G, '<')) goto l711;
 
-  {  int yypos745= G->pos, yythunkpos745= G->thunkpos;
-  {  int yypos746= G->pos, yythunkpos746= G->thunkpos;  if (!yymatchChar(G, '=')) goto l747;
-  goto l746;
-  l747:;	  G->pos= yypos746; G->thunkpos= yythunkpos746;  if (!yymatchChar(G, '<')) goto l745;
+  {  int yypos712= G->pos, yythunkpos712= G->thunkpos;
+  {  int yypos713= G->pos, yythunkpos713= G->thunkpos;  if (!yymatchChar(G, '=')) goto l714;
+  goto l713;
+  l714:;	  G->pos= yypos713; G->thunkpos= yythunkpos713;  if (!yymatchChar(G, '<')) goto l712;
 
   }
-  l746:;	  goto l744;
-  l745:;	  G->pos= yypos745; G->thunkpos= yythunkpos745;
-  }  if (!yy__(G))  goto l744;
+  l713:;	  goto l711;
+  l712:;	  G->pos= yypos712; G->thunkpos= yythunkpos712;
+  }  if (!yy__(G))  goto l711;
   yyprintf((stderr, "  ok   LESSTHAN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l744:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN"));
+  l711:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "LESSTHAN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12107,30 +11808,30 @@ YY_RULE(int) yy_LESSTHAN(GREG *G)
 YY_RULE(int) yy_GenericArguments(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "GenericArguments"));
-  if (!yy__(G))  goto l748;
-  if (!yy_LESSTHAN(G))  goto l748;
-  if (!yy__(G))  goto l748;
-  if (!yy_IDENT(G))  goto l748;
+  if (!yy__(G))  goto l715;
+  if (!yy_LESSTHAN(G))  goto l715;
+  if (!yy__(G))  goto l715;
+  if (!yy_IDENT(G))  goto l715;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_GenericArguments, G->begin, G->end, "yy_1_GenericArguments");
 
-  l749:;	
-  {  int yypos750= G->pos, yythunkpos750= G->thunkpos;  if (!yy__(G))  goto l750;
-  if (!yymatchChar(G, ',')) goto l750;
-  if (!yy__(G))  goto l750;
-  if (!yy_IDENT(G))  goto l750;
+  l716:;	
+  {  int yypos717= G->pos, yythunkpos717= G->thunkpos;  if (!yy__(G))  goto l717;
+  if (!yymatchChar(G, ',')) goto l717;
+  if (!yy__(G))  goto l717;
+  if (!yy_IDENT(G))  goto l717;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_GenericArguments, G->begin, G->end, "yy_2_GenericArguments");
-  goto l749;
-  l750:;	  G->pos= yypos750; G->thunkpos= yythunkpos750;
-  }  if (!yy_MORETHAN(G))  goto l748;
-  if (!yy__(G))  goto l748;
+  goto l716;
+  l717:;	  G->pos= yypos717; G->thunkpos= yythunkpos717;
+  }  if (!yy_MORETHAN(G))  goto l715;
+  if (!yy__(G))  goto l715;
   yyprintf((stderr, "  ok   GenericArguments"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l748:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericArguments"));
+  l715:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "GenericArguments"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12139,27 +11840,27 @@ YY_RULE(int) yy_GenericArguments(GREG *G)
 YY_RULE(int) yy_Terminator(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Terminator"));
 
-  {  int yypos752= G->pos, yythunkpos752= G->thunkpos;  if (!yy_CommentLine(G))  goto l753;
-  goto l752;
-  l753:;	  G->pos= yypos752; G->thunkpos= yythunkpos752;
-  {  int yypos754= G->pos, yythunkpos754= G->thunkpos;  if (!yy_CommentMultiLine(G))  goto l754;
-  goto l755;
-  l754:;	  G->pos= yypos754; G->thunkpos= yythunkpos754;
+  {  int yypos719= G->pos, yythunkpos719= G->thunkpos;  if (!yy_CommentLine(G))  goto l720;
+  goto l719;
+  l720:;	  G->pos= yypos719; G->thunkpos= yythunkpos719;
+  {  int yypos721= G->pos, yythunkpos721= G->thunkpos;  if (!yy_CommentMultiLine(G))  goto l721;
+  goto l722;
+  l721:;	  G->pos= yypos721; G->thunkpos= yythunkpos721;
   }
-  l755:;	
-  {  int yypos756= G->pos, yythunkpos756= G->thunkpos;  if (!yy_EOL(G))  goto l757;
-  goto l756;
-  l757:;	  G->pos= yypos756; G->thunkpos= yythunkpos756;  if (!yymatchChar(G, ';')) goto l751;
+  l722:;	
+  {  int yypos723= G->pos, yythunkpos723= G->thunkpos;  if (!yy_EOL(G))  goto l724;
+  goto l723;
+  l724:;	  G->pos= yypos723; G->thunkpos= yythunkpos723;  if (!yymatchChar(G, ';')) goto l718;
 
   }
-  l756:;	
+  l723:;	
   }
-  l752:;	  yyprintf((stderr, "  ok   Terminator"));
+  l719:;	  yyprintf((stderr, "  ok   Terminator"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l751:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Terminator"));
+  l718:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Terminator"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12169,21 +11870,21 @@ YY_RULE(int) yy_VariableDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VariableDecl"));
 
-  {  int yypos759= G->pos, yythunkpos759= G->thunkpos;  if (!yy_VarDeclFromExpr(G))  goto l760;
+  {  int yypos726= G->pos, yythunkpos726= G->thunkpos;  if (!yy_VarDeclFromExpr(G))  goto l727;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_VariableDecl, G->begin, G->end, "yy_1_VariableDecl");
-  goto l759;
-  l760:;	  G->pos= yypos759; G->thunkpos= yythunkpos759;  if (!yy_ConventionalVarDecl(G))  goto l758;
+  goto l726;
+  l727:;	  G->pos= yypos726; G->thunkpos= yythunkpos726;  if (!yy_ConventionalVarDecl(G))  goto l725;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VariableDecl, G->begin, G->end, "yy_2_VariableDecl");
 
   }
-  l759:;	  yyprintf((stderr, "  ok   VariableDecl"));
+  l726:;	  yyprintf((stderr, "  ok   VariableDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l758:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VariableDecl"));
+  l725:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VariableDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12193,21 +11894,21 @@ YY_RULE(int) yy_PropertyDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "PropertyDecl"));
 
-  {  int yypos762= G->pos, yythunkpos762= G->thunkpos;  if (!yy_PropertyDeclFromExpr(G))  goto l763;
+  {  int yypos729= G->pos, yythunkpos729= G->thunkpos;  if (!yy_PropertyDeclFromExpr(G))  goto l730;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_1_PropertyDecl, G->begin, G->end, "yy_1_PropertyDecl");
-  goto l762;
-  l763:;	  G->pos= yypos762; G->thunkpos= yythunkpos762;  if (!yy_ConventionalPropertyDecl(G))  goto l761;
+  goto l729;
+  l730:;	  G->pos= yypos729; G->thunkpos= yythunkpos729;  if (!yy_ConventionalPropertyDecl(G))  goto l728;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_PropertyDecl, G->begin, G->end, "yy_2_PropertyDecl");
 
   }
-  l762:;	  yyprintf((stderr, "  ok   PropertyDecl"));
+  l729:;	  yyprintf((stderr, "  ok   PropertyDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l761:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDecl"));
+  l728:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "PropertyDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12216,17 +11917,17 @@ YY_RULE(int) yy_PropertyDecl(GREG *G)
 YY_RULE(int) yy_FunctionDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "FunctionDecl"));
 
-  {  int yypos765= G->pos, yythunkpos765= G->thunkpos;  if (!yy_SuperFunctionDecl(G))  goto l766;
-  goto l765;
-  l766:;	  G->pos= yypos765; G->thunkpos= yythunkpos765;  if (!yy_RegularFunctionDecl(G))  goto l764;
+  {  int yypos732= G->pos, yythunkpos732= G->thunkpos;  if (!yy_SuperFunctionDecl(G))  goto l733;
+  goto l732;
+  l733:;	  G->pos= yypos732; G->thunkpos= yythunkpos732;  if (!yy_RegularFunctionDecl(G))  goto l731;
 
   }
-  l765:;	  yyprintf((stderr, "  ok   FunctionDecl"));
+  l732:;	  yyprintf((stderr, "  ok   FunctionDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l764:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDecl"));
+  l731:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "FunctionDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12235,115 +11936,115 @@ YY_RULE(int) yy_FunctionDecl(GREG *G)
 YY_RULE(int) yy_OperatorDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OperatorDecl"));
 
-  {  int yypos768= G->pos, yythunkpos768= G->thunkpos;  if (!yy_OPERATOR_KW(G))  goto l769;
+  {  int yypos735= G->pos, yythunkpos735= G->thunkpos;  if (!yy_OPERATOR_KW(G))  goto l736;
   yyDo(G, yy_1_OperatorDecl, G->begin, G->end, "yy_1_OperatorDecl");
-  goto l768;
-  l769:;	  G->pos= yypos768; G->thunkpos= yythunkpos768;  if (!yy_ABSTRACT_KW(G))  goto l767;
-  if (!yy__(G))  goto l767;
-  if (!yy_OPERATOR_KW(G))  goto l767;
+  goto l735;
+  l736:;	  G->pos= yypos735; G->thunkpos= yythunkpos735;  if (!yy_ABSTRACT_KW(G))  goto l734;
+  if (!yy__(G))  goto l734;
+  if (!yy_OPERATOR_KW(G))  goto l734;
   yyDo(G, yy_2_OperatorDecl, G->begin, G->end, "yy_2_OperatorDecl");
 
   }
-  l768:;	  if (!yy__(G))  goto l767;
+  l735:;	  if (!yy__(G))  goto l734;
 
-  {  int yypos770= G->pos, yythunkpos770= G->thunkpos;  if (!yymatchChar(G, '@')) goto l770;
+  {  int yypos737= G->pos, yythunkpos737= G->thunkpos;  if (!yymatchChar(G, '@')) goto l737;
   yyDo(G, yy_3_OperatorDecl, G->begin, G->end, "yy_3_OperatorDecl");
-  goto l771;
-  l770:;	  G->pos= yypos770; G->thunkpos= yythunkpos770;
+  goto l738;
+  l737:;	  G->pos= yypos737; G->thunkpos= yythunkpos737;
   }
-  l771:;	  if (!yy__(G))  goto l767;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l767;
-  {  int yypos772= G->pos, yythunkpos772= G->thunkpos;  if (!yymatchString(G, "=>")) goto l773;
-  goto l772;
-  l773:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "<=>")) goto l774;
-  goto l772;
-  l774:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, ">>=")) goto l775;
-  goto l772;
-  l775:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "<<=")) goto l776;
-  goto l772;
-  l776:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, ">>")) goto l777;
-  goto l772;
-  l777:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "<<")) goto l778;
-  goto l772;
-  l778:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, ">=")) goto l779;
-  goto l772;
-  l779:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "<=")) goto l780;
-  goto l772;
-  l780:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "!=")) goto l781;
-  goto l772;
-  l781:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "==")) goto l782;
-  goto l772;
-  l782:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '>')) goto l783;
-  goto l772;
-  l783:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '<')) goto l784;
-  goto l772;
-  l784:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '!')) goto l785;
-  goto l772;
-  l785:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "??")) goto l786;
-  goto l772;
-  l786:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "+=")) goto l787;
-  goto l772;
-  l787:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "-=")) goto l788;
-  goto l772;
-  l788:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "*=")) goto l789;
-  goto l772;
-  l789:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "**=")) goto l790;
-  goto l772;
-  l790:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "/=")) goto l791;
-  goto l772;
-  l791:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "%=")) goto l792;
-  goto l772;
-  l792:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '+')) goto l793;
-  goto l772;
-  l793:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '-')) goto l794;
-  goto l772;
-  l794:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "**")) goto l795;
-  goto l772;
-  l795:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '/')) goto l796;
-  goto l772;
-  l796:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '*')) goto l797;
-  goto l772;
-  l797:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '=')) goto l798;
-  goto l772;
-  l798:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "[]=")) goto l799;
-  goto l772;
-  l799:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "[]")) goto l800;
-  goto l772;
-  l800:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "&&")) goto l801;
-  goto l772;
-  l801:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "||")) goto l802;
-  goto l772;
-  l802:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '%')) goto l803;
-  goto l772;
-  l803:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "as")) goto l804;
-  goto l772;
-  l804:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "implicit as")) goto l805;
-  goto l772;
-  l805:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "&=")) goto l806;
-  goto l772;
-  l806:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "|=")) goto l807;
-  goto l772;
-  l807:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchString(G, "^=")) goto l808;
-  goto l772;
-  l808:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '&')) goto l809;
-  goto l772;
-  l809:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '|')) goto l810;
-  goto l772;
-  l810:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '^')) goto l811;
-  goto l772;
-  l811:;	  G->pos= yypos772; G->thunkpos= yythunkpos772;  if (!yymatchChar(G, '~')) goto l767;
+  l738:;	  if (!yy__(G))  goto l734;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l734;
+  {  int yypos739= G->pos, yythunkpos739= G->thunkpos;  if (!yymatchString(G, "=>")) goto l740;
+  goto l739;
+  l740:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<=>")) goto l741;
+  goto l739;
+  l741:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, ">>=")) goto l742;
+  goto l739;
+  l742:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<<=")) goto l743;
+  goto l739;
+  l743:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, ">>")) goto l744;
+  goto l739;
+  l744:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<<")) goto l745;
+  goto l739;
+  l745:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, ">=")) goto l746;
+  goto l739;
+  l746:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "<=")) goto l747;
+  goto l739;
+  l747:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "!=")) goto l748;
+  goto l739;
+  l748:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "==")) goto l749;
+  goto l739;
+  l749:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '>')) goto l750;
+  goto l739;
+  l750:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '<')) goto l751;
+  goto l739;
+  l751:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '!')) goto l752;
+  goto l739;
+  l752:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "??")) goto l753;
+  goto l739;
+  l753:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "+=")) goto l754;
+  goto l739;
+  l754:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "-=")) goto l755;
+  goto l739;
+  l755:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "*=")) goto l756;
+  goto l739;
+  l756:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "**=")) goto l757;
+  goto l739;
+  l757:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "/=")) goto l758;
+  goto l739;
+  l758:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "%=")) goto l759;
+  goto l739;
+  l759:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '+')) goto l760;
+  goto l739;
+  l760:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '-')) goto l761;
+  goto l739;
+  l761:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "**")) goto l762;
+  goto l739;
+  l762:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '/')) goto l763;
+  goto l739;
+  l763:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '*')) goto l764;
+  goto l739;
+  l764:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '=')) goto l765;
+  goto l739;
+  l765:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "[]=")) goto l766;
+  goto l739;
+  l766:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "[]")) goto l767;
+  goto l739;
+  l767:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "&&")) goto l768;
+  goto l739;
+  l768:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "||")) goto l769;
+  goto l739;
+  l769:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '%')) goto l770;
+  goto l739;
+  l770:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "as")) goto l771;
+  goto l739;
+  l771:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "implicit as")) goto l772;
+  goto l739;
+  l772:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "&=")) goto l773;
+  goto l739;
+  l773:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "|=")) goto l774;
+  goto l739;
+  l774:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchString(G, "^=")) goto l775;
+  goto l739;
+  l775:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '&')) goto l776;
+  goto l739;
+  l776:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '|')) goto l777;
+  goto l739;
+  l777:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '^')) goto l778;
+  goto l739;
+  l778:;	  G->pos= yypos739; G->thunkpos= yythunkpos739;  if (!yymatchChar(G, '~')) goto l734;
 
   }
-  l772:;	  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l767;  yyDo(G, yy_4_OperatorDecl, G->begin, G->end, "yy_4_OperatorDecl");
-  if (!yy__(G))  goto l767;
-  if (!yy_FunctionDeclBody(G))  goto l767;
+  l739:;	  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l734;  yyDo(G, yy_4_OperatorDecl, G->begin, G->end, "yy_4_OperatorDecl");
+  if (!yy__(G))  goto l734;
+  if (!yy_FunctionDeclBody(G))  goto l734;
   yyDo(G, yy_5_OperatorDecl, G->begin, G->end, "yy_5_OperatorDecl");
   yyprintf((stderr, "  ok   OperatorDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l767:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OperatorDecl"));
+  l734:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OperatorDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12352,70 +12053,70 @@ YY_RULE(int) yy_OperatorDecl(GREG *G)
 YY_RULE(int) yy_InterfaceDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "InterfaceDecl"));
-  if (!yy_OocDoc(G))  goto l812;
+  if (!yy_OocDoc(G))  goto l779;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_IDENT(G))  goto l812;
+  if (!yy_IDENT(G))  goto l779;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_InterfaceDecl, G->begin, G->end, "yy_1_InterfaceDecl");
-  if (!yy__(G))  goto l812;
-  if (!yy_COLON(G))  goto l812;
-  if (!yy__(G))  goto l812;
-  if (!yy_INTERFACE_KW(G))  goto l812;
+  if (!yy__(G))  goto l779;
+  if (!yy_COLON(G))  goto l779;
+  if (!yy__(G))  goto l779;
+  if (!yy_INTERFACE_KW(G))  goto l779;
 
-  {  int yypos813= G->pos, yythunkpos813= G->thunkpos;  if (!yy_GenericArguments(G))  goto l813;
-  goto l814;
-  l813:;	  G->pos= yypos813; G->thunkpos= yythunkpos813;
+  {  int yypos780= G->pos, yythunkpos780= G->thunkpos;  if (!yy_GenericArguments(G))  goto l780;
+  goto l781;
+  l780:;	  G->pos= yypos780; G->thunkpos= yythunkpos780;
   }
-  l814:;	
-  {  int yypos815= G->pos, yythunkpos815= G->thunkpos;  if (!yy__(G))  goto l815;
-  if (!yy_EXTENDS_KW(G))  goto l815;
-  if (!yy__(G))  goto l815;
-  if (!yy_Type(G))  goto l815;
+  l781:;	
+  {  int yypos782= G->pos, yythunkpos782= G->thunkpos;  if (!yy__(G))  goto l782;
+  if (!yy_EXTENDS_KW(G))  goto l782;
+  if (!yy__(G))  goto l782;
+  if (!yy_Type(G))  goto l782;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_2_InterfaceDecl, G->begin, G->end, "yy_2_InterfaceDecl");
-  goto l816;
-  l815:;	  G->pos= yypos815; G->thunkpos= yythunkpos815;
+  goto l783;
+  l782:;	  G->pos= yypos782; G->thunkpos= yythunkpos782;
   }
-  l816:;	
-  {  int yypos817= G->pos, yythunkpos817= G->thunkpos;  if (!yy__(G))  goto l817;
-  if (!yy_IMPLEMENTS_KW(G))  goto l817;
-  if (!yy__(G))  goto l817;
-  if (!yy_Type(G))  goto l817;
+  l783:;	
+  {  int yypos784= G->pos, yythunkpos784= G->thunkpos;  if (!yy__(G))  goto l784;
+  if (!yy_IMPLEMENTS_KW(G))  goto l784;
+  if (!yy__(G))  goto l784;
+  if (!yy_Type(G))  goto l784;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_InterfaceDecl, G->begin, G->end, "yy_3_InterfaceDecl");
 
-  l819:;	
-  {  int yypos820= G->pos, yythunkpos820= G->thunkpos;  if (!yy__(G))  goto l820;
-  if (!yymatchChar(G, ',')) goto l820;
-  if (!yy__(G))  goto l820;
-  if (!yy_Type(G))  goto l820;
+  l786:;	
+  {  int yypos787= G->pos, yythunkpos787= G->thunkpos;  if (!yy__(G))  goto l787;
+  if (!yymatchChar(G, ',')) goto l787;
+  if (!yy__(G))  goto l787;
+  if (!yy_Type(G))  goto l787;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_4_InterfaceDecl, G->begin, G->end, "yy_4_InterfaceDecl");
-  goto l819;
-  l820:;	  G->pos= yypos820; G->thunkpos= yythunkpos820;
-  }  goto l818;
-  l817:;	  G->pos= yypos817; G->thunkpos= yythunkpos817;
+  goto l786;
+  l787:;	  G->pos= yypos787; G->thunkpos= yythunkpos787;
+  }  goto l785;
+  l784:;	  G->pos= yypos784; G->thunkpos= yythunkpos784;
   }
-  l818:;	  if (!yy_WS(G))  goto l812;
-  if (!yymatchChar(G, '{')) goto l812;
-  if (!yy_WS(G))  goto l812;
+  l785:;	  if (!yy_WS(G))  goto l779;
+  if (!yymatchChar(G, '{')) goto l779;
+  if (!yy_WS(G))  goto l779;
 
-  l821:;	
-  {  int yypos822= G->pos, yythunkpos822= G->thunkpos;  if (!yy_WS(G))  goto l822;
-  if (!yy_FunctionDecl(G))  goto l822;
+  l788:;	
+  {  int yypos789= G->pos, yythunkpos789= G->thunkpos;  if (!yy_WS(G))  goto l789;
+  if (!yy_FunctionDecl(G))  goto l789;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l822;
-  goto l821;
-  l822:;	  G->pos= yypos822; G->thunkpos= yythunkpos822;
-  }  if (!yy_WS(G))  goto l812;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected method or '"_CSBRACK"' to close interface.\n"); ; } goto l812; }
+  if (!yy_WS(G))  goto l789;
+  goto l788;
+  l789:;	  G->pos= yypos789; G->thunkpos= yythunkpos789;
+  }  if (!yy_WS(G))  goto l779;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected method or '"_CSBRACK"' to close interface.\n"); ; } goto l779; }
   yyDo(G, yy_5_InterfaceDecl, G->begin, G->end, "yy_5_InterfaceDecl");
   yyprintf((stderr, "  ok   InterfaceDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l812:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "InterfaceDecl"));
+  l779:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "InterfaceDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12424,86 +12125,86 @@ YY_RULE(int) yy_InterfaceDecl(GREG *G)
 YY_RULE(int) yy_EnumDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 5, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "EnumDecl"));
-  if (!yy_OocDoc(G))  goto l823;
+  if (!yy_OocDoc(G))  goto l790;
   yyDo(G, yySet, -5, 0, "yySet");
-  if (!yy_IDENT(G))  goto l823;
+  if (!yy_IDENT(G))  goto l790;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_1_EnumDecl, G->begin, G->end, "yy_1_EnumDecl");
-  if (!yy__(G))  goto l823;
-  if (!yy_COLON(G))  goto l823;
-  if (!yy__(G))  goto l823;
-  if (!yy_ENUM_KW(G))  goto l823;
+  if (!yy__(G))  goto l790;
+  if (!yy_COLON(G))  goto l790;
+  if (!yy__(G))  goto l790;
+  if (!yy_ENUM_KW(G))  goto l790;
 
-  {  int yypos824= G->pos, yythunkpos824= G->thunkpos;  if (!yy__(G))  goto l824;
-  if (!yy_FROM_KW(G))  goto l824;
-  if (!yy__(G))  goto l824;
-  if (!yy_Type(G))  goto l824;
+  {  int yypos791= G->pos, yythunkpos791= G->thunkpos;  if (!yy__(G))  goto l791;
+  if (!yy_FROM_KW(G))  goto l791;
+  if (!yy__(G))  goto l791;
+  if (!yy_Type(G))  goto l791;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_2_EnumDecl, G->begin, G->end, "yy_2_EnumDecl");
-  goto l825;
-  l824:;	  G->pos= yypos824; G->thunkpos= yythunkpos824;
+  goto l792;
+  l791:;	  G->pos= yypos791; G->thunkpos= yythunkpos791;
   }
-  l825:;	
-  {  int yypos826= G->pos, yythunkpos826= G->thunkpos;  if (!yy__(G))  goto l826;
-  if (!yymatchChar(G, '(')) goto l826;
-  if (!yy__(G))  goto l826;
-  if (!yy_EnumIncrementOper(G))  goto l826;
+  l792:;	
+  {  int yypos793= G->pos, yythunkpos793= G->thunkpos;  if (!yy__(G))  goto l793;
+  if (!yymatchChar(G, '(')) goto l793;
+  if (!yy__(G))  goto l793;
+  if (!yy_EnumIncrementOper(G))  goto l793;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l826;
-  if (!yy_IntLiteral(G))  goto l826;
+  if (!yy_WS(G))  goto l793;
+  if (!yy_IntLiteral(G))  goto l793;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_EnumDecl, G->begin, G->end, "yy_3_EnumDecl");
-  if (!yy__(G))  goto l826;
-  if (!yymatchChar(G, ')')) goto l826;
-  goto l827;
-  l826:;	  G->pos= yypos826; G->thunkpos= yythunkpos826;
+  if (!yy__(G))  goto l793;
+  if (!yymatchChar(G, ')')) goto l793;
+  goto l794;
+  l793:;	  G->pos= yypos793; G->thunkpos= yythunkpos793;
   }
-  l827:;	  if (!yy_WS(G))  goto l823;
-  if (!yymatchChar(G, '{')) goto l823;
-  if (!yy_WS(G))  goto l823;
+  l794:;	  if (!yy_WS(G))  goto l790;
+  if (!yymatchChar(G, '{')) goto l790;
+  if (!yy_WS(G))  goto l790;
 
-  {  int yypos828= G->pos, yythunkpos828= G->thunkpos;  if (!yy_EnumElement(G))  goto l828;
+  {  int yypos795= G->pos, yythunkpos795= G->thunkpos;  if (!yy_EnumElement(G))  goto l795;
 
-  l830:;	
-  {  int yypos831= G->pos, yythunkpos831= G->thunkpos;
-  {  int yypos832= G->pos, yythunkpos832= G->thunkpos;  if (!yy_Terminator(G))  goto l833;
+  l797:;	
+  {  int yypos798= G->pos, yythunkpos798= G->thunkpos;
+  {  int yypos799= G->pos, yythunkpos799= G->thunkpos;  if (!yy_Terminator(G))  goto l800;
 
-  l834:;	
-  {  int yypos835= G->pos, yythunkpos835= G->thunkpos;  if (!yy_Terminator(G))  goto l835;
-  goto l834;
-  l835:;	  G->pos= yypos835; G->thunkpos= yythunkpos835;
-  }  if (!yy_WS(G))  goto l833;
-  if (!yy_FunctionDecl(G))  goto l833;
-  goto l832;
-  l833:;	  G->pos= yypos832; G->thunkpos= yythunkpos832;
-  {  int yypos836= G->pos, yythunkpos836= G->thunkpos;  if (!yymatchChar(G, ',')) goto l837;
-  goto l836;
-  l837:;	  G->pos= yypos836; G->thunkpos= yythunkpos836;  if (!yy_Terminator(G))  goto l831;
+  l801:;	
+  {  int yypos802= G->pos, yythunkpos802= G->thunkpos;  if (!yy_Terminator(G))  goto l802;
+  goto l801;
+  l802:;	  G->pos= yypos802; G->thunkpos= yythunkpos802;
+  }  if (!yy_WS(G))  goto l800;
+  if (!yy_FunctionDecl(G))  goto l800;
+  goto l799;
+  l800:;	  G->pos= yypos799; G->thunkpos= yythunkpos799;
+  {  int yypos803= G->pos, yythunkpos803= G->thunkpos;  if (!yymatchChar(G, ',')) goto l804;
+  goto l803;
+  l804:;	  G->pos= yypos803; G->thunkpos= yythunkpos803;  if (!yy_Terminator(G))  goto l798;
 
-  l838:;	
-  {  int yypos839= G->pos, yythunkpos839= G->thunkpos;  if (!yy_Terminator(G))  goto l839;
-  goto l838;
-  l839:;	  G->pos= yypos839; G->thunkpos= yythunkpos839;
+  l805:;	
+  {  int yypos806= G->pos, yythunkpos806= G->thunkpos;  if (!yy_Terminator(G))  goto l806;
+  goto l805;
+  l806:;	  G->pos= yypos806; G->thunkpos= yythunkpos806;
   }
   }
-  l836:;	  if (!yy_WS(G))  goto l831;
-  if (!yy_EnumElement(G))  goto l831;
+  l803:;	  if (!yy_WS(G))  goto l798;
+  if (!yy_EnumElement(G))  goto l798;
 
   }
-  l832:;	  goto l830;
-  l831:;	  G->pos= yypos831; G->thunkpos= yythunkpos831;
-  }  goto l829;
-  l828:;	  G->pos= yypos828; G->thunkpos= yythunkpos828;
+  l799:;	  goto l797;
+  l798:;	  G->pos= yypos798; G->thunkpos= yythunkpos798;
+  }  goto l796;
+  l795:;	  G->pos= yypos795; G->thunkpos= yythunkpos795;
   }
-  l829:;	  if (!yy_WS(G))  goto l823;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ENUM_ELEMENT, "Expected enum element!\n"); ; } goto l823; }
+  l796:;	  if (!yy_WS(G))  goto l790;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_ENUM_ELEMENT, "Expected enum element!\n"); ; } goto l790; }
   yyDo(G, yy_4_EnumDecl, G->begin, G->end, "yy_4_EnumDecl");
   yyprintf((stderr, "  ok   EnumDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 5, 0, "yyPop");
   return 1;
-  l823:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumDecl"));
+  l790:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EnumDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12512,40 +12213,40 @@ YY_RULE(int) yy_EnumDecl(GREG *G)
 YY_RULE(int) yy_ExtendDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ExtendDecl"));
-  if (!yy_OocDoc(G))  goto l840;
+  if (!yy_OocDoc(G))  goto l807;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yymatchString(G, "extend")) goto l840;
-  if (!yy_WS(G))  goto l840;
-  if (!yy_Type(G))  goto l840;
+  if (!yymatchString(G, "extend")) goto l807;
+  if (!yy_WS(G))  goto l807;
+  if (!yy_Type(G))  goto l807;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_1_ExtendDecl, G->begin, G->end, "yy_1_ExtendDecl");
-  if (!yy_WS(G))  goto l840;
-  if (!yymatchChar(G, '{')) goto l840;
-  if (!yy_WS(G))  goto l840;
+  if (!yy_WS(G))  goto l807;
+  if (!yymatchChar(G, '{')) goto l807;
+  if (!yy_WS(G))  goto l807;
 
-  l841:;	
-  {  int yypos842= G->pos, yythunkpos842= G->thunkpos;  if (!yy_WS(G))  goto l842;
+  l808:;	
+  {  int yypos809= G->pos, yythunkpos809= G->thunkpos;  if (!yy_WS(G))  goto l809;
 
-  {  int yypos843= G->pos, yythunkpos843= G->thunkpos;  if (!yy_FunctionDecl(G))  goto l844;
+  {  int yypos810= G->pos, yythunkpos810= G->thunkpos;  if (!yy_FunctionDecl(G))  goto l811;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l843;
-  l844:;	  G->pos= yypos843; G->thunkpos= yythunkpos843;  if (!yy_PropertyDecl(G))  goto l842;
+  goto l810;
+  l811:;	  G->pos= yypos810; G->thunkpos= yythunkpos810;  if (!yy_PropertyDecl(G))  goto l809;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_ExtendDecl, G->begin, G->end, "yy_2_ExtendDecl");
 
   }
-  l843:;	  if (!yy_WS(G))  goto l842;
-  goto l841;
-  l842:;	  G->pos= yypos842; G->thunkpos= yythunkpos842;
-  }  if (!yy_WS(G))  goto l840;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected or function declaration\n"); ; } goto l840; }
+  l810:;	  if (!yy_WS(G))  goto l809;
+  goto l808;
+  l809:;	  G->pos= yypos809; G->thunkpos= yythunkpos809;
+  }  if (!yy_WS(G))  goto l807;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected or function declaration\n"); ; } goto l807; }
   yyDo(G, yy_3_ExtendDecl, G->begin, G->end, "yy_3_ExtendDecl");
   yyprintf((stderr, "  ok   ExtendDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l840:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExtendDecl"));
+  l807:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ExtendDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12554,124 +12255,124 @@ YY_RULE(int) yy_ExtendDecl(GREG *G)
 YY_RULE(int) yy_CoverDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 8, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "CoverDecl"));
-  if (!yy_OocDoc(G))  goto l845;
+  if (!yy_OocDoc(G))  goto l812;
   yyDo(G, yySet, -8, 0, "yySet");
-  if (!yy_IDENT(G))  goto l845;
+  if (!yy_IDENT(G))  goto l812;
   yyDo(G, yySet, -7, 0, "yySet");
   yyDo(G, yy_1_CoverDecl, G->begin, G->end, "yy_1_CoverDecl");
-  if (!yy__(G))  goto l845;
-  if (!yy_COLON(G))  goto l845;
+  if (!yy__(G))  goto l812;
+  if (!yy_COLON(G))  goto l812;
 
-  {  int yypos846= G->pos, yythunkpos846= G->thunkpos;  if (!yy__(G))  goto l846;
-  if (!yy_ExternName(G))  goto l846;
+  {  int yypos813= G->pos, yythunkpos813= G->thunkpos;  if (!yy__(G))  goto l813;
+  if (!yy_ExternName(G))  goto l813;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_2_CoverDecl, G->begin, G->end, "yy_2_CoverDecl");
-  goto l847;
-  l846:;	  G->pos= yypos846; G->thunkpos= yythunkpos846;
+  goto l814;
+  l813:;	  G->pos= yypos813; G->thunkpos= yythunkpos813;
   }
-  l847:;	
-  {  int yypos848= G->pos, yythunkpos848= G->thunkpos;  if (!yy__(G))  goto l848;
-  if (!yy_PROTO_KW(G))  goto l848;
+  l814:;	
+  {  int yypos815= G->pos, yythunkpos815= G->thunkpos;  if (!yy__(G))  goto l815;
+  if (!yy_PROTO_KW(G))  goto l815;
   yyDo(G, yy_3_CoverDecl, G->begin, G->end, "yy_3_CoverDecl");
-  goto l849;
-  l848:;	  G->pos= yypos848; G->thunkpos= yythunkpos848;
+  goto l816;
+  l815:;	  G->pos= yypos815; G->thunkpos= yythunkpos815;
   }
-  l849:;	  if (!yy__(G))  goto l845;
-  if (!yy_COVER_KW(G))  goto l845;
+  l816:;	  if (!yy__(G))  goto l812;
+  if (!yy_COVER_KW(G))  goto l812;
 
-  {  int yypos850= G->pos, yythunkpos850= G->thunkpos;  if (!yy_GenericArguments(G))  goto l850;
-  goto l851;
-  l850:;	  G->pos= yypos850; G->thunkpos= yythunkpos850;
+  {  int yypos817= G->pos, yythunkpos817= G->thunkpos;  if (!yy_GenericArguments(G))  goto l817;
+  goto l818;
+  l817:;	  G->pos= yypos817; G->thunkpos= yythunkpos817;
   }
-  l851:;	
-  {  int yypos852= G->pos, yythunkpos852= G->thunkpos;  if (!yy_TemplateDef(G))  goto l852;
-  goto l853;
-  l852:;	  G->pos= yypos852; G->thunkpos= yythunkpos852;
+  l818:;	
+  {  int yypos819= G->pos, yythunkpos819= G->thunkpos;  if (!yy_TemplateDef(G))  goto l819;
+  goto l820;
+  l819:;	  G->pos= yypos819; G->thunkpos= yythunkpos819;
   }
-  l853:;	
-  {  int yypos854= G->pos, yythunkpos854= G->thunkpos;  if (!yy__(G))  goto l854;
-  if (!yy_FROM_KW(G))  goto l854;
-  if (!yy__(G))  goto l854;
-  if (!yy_Type(G))  goto l854;
+  l820:;	
+  {  int yypos821= G->pos, yythunkpos821= G->thunkpos;  if (!yy__(G))  goto l821;
+  if (!yy_FROM_KW(G))  goto l821;
+  if (!yy__(G))  goto l821;
+  if (!yy_Type(G))  goto l821;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_4_CoverDecl, G->begin, G->end, "yy_4_CoverDecl");
-  goto l855;
-  l854:;	  G->pos= yypos854; G->thunkpos= yythunkpos854;
+  goto l822;
+  l821:;	  G->pos= yypos821; G->thunkpos= yythunkpos821;
   }
-  l855:;	
-  {  int yypos856= G->pos, yythunkpos856= G->thunkpos;  if (!yy__(G))  goto l856;
-  if (!yy_EXTENDS_KW(G))  goto l856;
-  if (!yy__(G))  goto l856;
-  if (!yy_Type(G))  goto l856;
+  l822:;	
+  {  int yypos823= G->pos, yythunkpos823= G->thunkpos;  if (!yy__(G))  goto l823;
+  if (!yy_EXTENDS_KW(G))  goto l823;
+  if (!yy__(G))  goto l823;
+  if (!yy_Type(G))  goto l823;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_5_CoverDecl, G->begin, G->end, "yy_5_CoverDecl");
-  goto l857;
-  l856:;	  G->pos= yypos856; G->thunkpos= yythunkpos856;
+  goto l824;
+  l823:;	  G->pos= yypos823; G->thunkpos= yythunkpos823;
   }
-  l857:;	
-  {  int yypos858= G->pos, yythunkpos858= G->thunkpos;  if (!yy__(G))  goto l858;
-  if (!yy_IMPLEMENTS_KW(G))  goto l858;
-  if (!yy__(G))  goto l858;
-  if (!yy_Type(G))  goto l858;
+  l824:;	
+  {  int yypos825= G->pos, yythunkpos825= G->thunkpos;  if (!yy__(G))  goto l825;
+  if (!yy_IMPLEMENTS_KW(G))  goto l825;
+  if (!yy__(G))  goto l825;
+  if (!yy_Type(G))  goto l825;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_6_CoverDecl, G->begin, G->end, "yy_6_CoverDecl");
 
-  l860:;	
-  {  int yypos861= G->pos, yythunkpos861= G->thunkpos;  if (!yy__(G))  goto l861;
-  if (!yymatchChar(G, ',')) goto l861;
-  if (!yy__(G))  goto l861;
-  if (!yy_Type(G))  goto l861;
+  l827:;	
+  {  int yypos828= G->pos, yythunkpos828= G->thunkpos;  if (!yy__(G))  goto l828;
+  if (!yymatchChar(G, ',')) goto l828;
+  if (!yy__(G))  goto l828;
+  if (!yy_Type(G))  goto l828;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_7_CoverDecl, G->begin, G->end, "yy_7_CoverDecl");
-  goto l860;
-  l861:;	  G->pos= yypos861; G->thunkpos= yythunkpos861;
-  }  goto l859;
-  l858:;	  G->pos= yypos858; G->thunkpos= yythunkpos858;
+  goto l827;
+  l828:;	  G->pos= yypos828; G->thunkpos= yythunkpos828;
+  }  goto l826;
+  l825:;	  G->pos= yypos825; G->thunkpos= yythunkpos825;
   }
-  l859:;	
-  {  int yypos862= G->pos, yythunkpos862= G->thunkpos;  if (!yy_WS(G))  goto l862;
-  if (!yymatchChar(G, '{')) goto l862;
-  if (!yy_WS(G))  goto l862;
+  l826:;	
+  {  int yypos829= G->pos, yythunkpos829= G->thunkpos;  if (!yy_WS(G))  goto l829;
+  if (!yymatchChar(G, '{')) goto l829;
+  if (!yy_WS(G))  goto l829;
 
-  l864:;	
-  {  int yypos865= G->pos, yythunkpos865= G->thunkpos;  if (!yy_WS(G))  goto l865;
+  l831:;	
+  {  int yypos832= G->pos, yythunkpos832= G->thunkpos;  if (!yy_WS(G))  goto l832;
 
-  {  int yypos866= G->pos, yythunkpos866= G->thunkpos;  if (!yy_VariableDecl(G))  goto l867;
+  {  int yypos833= G->pos, yythunkpos833= G->thunkpos;  if (!yy_VariableDecl(G))  goto l834;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_8_CoverDecl, G->begin, G->end, "yy_8_CoverDecl");
-  if (!yy_Terminator(G))  goto l867;
+  if (!yy_Terminator(G))  goto l834;
 
-  l868:;	
-  {  int yypos869= G->pos, yythunkpos869= G->thunkpos;  if (!yy_Terminator(G))  goto l869;
-  goto l868;
-  l869:;	  G->pos= yypos869; G->thunkpos= yythunkpos869;
-  }  goto l866;
-  l867:;	  G->pos= yypos866; G->thunkpos= yythunkpos866;  if (!yy_PropertyDecl(G))  goto l870;
+  l835:;	
+  {  int yypos836= G->pos, yythunkpos836= G->thunkpos;  if (!yy_Terminator(G))  goto l836;
+  goto l835;
+  l836:;	  G->pos= yypos836; G->thunkpos= yythunkpos836;
+  }  goto l833;
+  l834:;	  G->pos= yypos833; G->thunkpos= yythunkpos833;  if (!yy_PropertyDecl(G))  goto l837;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_9_CoverDecl, G->begin, G->end, "yy_9_CoverDecl");
-  goto l866;
-  l870:;	  G->pos= yypos866; G->thunkpos= yythunkpos866;  if (!yy_OperatorDecl(G))  goto l871;
+  goto l833;
+  l837:;	  G->pos= yypos833; G->thunkpos= yythunkpos833;  if (!yy_OperatorDecl(G))  goto l838;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l866;
-  l871:;	  G->pos= yypos866; G->thunkpos= yythunkpos866;  if (!yy_FunctionDecl(G))  goto l865;
+  goto l833;
+  l838:;	  G->pos= yypos833; G->thunkpos= yythunkpos833;  if (!yy_FunctionDecl(G))  goto l832;
   yyDo(G, yySet, -1, 0, "yySet");
 
   }
-  l866:;	  if (!yy_WS(G))  goto l865;
-  goto l864;
-  l865:;	  G->pos= yypos865; G->thunkpos= yythunkpos865;
-  }  if (!yy_WS(G))  goto l862;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n"); ; } goto l862; }
-  goto l863;
-  l862:;	  G->pos= yypos862; G->thunkpos= yythunkpos862;
+  l833:;	  if (!yy_WS(G))  goto l832;
+  goto l831;
+  l832:;	  G->pos= yypos832; G->thunkpos= yythunkpos832;
+  }  if (!yy_WS(G))  goto l829;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected variable declaration or function declaration\n"); ; } goto l829; }
+  goto l830;
+  l829:;	  G->pos= yypos829; G->thunkpos= yythunkpos829;
   }
-  l863:;	  yyDo(G, yy_10_CoverDecl, G->begin, G->end, "yy_10_CoverDecl");
+  l830:;	  yyDo(G, yy_10_CoverDecl, G->begin, G->end, "yy_10_CoverDecl");
   yyprintf((stderr, "  ok   CoverDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 8, 0, "yyPop");
   return 1;
-  l845:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CoverDecl"));
+  l812:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CoverDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12680,115 +12381,110 @@ YY_RULE(int) yy_CoverDecl(GREG *G)
 YY_RULE(int) yy_ClassDecl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 8, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ClassDecl"));
-  if (!yy_OocDoc(G))  goto l872;
+  if (!yy_OocDoc(G))  goto l839;
   yyDo(G, yySet, -8, 0, "yySet");
-  if (!yy_IDENT(G))  goto l872;
+  if (!yy_IDENT(G))  goto l839;
   yyDo(G, yySet, -7, 0, "yySet");
   yyDo(G, yy_1_ClassDecl, G->begin, G->end, "yy_1_ClassDecl");
-  if (!yy__(G))  goto l872;
-  if (!yy_COLON(G))  goto l872;
+  if (!yy__(G))  goto l839;
+  if (!yy_COLON(G))  goto l839;
 
-  l873:;	
-  {  int yypos874= G->pos, yythunkpos874= G->thunkpos;  if (!yy__(G))  goto l874;
+  l840:;	
+  {  int yypos841= G->pos, yythunkpos841= G->thunkpos;  if (!yy__(G))  goto l841;
 
-  {  int yypos875= G->pos, yythunkpos875= G->thunkpos;  if (!yy_ExternName(G))  goto l876;
-  goto l875;
-  l876:;	  G->pos= yypos875; G->thunkpos= yythunkpos875;  if (!yy_ABSTRACT_KW(G))  goto l877;
+  {  int yypos842= G->pos, yythunkpos842= G->thunkpos;  if (!yy_ExternName(G))  goto l843;
+  goto l842;
+  l843:;	  G->pos= yypos842; G->thunkpos= yythunkpos842;  if (!yy_ABSTRACT_KW(G))  goto l844;
   yyDo(G, yy_2_ClassDecl, G->begin, G->end, "yy_2_ClassDecl");
-  goto l875;
-  l877:;	  G->pos= yypos875; G->thunkpos= yythunkpos875;  if (!yy_FINAL_KW(G))  goto l874;
+  goto l842;
+  l844:;	  G->pos= yypos842; G->thunkpos= yythunkpos842;  if (!yy_FINAL_KW(G))  goto l841;
   yyDo(G, yy_3_ClassDecl, G->begin, G->end, "yy_3_ClassDecl");
 
   }
-  l875:;	  goto l873;
-  l874:;	  G->pos= yypos874; G->thunkpos= yythunkpos874;
-  }  if (!yy__(G))  goto l872;
-  if (!yy_CLASS_KW(G))  goto l872;
+  l842:;	  goto l840;
+  l841:;	  G->pos= yypos841; G->thunkpos= yythunkpos841;
+  }  if (!yy__(G))  goto l839;
+  if (!yy_CLASS_KW(G))  goto l839;
 
-  {  int yypos878= G->pos, yythunkpos878= G->thunkpos;  if (!yy_GenericArguments(G))  goto l878;
-  goto l879;
-  l878:;	  G->pos= yypos878; G->thunkpos= yythunkpos878;
+  {  int yypos845= G->pos, yythunkpos845= G->thunkpos;  if (!yy_GenericArguments(G))  goto l845;
+  goto l846;
+  l845:;	  G->pos= yypos845; G->thunkpos= yythunkpos845;
   }
-  l879:;	
-  {  int yypos880= G->pos, yythunkpos880= G->thunkpos;  if (!yy_TemplateDef(G))  goto l880;
-  goto l881;
-  l880:;	  G->pos= yypos880; G->thunkpos= yythunkpos880;
-  }
-  l881:;	
-  {  int yypos882= G->pos, yythunkpos882= G->thunkpos;  if (!yy__(G))  goto l882;
-  if (!yy_EXTENDS_KW(G))  goto l882;
-  if (!yy__(G))  goto l882;
-  if (!yy_Type(G))  goto l882;
+  l846:;	
+  {  int yypos847= G->pos, yythunkpos847= G->thunkpos;  if (!yy__(G))  goto l847;
+  if (!yy_EXTENDS_KW(G))  goto l847;
+  if (!yy__(G))  goto l847;
+  if (!yy_Type(G))  goto l847;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_4_ClassDecl, G->begin, G->end, "yy_4_ClassDecl");
-  goto l883;
-  l882:;	  G->pos= yypos882; G->thunkpos= yythunkpos882;
+  goto l848;
+  l847:;	  G->pos= yypos847; G->thunkpos= yythunkpos847;
   }
-  l883:;	
-  {  int yypos884= G->pos, yythunkpos884= G->thunkpos;  if (!yy__(G))  goto l884;
-  if (!yy_IMPLEMENTS_KW(G))  goto l884;
-  if (!yy__(G))  goto l884;
-  if (!yy_Type(G))  goto l884;
+  l848:;	
+  {  int yypos849= G->pos, yythunkpos849= G->thunkpos;  if (!yy__(G))  goto l849;
+  if (!yy_IMPLEMENTS_KW(G))  goto l849;
+  if (!yy__(G))  goto l849;
+  if (!yy_Type(G))  goto l849;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_5_ClassDecl, G->begin, G->end, "yy_5_ClassDecl");
 
-  l886:;	
-  {  int yypos887= G->pos, yythunkpos887= G->thunkpos;  if (!yy__(G))  goto l887;
-  if (!yymatchChar(G, ',')) goto l887;
-  if (!yy__(G))  goto l887;
-  if (!yy_Type(G))  goto l887;
+  l851:;	
+  {  int yypos852= G->pos, yythunkpos852= G->thunkpos;  if (!yy__(G))  goto l852;
+  if (!yymatchChar(G, ',')) goto l852;
+  if (!yy__(G))  goto l852;
+  if (!yy_Type(G))  goto l852;
   yyDo(G, yySet, -6, 0, "yySet");
   yyDo(G, yy_6_ClassDecl, G->begin, G->end, "yy_6_ClassDecl");
-  goto l886;
-  l887:;	  G->pos= yypos887; G->thunkpos= yythunkpos887;
-  }  goto l885;
-  l884:;	  G->pos= yypos884; G->thunkpos= yythunkpos884;
+  goto l851;
+  l852:;	  G->pos= yypos852; G->thunkpos= yythunkpos852;
+  }  goto l850;
+  l849:;	  G->pos= yypos849; G->thunkpos= yythunkpos849;
   }
-  l885:;	  yyDo(G, yy_7_ClassDecl, G->begin, G->end, "yy_7_ClassDecl");
-  if (!yy_WS(G))  goto l872;
-  if (!yymatchChar(G, '{')) goto l872;
-  if (!yy_WS(G))  goto l872;
+  l850:;	  yyDo(G, yy_7_ClassDecl, G->begin, G->end, "yy_7_ClassDecl");
+  if (!yy_WS(G))  goto l839;
+  if (!yymatchChar(G, '{')) goto l839;
+  if (!yy_WS(G))  goto l839;
 
-  l888:;	
-  {  int yypos889= G->pos, yythunkpos889= G->thunkpos;  if (!yy_WS(G))  goto l889;
+  l853:;	
+  {  int yypos854= G->pos, yythunkpos854= G->thunkpos;  if (!yy_WS(G))  goto l854;
 
-  {  int yypos890= G->pos, yythunkpos890= G->thunkpos;  if (!yy_VariableDecl(G))  goto l891;
+  {  int yypos855= G->pos, yythunkpos855= G->thunkpos;  if (!yy_VariableDecl(G))  goto l856;
   yyDo(G, yySet, -5, 0, "yySet");
   yyDo(G, yy_8_ClassDecl, G->begin, G->end, "yy_8_ClassDecl");
-  if (!yy_Terminator(G))  goto l891;
+  if (!yy_Terminator(G))  goto l856;
 
-  l892:;	
-  {  int yypos893= G->pos, yythunkpos893= G->thunkpos;  if (!yy_Terminator(G))  goto l893;
-  goto l892;
-  l893:;	  G->pos= yypos893; G->thunkpos= yythunkpos893;
-  }  goto l890;
-  l891:;	  G->pos= yypos890; G->thunkpos= yythunkpos890;  if (!yy_PropertyDecl(G))  goto l894;
+  l857:;	
+  {  int yypos858= G->pos, yythunkpos858= G->thunkpos;  if (!yy_Terminator(G))  goto l858;
+  goto l857;
+  l858:;	  G->pos= yypos858; G->thunkpos= yythunkpos858;
+  }  goto l855;
+  l856:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_PropertyDecl(G))  goto l859;
   yyDo(G, yySet, -4, 0, "yySet");
   yyDo(G, yy_9_ClassDecl, G->begin, G->end, "yy_9_ClassDecl");
-  goto l890;
-  l894:;	  G->pos= yypos890; G->thunkpos= yythunkpos890;  if (!yy_FunctionDecl(G))  goto l895;
+  goto l855;
+  l859:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_FunctionDecl(G))  goto l860;
   yyDo(G, yySet, -3, 0, "yySet");
-  goto l890;
-  l895:;	  G->pos= yypos890; G->thunkpos= yythunkpos890;  if (!yy_OperatorDecl(G))  goto l896;
+  goto l855;
+  l860:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_OperatorDecl(G))  goto l861;
   yyDo(G, yySet, -2, 0, "yySet");
-  goto l890;
-  l896:;	  G->pos= yypos890; G->thunkpos= yythunkpos890;  if (!yy_Stmt(G))  goto l889;
+  goto l855;
+  l861:;	  G->pos= yypos855; G->thunkpos= yythunkpos855;  if (!yy_Stmt(G))  goto l854;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_10_ClassDecl, G->begin, G->end, "yy_10_ClassDecl");
 
   }
-  l890:;	  if (!yy_WS(G))  goto l889;
-  goto l888;
-  l889:;	  G->pos= yypos889; G->thunkpos= yythunkpos889;
-  }  if (!yy_WS(G))  goto l872;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected member, method, or '"_CSBRACK"' to close class.\n"); ; } goto l872; }
+  l855:;	  if (!yy_WS(G))  goto l854;
+  goto l853;
+  l854:;	  G->pos= yypos854; G->thunkpos= yythunkpos854;
+  }  if (!yy_WS(G))  goto l839;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  throwError(NQE_EXP_VAR_OR_FUNC_DECL, "Expected member, method, or '"_CSBRACK"' to close class.\n"); ; } goto l839; }
   yyDo(G, yy_11_ClassDecl, G->begin, G->end, "yy_11_ClassDecl");
   yyprintf((stderr, "  ok   ClassDecl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 8, 0, "yyPop");
   return 1;
-  l872:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ClassDecl"));
+  l839:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ClassDecl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12797,15 +12493,15 @@ YY_RULE(int) yy_ClassDecl(GREG *G)
 YY_RULE(int) yy_IDENT(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IDENT"));
-  if (!yy_IDENT_CORE(G))  goto l897;
+  if (!yy_IDENT_CORE(G))  goto l862;
   yyDo(G, yySet, 0, 0, "yySet");
-  if (!yy__(G))  goto l897;
+  if (!yy__(G))  goto l862;
   yyprintf((stderr, "  ok   IDENT"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l897:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IDENT"));
+  l862:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IDENT"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12813,13 +12509,13 @@ YY_RULE(int) yy_IDENT(GREG *G)
 }
 YY_RULE(int) yy_INTO_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INTO_KW"));
-  if (!yymatchString(G, "into")) goto l898;
+  if (!yymatchString(G, "into")) goto l863;
   yyprintf((stderr, "  ok   INTO_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l898:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTO_KW"));
+  l863:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INTO_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12827,29 +12523,29 @@ YY_RULE(int) yy_INTO_KW(GREG *G)
 }
 YY_RULE(int) yy_ImportName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ImportName"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l899;
-  {  int yypos902= G->pos, yythunkpos902= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l903;
-  goto l902;
-  l903:;	  G->pos= yypos902; G->thunkpos= yythunkpos902;  if (!yymatchChar(G, '-')) goto l899;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l864;
+  {  int yypos867= G->pos, yythunkpos867= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l868;
+  goto l867;
+  l868:;	  G->pos= yypos867; G->thunkpos= yythunkpos867;  if (!yymatchChar(G, '-')) goto l864;
 
   }
-  l902:;	
-  l900:;	
-  {  int yypos901= G->pos, yythunkpos901= G->thunkpos;
-  {  int yypos904= G->pos, yythunkpos904= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l905;
-  goto l904;
-  l905:;	  G->pos= yypos904; G->thunkpos= yythunkpos904;  if (!yymatchChar(G, '-')) goto l901;
+  l867:;	
+  l865:;	
+  {  int yypos866= G->pos, yythunkpos866= G->thunkpos;
+  {  int yypos869= G->pos, yythunkpos869= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l870;
+  goto l869;
+  l870:;	  G->pos= yypos869; G->thunkpos= yythunkpos869;  if (!yymatchChar(G, '-')) goto l866;
 
   }
-  l904:;	  goto l900;
-  l901:;	  G->pos= yypos901; G->thunkpos= yythunkpos901;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l899;  yyDo(G, yy_1_ImportName, G->begin, G->end, "yy_1_ImportName");
+  l869:;	  goto l865;
+  l866:;	  G->pos= yypos866; G->thunkpos= yythunkpos866;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l864;  yyDo(G, yy_1_ImportName, G->begin, G->end, "yy_1_ImportName");
   yyprintf((stderr, "  ok   ImportName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l899:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportName"));
+  l864:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12857,38 +12553,38 @@ YY_RULE(int) yy_ImportName(GREG *G)
 }
 YY_RULE(int) yy_ImportPath(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "ImportPath"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l906;
-  l907:;	
-  {  int yypos908= G->pos, yythunkpos908= G->thunkpos;
-  {  int yypos911= G->pos, yythunkpos911= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l912;
-  goto l911;
-  l912:;	  G->pos= yypos911; G->thunkpos= yythunkpos911;  if (!yymatchChar(G, '.')) goto l913;
-  goto l911;
-  l913:;	  G->pos= yypos911; G->thunkpos= yythunkpos911;  if (!yymatchChar(G, '-')) goto l908;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l871;
+  l872:;	
+  {  int yypos873= G->pos, yythunkpos873= G->thunkpos;
+  {  int yypos876= G->pos, yythunkpos876= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l877;
+  goto l876;
+  l877:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;  if (!yymatchChar(G, '.')) goto l878;
+  goto l876;
+  l878:;	  G->pos= yypos876; G->thunkpos= yythunkpos876;  if (!yymatchChar(G, '-')) goto l873;
 
   }
-  l911:;	
-  l909:;	
-  {  int yypos910= G->pos, yythunkpos910= G->thunkpos;
-  {  int yypos914= G->pos, yythunkpos914= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l915;
-  goto l914;
-  l915:;	  G->pos= yypos914; G->thunkpos= yythunkpos914;  if (!yymatchChar(G, '.')) goto l916;
-  goto l914;
-  l916:;	  G->pos= yypos914; G->thunkpos= yythunkpos914;  if (!yymatchChar(G, '-')) goto l910;
+  l876:;	
+  l874:;	
+  {  int yypos875= G->pos, yythunkpos875= G->thunkpos;
+  {  int yypos879= G->pos, yythunkpos879= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z_0-9")) goto l880;
+  goto l879;
+  l880:;	  G->pos= yypos879; G->thunkpos= yythunkpos879;  if (!yymatchChar(G, '.')) goto l881;
+  goto l879;
+  l881:;	  G->pos= yypos879; G->thunkpos= yythunkpos879;  if (!yymatchChar(G, '-')) goto l875;
 
   }
-  l914:;	  goto l909;
-  l910:;	  G->pos= yypos910; G->thunkpos= yythunkpos910;
-  }  if (!yymatchChar(G, '/')) goto l908;
-  goto l907;
-  l908:;	  G->pos= yypos908; G->thunkpos= yythunkpos908;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l906;  yyDo(G, yy_1_ImportPath, G->begin, G->end, "yy_1_ImportPath");
+  l879:;	  goto l874;
+  l875:;	  G->pos= yypos875; G->thunkpos= yythunkpos875;
+  }  if (!yymatchChar(G, '/')) goto l873;
+  goto l872;
+  l873:;	  G->pos= yypos873; G->thunkpos= yythunkpos873;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l871;  yyDo(G, yy_1_ImportPath, G->begin, G->end, "yy_1_ImportPath");
   yyprintf((stderr, "  ok   ImportPath"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l906:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportPath"));
+  l871:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportPath"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12897,60 +12593,60 @@ YY_RULE(int) yy_ImportPath(GREG *G)
 YY_RULE(int) yy_ImportAtom(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 3, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ImportAtom"));
-  if (!yy_ImportPath(G))  goto l917;
+  if (!yy_ImportPath(G))  goto l882;
   yyDo(G, yySet, -3, 0, "yySet");
 
-  {  int yypos918= G->pos, yythunkpos918= G->thunkpos;  if (!yy_ImportName(G))  goto l919;
+  {  int yypos883= G->pos, yythunkpos883= G->thunkpos;  if (!yy_ImportName(G))  goto l884;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_1_ImportAtom, G->begin, G->end, "yy_1_ImportAtom");
   yyDo(G, yy_2_ImportAtom, G->begin, G->end, "yy_2_ImportAtom");
 
-  {  int yypos920= G->pos, yythunkpos920= G->thunkpos;  if (!yy__(G))  goto l920;
-  if (!yy_INTO_KW(G))  goto l920;
-  if (!yy__(G))  goto l920;
-  if (!yy_IDENT(G))  goto l920;
+  {  int yypos885= G->pos, yythunkpos885= G->thunkpos;  if (!yy__(G))  goto l885;
+  if (!yy_INTO_KW(G))  goto l885;
+  if (!yy__(G))  goto l885;
+  if (!yy_IDENT(G))  goto l885;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_ImportAtom, G->begin, G->end, "yy_3_ImportAtom");
-  goto l921;
-  l920:;	  G->pos= yypos920; G->thunkpos= yythunkpos920;
+  goto l886;
+  l885:;	  G->pos= yypos885; G->thunkpos= yythunkpos885;
   }
-  l921:;	  goto l918;
-  l919:;	  G->pos= yypos918; G->thunkpos= yythunkpos918;  if (!yymatchChar(G, '[')) goto l917;
+  l886:;	  goto l883;
+  l884:;	  G->pos= yypos883; G->thunkpos= yythunkpos883;  if (!yymatchChar(G, '[')) goto l882;
   yyDo(G, yy_4_ImportAtom, G->begin, G->end, "yy_4_ImportAtom");
 
-  l922:;	
-  {  int yypos923= G->pos, yythunkpos923= G->thunkpos;  if (!yy_ImportName(G))  goto l923;
+  l887:;	
+  {  int yypos888= G->pos, yythunkpos888= G->thunkpos;  if (!yy_ImportName(G))  goto l888;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_5_ImportAtom, G->begin, G->end, "yy_5_ImportAtom");
-  if (!yy__(G))  goto l923;
-  if (!yymatchChar(G, ',')) goto l923;
-  if (!yy_WS(G))  goto l923;
+  if (!yy__(G))  goto l888;
+  if (!yymatchChar(G, ',')) goto l888;
+  if (!yy_WS(G))  goto l888;
   yyDo(G, yy_6_ImportAtom, G->begin, G->end, "yy_6_ImportAtom");
-  goto l922;
-  l923:;	  G->pos= yypos923; G->thunkpos= yythunkpos923;
-  }  if (!yy_ImportName(G))  goto l917;
+  goto l887;
+  l888:;	  G->pos= yypos888; G->thunkpos= yythunkpos888;
+  }  if (!yy_ImportName(G))  goto l882;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_7_ImportAtom, G->begin, G->end, "yy_7_ImportAtom");
   yyDo(G, yy_8_ImportAtom, G->begin, G->end, "yy_8_ImportAtom");
-  if (!yymatchChar(G, ']')) goto l917;
+  if (!yymatchChar(G, ']')) goto l882;
 
-  {  int yypos924= G->pos, yythunkpos924= G->thunkpos;  if (!yy__(G))  goto l924;
-  if (!yy_INTO_KW(G))  goto l924;
-  if (!yy__(G))  goto l924;
-  if (!yy_IDENT(G))  goto l924;
+  {  int yypos889= G->pos, yythunkpos889= G->thunkpos;  if (!yy__(G))  goto l889;
+  if (!yy_INTO_KW(G))  goto l889;
+  if (!yy__(G))  goto l889;
+  if (!yy_IDENT(G))  goto l889;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_9_ImportAtom, G->begin, G->end, "yy_9_ImportAtom");
-  goto l925;
-  l924:;	  G->pos= yypos924; G->thunkpos= yythunkpos924;
+  goto l890;
+  l889:;	  G->pos= yypos889; G->thunkpos= yythunkpos889;
   }
-  l925:;	
+  l890:;	
   }
-  l918:;	  yyprintf((stderr, "  ok   ImportAtom"));
+  l883:;	  yyprintf((stderr, "  ok   ImportAtom"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 3, 0, "yyPop");
   return 1;
-  l917:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportAtom"));
+  l882:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ImportAtom"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12958,13 +12654,13 @@ YY_RULE(int) yy_ImportAtom(GREG *G)
 }
 YY_RULE(int) yy_IMPORT_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "IMPORT_KW"));
-  if (!yymatchString(G, "import")) goto l926;
+  if (!yymatchString(G, "import")) goto l891;
   yyprintf((stderr, "  ok   IMPORT_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l926:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPORT_KW"));
+  l891:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IMPORT_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -12973,38 +12669,38 @@ YY_RULE(int) yy_IMPORT_KW(GREG *G)
 YY_RULE(int) yy_DefineValue(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DefineValue"));
 
-  {  int yypos928= G->pos, yythunkpos928= G->thunkpos;
-  {  int yypos930= G->pos, yythunkpos930= G->thunkpos;  if (!yymatchChar(G, '=')) goto l930;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l930;
-  {  int yypos934= G->pos, yythunkpos934= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l935;
-  goto l934;
-  l935:;	  G->pos= yypos934; G->thunkpos= yythunkpos934;  if (!yymatchChar(G, '-')) goto l930;
+  {  int yypos893= G->pos, yythunkpos893= G->thunkpos;
+  {  int yypos895= G->pos, yythunkpos895= G->thunkpos;  if (!yymatchChar(G, '=')) goto l895;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l895;
+  {  int yypos899= G->pos, yythunkpos899= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l900;
+  goto l899;
+  l900:;	  G->pos= yypos899; G->thunkpos= yythunkpos899;  if (!yymatchChar(G, '-')) goto l895;
 
   }
-  l934:;	
-  l932:;	
-  {  int yypos933= G->pos, yythunkpos933= G->thunkpos;
-  {  int yypos936= G->pos, yythunkpos936= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l937;
-  goto l936;
-  l937:;	  G->pos= yypos936; G->thunkpos= yythunkpos936;  if (!yymatchChar(G, '-')) goto l933;
+  l899:;	
+  l897:;	
+  {  int yypos898= G->pos, yythunkpos898= G->thunkpos;
+  {  int yypos901= G->pos, yythunkpos901= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l902;
+  goto l901;
+  l902:;	  G->pos= yypos901; G->thunkpos= yythunkpos901;  if (!yymatchChar(G, '-')) goto l898;
 
   }
-  l936:;	  goto l932;
-  l933:;	  G->pos= yypos933; G->thunkpos= yythunkpos933;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l930;  goto l931;
-  l930:;	  G->pos= yypos930; G->thunkpos= yythunkpos930;
+  l901:;	  goto l897;
+  l898:;	  G->pos= yypos898; G->thunkpos= yythunkpos898;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l895;  goto l896;
+  l895:;	  G->pos= yypos895; G->thunkpos= yythunkpos895;
   }
-  l931:;	  yyDo(G, yy_1_DefineValue, G->begin, G->end, "yy_1_DefineValue");
-  goto l928;
-  l929:;	  G->pos= yypos928; G->thunkpos= yythunkpos928;  yyDo(G, yy_2_DefineValue, G->begin, G->end, "yy_2_DefineValue");
+  l896:;	  yyDo(G, yy_1_DefineValue, G->begin, G->end, "yy_1_DefineValue");
+  goto l893;
+  l894:;	  G->pos= yypos893; G->thunkpos= yythunkpos893;  yyDo(G, yy_2_DefineValue, G->begin, G->end, "yy_2_DefineValue");
 
   }
-  l928:;	  yyprintf((stderr, "  ok   DefineValue"));
+  l893:;	  yyprintf((stderr, "  ok   DefineValue"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l927:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineValue"));
+  l892:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineValue"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13012,29 +12708,29 @@ YY_RULE(int) yy_DefineValue(GREG *G)
 }
 YY_RULE(int) yy_DefineName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "DefineName"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l938;
-  {  int yypos941= G->pos, yythunkpos941= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l942;
-  goto l941;
-  l942:;	  G->pos= yypos941; G->thunkpos= yythunkpos941;  if (!yymatchChar(G, '-')) goto l938;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l903;
+  {  int yypos906= G->pos, yythunkpos906= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l907;
+  goto l906;
+  l907:;	  G->pos= yypos906; G->thunkpos= yythunkpos906;  if (!yymatchChar(G, '-')) goto l903;
 
   }
-  l941:;	
-  l939:;	
-  {  int yypos940= G->pos, yythunkpos940= G->thunkpos;
-  {  int yypos943= G->pos, yythunkpos943= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l944;
-  goto l943;
-  l944:;	  G->pos= yypos943; G->thunkpos= yythunkpos943;  if (!yymatchChar(G, '-')) goto l940;
+  l906:;	
+  l904:;	
+  {  int yypos905= G->pos, yythunkpos905= G->thunkpos;
+  {  int yypos908= G->pos, yythunkpos908= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9_/._")) goto l909;
+  goto l908;
+  l909:;	  G->pos= yypos908; G->thunkpos= yythunkpos908;  if (!yymatchChar(G, '-')) goto l905;
 
   }
-  l943:;	  goto l939;
-  l940:;	  G->pos= yypos940; G->thunkpos= yythunkpos940;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l938;  yyDo(G, yy_1_DefineName, G->begin, G->end, "yy_1_DefineName");
+  l908:;	  goto l904;
+  l905:;	  G->pos= yypos905; G->thunkpos= yythunkpos905;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l903;  yyDo(G, yy_1_DefineName, G->begin, G->end, "yy_1_DefineName");
   yyprintf((stderr, "  ok   DefineName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l938:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineName"));
+  l903:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "DefineName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13043,57 +12739,57 @@ YY_RULE(int) yy_DefineName(GREG *G)
 YY_RULE(int) yy_IncludeCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "IncludeCore"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l945;
-  {  int yypos948= G->pos, yythunkpos948= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l949;
-  goto l948;
-  l949:;	  G->pos= yypos948; G->thunkpos= yythunkpos948;  if (!yymatchChar(G, '-')) goto l945;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l910;
+  {  int yypos913= G->pos, yythunkpos913= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l914;
+  goto l913;
+  l914:;	  G->pos= yypos913; G->thunkpos= yythunkpos913;  if (!yymatchChar(G, '-')) goto l910;
 
   }
-  l948:;	
-  l946:;	
-  {  int yypos947= G->pos, yythunkpos947= G->thunkpos;
-  {  int yypos950= G->pos, yythunkpos950= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l951;
-  goto l950;
-  l951:;	  G->pos= yypos950; G->thunkpos= yythunkpos950;  if (!yymatchChar(G, '-')) goto l947;
+  l913:;	
+  l911:;	
+  {  int yypos912= G->pos, yythunkpos912= G->thunkpos;
+  {  int yypos915= G->pos, yythunkpos915= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l916;
+  goto l915;
+  l916:;	  G->pos= yypos915; G->thunkpos= yythunkpos915;  if (!yymatchChar(G, '-')) goto l912;
 
   }
-  l950:;	  goto l946;
-  l947:;	  G->pos= yypos947; G->thunkpos= yythunkpos947;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l945;  yyDo(G, yy_1_IncludeCore, G->begin, G->end, "yy_1_IncludeCore");
+  l915:;	  goto l911;
+  l912:;	  G->pos= yypos912; G->thunkpos= yythunkpos912;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l910;  yyDo(G, yy_1_IncludeCore, G->begin, G->end, "yy_1_IncludeCore");
 
-  {  int yypos952= G->pos, yythunkpos952= G->thunkpos;  if (!yy__(G))  goto l952;
-  if (!yymatchChar(G, '|')) goto l952;
-  if (!yy__(G))  goto l952;
-  if (!yymatchChar(G, '(')) goto l952;
-  if (!yy__(G))  goto l952;
-  if (!yy_DefineName(G))  goto l952;
+  {  int yypos917= G->pos, yythunkpos917= G->thunkpos;  if (!yy__(G))  goto l917;
+  if (!yymatchChar(G, '|')) goto l917;
+  if (!yy__(G))  goto l917;
+  if (!yymatchChar(G, '(')) goto l917;
+  if (!yy__(G))  goto l917;
+  if (!yy_DefineName(G))  goto l917;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DefineValue(G))  goto l952;
+  if (!yy_DefineValue(G))  goto l917;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_IncludeCore, G->begin, G->end, "yy_2_IncludeCore");
 
-  l954:;	
-  {  int yypos955= G->pos, yythunkpos955= G->thunkpos;  if (!yy__(G))  goto l955;
-  if (!yymatchChar(G, ',')) goto l955;
-  if (!yy__(G))  goto l955;
-  if (!yy_DefineName(G))  goto l955;
+  l919:;	
+  {  int yypos920= G->pos, yythunkpos920= G->thunkpos;  if (!yy__(G))  goto l920;
+  if (!yymatchChar(G, ',')) goto l920;
+  if (!yy__(G))  goto l920;
+  if (!yy_DefineName(G))  goto l920;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_DefineValue(G))  goto l955;
+  if (!yy_DefineValue(G))  goto l920;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_3_IncludeCore, G->begin, G->end, "yy_3_IncludeCore");
-  goto l954;
-  l955:;	  G->pos= yypos955; G->thunkpos= yythunkpos955;
-  }  if (!yy__(G))  goto l952;
-  if (!yymatchChar(G, ')')) goto l952;
-  goto l953;
-  l952:;	  G->pos= yypos952; G->thunkpos= yythunkpos952;
+  goto l919;
+  l920:;	  G->pos= yypos920; G->thunkpos= yythunkpos920;
+  }  if (!yy__(G))  goto l917;
+  if (!yymatchChar(G, ')')) goto l917;
+  goto l918;
+  l917:;	  G->pos= yypos917; G->thunkpos= yythunkpos917;
   }
-  l953:;	  yyprintf((stderr, "  ok   IncludeCore"));
+  l918:;	  yyprintf((stderr, "  ok   IncludeCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l945:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IncludeCore"));
+  l910:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "IncludeCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13101,13 +12797,13 @@ YY_RULE(int) yy_IncludeCore(GREG *G)
 }
 YY_RULE(int) yy_INCLUDE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "INCLUDE_KW"));
-  if (!yymatchString(G, "include")) goto l956;
+  if (!yymatchString(G, "include")) goto l921;
   yyprintf((stderr, "  ok   INCLUDE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l956:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INCLUDE_KW"));
+  l921:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "INCLUDE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13115,29 +12811,29 @@ YY_RULE(int) yy_INCLUDE_KW(GREG *G)
 }
 YY_RULE(int) yy_UseCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "UseCore"));
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l957;
-  {  int yypos960= G->pos, yythunkpos960= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l961;
-  goto l960;
-  l961:;	  G->pos= yypos960; G->thunkpos= yythunkpos960;  if (!yymatchChar(G, '-')) goto l957;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l922;
+  {  int yypos925= G->pos, yythunkpos925= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l926;
+  goto l925;
+  l926:;	  G->pos= yypos925; G->thunkpos= yythunkpos925;  if (!yymatchChar(G, '-')) goto l922;
 
   }
-  l960:;	
-  l958:;	
-  {  int yypos959= G->pos, yythunkpos959= G->thunkpos;
-  {  int yypos962= G->pos, yythunkpos962= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l963;
-  goto l962;
-  l963:;	  G->pos= yypos962; G->thunkpos= yythunkpos962;  if (!yymatchChar(G, '-')) goto l959;
+  l925:;	
+  l923:;	
+  {  int yypos924= G->pos, yythunkpos924= G->thunkpos;
+  {  int yypos927= G->pos, yythunkpos927= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\300\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "A-Za-z0-9/._")) goto l928;
+  goto l927;
+  l928:;	  G->pos= yypos927; G->thunkpos= yythunkpos927;  if (!yymatchChar(G, '-')) goto l924;
 
   }
-  l962:;	  goto l958;
-  l959:;	  G->pos= yypos959; G->thunkpos= yythunkpos959;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l957;  yyDo(G, yy_1_UseCore, G->begin, G->end, "yy_1_UseCore");
+  l927:;	  goto l923;
+  l924:;	  G->pos= yypos924; G->thunkpos= yythunkpos924;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l922;  yyDo(G, yy_1_UseCore, G->begin, G->end, "yy_1_UseCore");
   yyprintf((stderr, "  ok   UseCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l957:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UseCore"));
+  l922:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "UseCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13145,13 +12841,13 @@ YY_RULE(int) yy_UseCore(GREG *G)
 }
 YY_RULE(int) yy_USE_KW(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "USE_KW"));
-  if (!yymatchString(G, "use")) goto l964;
+  if (!yymatchString(G, "use")) goto l929;
   yyprintf((stderr, "  ok   USE_KW"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l964:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "USE_KW"));
+  l929:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "USE_KW"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13159,20 +12855,20 @@ YY_RULE(int) yy_USE_KW(GREG *G)
 }
 YY_RULE(int) yy_VersionName(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "VersionName"));
-  if (!yy__(G))  goto l965;
-  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l965;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l965;
+  if (!yy__(G))  goto l930;
+  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l930;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l930;
 
-  l966:;	
-  {  int yypos967= G->pos, yythunkpos967= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l967;
-  goto l966;
-  l967:;	  G->pos= yypos967; G->thunkpos= yythunkpos967;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l965;  yyDo(G, yy_1_VersionName, G->begin, G->end, "yy_1_VersionName");
+  l931:;	
+  {  int yypos932= G->pos, yythunkpos932= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", "a-zA-Z0-9_")) goto l932;
+  goto l931;
+  l932:;	  G->pos= yypos932; G->thunkpos= yythunkpos932;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l930;  yyDo(G, yy_1_VersionName, G->begin, G->end, "yy_1_VersionName");
   yyprintf((stderr, "  ok   VersionName"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l965:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionName"));
+  l930:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionName"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13181,34 +12877,19 @@ YY_RULE(int) yy_VersionName(GREG *G)
 YY_RULE(int) yy_VersionNegation(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VersionNegation"));
-
-  {  int yypos969= G->pos, yythunkpos969= G->thunkpos;  if (!yy__(G))  goto l970;
-  if (!yymatchChar(G, '!')) goto l970;
+  if (!yy__(G))  goto l933;
+  if (!yymatchChar(G, '!')) goto l933;
   yyDo(G, yy_1_VersionNegation, G->begin, G->end, "yy_1_VersionNegation");
-  if (!yy__(G))  goto l970;
-  if (!yy_VersionName(G))  goto l970;
+  if (!yy__(G))  goto l933;
+  if (!yy_VersionSpec(G))  goto l933;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VersionNegation, G->begin, G->end, "yy_2_VersionNegation");
-  goto l969;
-  l970:;	  G->pos= yypos969; G->thunkpos= yythunkpos969;  if (!yy__(G))  goto l968;
-  if (!yymatchChar(G, '!')) goto l968;
-  yyDo(G, yy_3_VersionNegation, G->begin, G->end, "yy_3_VersionNegation");
-  if (!yy__(G))  goto l968;
-  if (!yymatchChar(G, '(')) goto l968;
-  if (!yy__(G))  goto l968;
-  if (!yy_VersionSpec(G))  goto l968;
-  yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy__(G))  goto l968;
-  if (!yymatchChar(G, ')')) goto l968;
-  yyDo(G, yy_4_VersionNegation, G->begin, G->end, "yy_4_VersionNegation");
-
-  }
-  l969:;	  yyprintf((stderr, "  ok   VersionNegation"));
+  yyprintf((stderr, "  ok   VersionNegation"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l968:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionNegation"));
+  l933:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionNegation"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13217,17 +12898,17 @@ YY_RULE(int) yy_VersionNegation(GREG *G)
 YY_RULE(int) yy_VersionCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "VersionCore"));
 
-  {  int yypos972= G->pos, yythunkpos972= G->thunkpos;  if (!yy_VersionNegation(G))  goto l973;
-  goto l972;
-  l973:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_VersionName(G))  goto l971;
+  {  int yypos935= G->pos, yythunkpos935= G->thunkpos;  if (!yy_VersionNegation(G))  goto l936;
+  goto l935;
+  l936:;	  G->pos= yypos935; G->thunkpos= yythunkpos935;  if (!yy_VersionName(G))  goto l934;
 
   }
-  l972:;	  yyprintf((stderr, "  ok   VersionCore"));
+  l935:;	  yyprintf((stderr, "  ok   VersionCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l971:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionCore"));
+  l934:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13236,52 +12917,52 @@ YY_RULE(int) yy_VersionCore(GREG *G)
 YY_RULE(int) yy_OocDocCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "OocDocCore"));
 
-  {  int yypos975= G->pos, yythunkpos975= G->thunkpos;  if (!yymatchString(G, "/**")) goto l976;
+  {  int yypos938= G->pos, yythunkpos938= G->thunkpos;  if (!yymatchString(G, "/**")) goto l939;
 
-  {  int yypos977= G->pos, yythunkpos977= G->thunkpos;  if (!yymatchChar(G, '*')) goto l977;
-  goto l976;
-  l977:;	  G->pos= yypos977; G->thunkpos= yythunkpos977;
-  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l976;
-  l978:;	
-  {  int yypos979= G->pos, yythunkpos979= G->thunkpos;
-  {  int yypos980= G->pos, yythunkpos980= G->thunkpos;  if (!yymatchString(G, "*/")) goto l980;
-  goto l979;
-  l980:;	  G->pos= yypos980; G->thunkpos= yythunkpos980;
+  {  int yypos940= G->pos, yythunkpos940= G->thunkpos;  if (!yymatchChar(G, '*')) goto l940;
+  goto l939;
+  l940:;	  G->pos= yypos940; G->thunkpos= yythunkpos940;
+  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l939;
+  l941:;	
+  {  int yypos942= G->pos, yythunkpos942= G->thunkpos;
+  {  int yypos943= G->pos, yythunkpos943= G->thunkpos;  if (!yymatchString(G, "*/")) goto l943;
+  goto l942;
+  l943:;	  G->pos= yypos943; G->thunkpos= yythunkpos943;
   }
-  {  int yypos981= G->pos, yythunkpos981= G->thunkpos;  if (!yy_EOL(G))  goto l982;
-  goto l981;
-  l982:;	  G->pos= yypos981; G->thunkpos= yythunkpos981;  if (!yymatchDot(G)) goto l979;
+  {  int yypos944= G->pos, yythunkpos944= G->thunkpos;  if (!yy_EOL(G))  goto l945;
+  goto l944;
+  l945:;	  G->pos= yypos944; G->thunkpos= yythunkpos944;  if (!yymatchDot(G)) goto l942;
   }
-  l981:;	  goto l978;
-  l979:;	  G->pos= yypos979; G->thunkpos= yythunkpos979;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l976;  if (!yymatchString(G, "*/")) goto l976;
+  l944:;	  goto l941;
+  l942:;	  G->pos= yypos942; G->thunkpos= yythunkpos942;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l939;  if (!yymatchString(G, "*/")) goto l939;
   yyDo(G, yy_1_OocDocCore, G->begin, G->end, "yy_1_OocDocCore");
-  if (!yy_WS(G))  goto l976;
-  goto l975;
-  l976:;	  G->pos= yypos975; G->thunkpos= yythunkpos975;  if (!yymatchString(G, "///")) goto l974;
+  if (!yy_WS(G))  goto l939;
+  goto l938;
+  l939:;	  G->pos= yypos938; G->thunkpos= yythunkpos938;  if (!yymatchString(G, "///")) goto l937;
 
-  {  int yypos983= G->pos, yythunkpos983= G->thunkpos;  if (!yymatchChar(G, '/')) goto l983;
-  goto l974;
-  l983:;	  G->pos= yypos983; G->thunkpos= yythunkpos983;
-  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l974;
-  l984:;	
-  {  int yypos985= G->pos, yythunkpos985= G->thunkpos;
-  {  int yypos986= G->pos, yythunkpos986= G->thunkpos;  if (!yy_EOL(G))  goto l986;
-  goto l985;
-  l986:;	  G->pos= yypos986; G->thunkpos= yythunkpos986;
-  }  if (!yymatchDot(G)) goto l985;  goto l984;
-  l985:;	  G->pos= yypos985; G->thunkpos= yythunkpos985;
-  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l974;  if (!yy_EOL(G))  goto l974;
+  {  int yypos946= G->pos, yythunkpos946= G->thunkpos;  if (!yymatchChar(G, '/')) goto l946;
+  goto l937;
+  l946:;	  G->pos= yypos946; G->thunkpos= yythunkpos946;
+  }  yyText(G, G->begin, G->end);  if (!(YY_BEGIN)) goto l937;
+  l947:;	
+  {  int yypos948= G->pos, yythunkpos948= G->thunkpos;
+  {  int yypos949= G->pos, yythunkpos949= G->thunkpos;  if (!yy_EOL(G))  goto l949;
+  goto l948;
+  l949:;	  G->pos= yypos949; G->thunkpos= yythunkpos949;
+  }  if (!yymatchDot(G)) goto l948;  goto l947;
+  l948:;	  G->pos= yypos948; G->thunkpos= yythunkpos948;
+  }  yyText(G, G->begin, G->end);  if (!(YY_END)) goto l937;  if (!yy_EOL(G))  goto l937;
   yyDo(G, yy_2_OocDocCore, G->begin, G->end, "yy_2_OocDocCore");
-  if (!yy_WS(G))  goto l974;
+  if (!yy_WS(G))  goto l937;
 
   }
-  l975:;	  yyprintf((stderr, "  ok   OocDocCore"));
+  l938:;	  yyprintf((stderr, "  ok   OocDocCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l974:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDocCore"));
+  l937:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "OocDocCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13291,39 +12972,39 @@ YY_RULE(int) yy_Decl(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 1, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Decl"));
 
-  {  int yypos988= G->pos, yythunkpos988= G->thunkpos;  if (!yy_ClassDecl(G))  goto l989;
-  goto l988;
-  l989:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;  if (!yy_CoverDecl(G))  goto l990;
-  goto l988;
-  l990:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;  if (!yy_ExtendDecl(G))  goto l991;
-  goto l988;
-  l991:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;  if (!yy_EnumDecl(G))  goto l992;
-  goto l988;
-  l992:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;  if (!yy_InterfaceDecl(G))  goto l993;
-  goto l988;
-  l993:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;  if (!yy_OperatorDecl(G))  goto l994;
-  goto l988;
-  l994:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;  if (!yy_FunctionDecl(G))  goto l995;
-  goto l988;
-  l995:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;  if (!yy_PropertyDecl(G))  goto l996;
-  goto l988;
-  l996:;	  G->pos= yypos988; G->thunkpos= yythunkpos988;  if (!yy_VariableDecl(G))  goto l987;
+  {  int yypos951= G->pos, yythunkpos951= G->thunkpos;  if (!yy_ClassDecl(G))  goto l952;
+  goto l951;
+  l952:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_CoverDecl(G))  goto l953;
+  goto l951;
+  l953:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_ExtendDecl(G))  goto l954;
+  goto l951;
+  l954:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_EnumDecl(G))  goto l955;
+  goto l951;
+  l955:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_InterfaceDecl(G))  goto l956;
+  goto l951;
+  l956:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_OperatorDecl(G))  goto l957;
+  goto l951;
+  l957:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_FunctionDecl(G))  goto l958;
+  goto l951;
+  l958:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_PropertyDecl(G))  goto l959;
+  goto l951;
+  l959:;	  G->pos= yypos951; G->thunkpos= yythunkpos951;  if (!yy_VariableDecl(G))  goto l950;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_Terminator(G))  goto l987;
+  if (!yy_Terminator(G))  goto l950;
 
-  l997:;	
-  {  int yypos998= G->pos, yythunkpos998= G->thunkpos;  if (!yy_Terminator(G))  goto l998;
-  goto l997;
-  l998:;	  G->pos= yypos998; G->thunkpos= yythunkpos998;
+  l960:;	
+  {  int yypos961= G->pos, yythunkpos961= G->thunkpos;  if (!yy_Terminator(G))  goto l961;
+  goto l960;
+  l961:;	  G->pos= yypos961; G->thunkpos= yythunkpos961;
   }  yyDo(G, yy_1_Decl, G->begin, G->end, "yy_1_Decl");
 
   }
-  l988:;	  yyprintf((stderr, "  ok   Decl"));
+  l951:;	  yyprintf((stderr, "  ok   Decl"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 1, 0, "yyPop");
   return 1;
-  l987:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Decl"));
+  l950:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Decl"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13331,24 +13012,24 @@ YY_RULE(int) yy_Decl(GREG *G)
 }
 YY_RULE(int) yy_Use(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Use"));
-  if (!yy_USE_KW(G))  goto l999;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l999;
-  if (!yy__(G))  goto l999;
-  if (!yy_UseCore(G))  goto l999;
+  if (!yy_USE_KW(G))  goto l962;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l962;
+  if (!yy__(G))  goto l962;
+  if (!yy_UseCore(G))  goto l962;
 
-  l1000:;	
-  {  int yypos1001= G->pos, yythunkpos1001= G->thunkpos;  if (!yy__(G))  goto l1001;
-  if (!yymatchChar(G, ',')) goto l1001;
-  if (!yy__(G))  goto l1001;
-  if (!yy_UseCore(G))  goto l1001;
-  goto l1000;
-  l1001:;	  G->pos= yypos1001; G->thunkpos= yythunkpos1001;
+  l963:;	
+  {  int yypos964= G->pos, yythunkpos964= G->thunkpos;  if (!yy__(G))  goto l964;
+  if (!yymatchChar(G, ',')) goto l964;
+  if (!yy__(G))  goto l964;
+  if (!yy_UseCore(G))  goto l964;
+  goto l963;
+  l964:;	  G->pos= yypos964; G->thunkpos= yythunkpos964;
   }  yyprintf((stderr, "  ok   Use"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l999:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Use"));
+  l962:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Use"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13356,24 +13037,24 @@ YY_RULE(int) yy_Use(GREG *G)
 }
 YY_RULE(int) yy_Import(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Import"));
-  if (!yy_IMPORT_KW(G))  goto l1002;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1002;
-  if (!yy__(G))  goto l1002;
-  if (!yy_ImportAtom(G))  goto l1002;
+  if (!yy_IMPORT_KW(G))  goto l965;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l965;
+  if (!yy__(G))  goto l965;
+  if (!yy_ImportAtom(G))  goto l965;
 
-  l1003:;	
-  {  int yypos1004= G->pos, yythunkpos1004= G->thunkpos;  if (!yymatchChar(G, ',')) goto l1004;
-  if (!yy_WS(G))  goto l1004;
-  if (!yy__(G))  goto l1004;
-  if (!yy_ImportAtom(G))  goto l1004;
-  goto l1003;
-  l1004:;	  G->pos= yypos1004; G->thunkpos= yythunkpos1004;
+  l966:;	
+  {  int yypos967= G->pos, yythunkpos967= G->thunkpos;  if (!yymatchChar(G, ',')) goto l967;
+  if (!yy_WS(G))  goto l967;
+  if (!yy__(G))  goto l967;
+  if (!yy_ImportAtom(G))  goto l967;
+  goto l966;
+  l967:;	  G->pos= yypos967; G->thunkpos= yythunkpos967;
   }  yyprintf((stderr, "  ok   Import"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1002:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Import"));
+  l965:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Import"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13381,24 +13062,24 @@ YY_RULE(int) yy_Import(GREG *G)
 }
 YY_RULE(int) yy_Include(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Include"));
-  if (!yy_INCLUDE_KW(G))  goto l1005;
-  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1005;
-  if (!yy__(G))  goto l1005;
-  if (!yy_IncludeCore(G))  goto l1005;
+  if (!yy_INCLUDE_KW(G))  goto l968;
+  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l968;
+  if (!yy__(G))  goto l968;
+  if (!yy_IncludeCore(G))  goto l968;
 
-  l1006:;	
-  {  int yypos1007= G->pos, yythunkpos1007= G->thunkpos;  if (!yy__(G))  goto l1007;
-  if (!yymatchChar(G, ',')) goto l1007;
-  if (!yy__(G))  goto l1007;
-  if (!yy_IncludeCore(G))  goto l1007;
-  goto l1006;
-  l1007:;	  G->pos= yypos1007; G->thunkpos= yythunkpos1007;
+  l969:;	
+  {  int yypos970= G->pos, yythunkpos970= G->thunkpos;  if (!yy__(G))  goto l970;
+  if (!yymatchChar(G, ',')) goto l970;
+  if (!yy__(G))  goto l970;
+  if (!yy_IncludeCore(G))  goto l970;
+  goto l969;
+  l970:;	  G->pos= yypos970; G->thunkpos= yythunkpos970;
   }  yyprintf((stderr, "  ok   Include"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1005:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Include"));
+  l968:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Include"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13408,120 +13089,120 @@ YY_RULE(int) yy_Stmt(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "Stmt"));
 
-  {  int yypos1009= G->pos, yythunkpos1009= G->thunkpos;  if (!yy_Old(G))  goto l1010;
+  {  int yypos972= G->pos, yythunkpos972= G->thunkpos;  if (!yy_Old(G))  goto l973;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_WS(G))  goto l1010;
-  if (!yymatchString(G, "version")) goto l1010;
+  if (!yy_WS(G))  goto l973;
+  if (!yymatchString(G, "version")) goto l973;
   yyDo(G, yy_1_Stmt, G->begin, G->end, "yy_1_Stmt");
-  if (!yy_WS(G))  goto l1010;
-  if (!yymatchChar(G, '(')) goto l1010;
-  if (!yy__(G))  goto l1010;
-  if (!yy_VersionSpec(G))  goto l1010;
+  if (!yy_WS(G))  goto l973;
+  if (!yymatchChar(G, '(')) goto l973;
+  if (!yy__(G))  goto l973;
+  if (!yy_VersionSpec(G))  goto l973;
   yyDo(G, yySet, -3, 0, "yySet");
-  if (!yy_WS(G))  goto l1010;
-  if (!yymatchChar(G, ')')) goto l1010;
+  if (!yy_WS(G))  goto l973;
+  if (!yymatchChar(G, ')')) goto l973;
 
-  {  int yypos1011= G->pos, yythunkpos1011= G->thunkpos;  if (!yy__(G))  goto l1012;
-  if (!yymatchChar(G, '{')) goto l1012;
+  {  int yypos974= G->pos, yythunkpos974= G->thunkpos;  if (!yy__(G))  goto l975;
+  if (!yymatchChar(G, '{')) goto l975;
   yyDo(G, yy_2_Stmt, G->begin, G->end, "yy_2_Stmt");
-  if (!yy_WS(G))  goto l1012;
+  if (!yy_WS(G))  goto l975;
 
-  l1013:;	
-  {  int yypos1014= G->pos, yythunkpos1014= G->thunkpos;  if (!yy_Stmt(G))  goto l1014;
+  l976:;	
+  {  int yypos977= G->pos, yythunkpos977= G->thunkpos;  if (!yy_Stmt(G))  goto l977;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_3_Stmt, G->begin, G->end, "yy_3_Stmt");
-  goto l1013;
-  l1014:;	  G->pos= yypos1014; G->thunkpos= yythunkpos1014;
-  }  if (!yy_WS(G))  goto l1012;
-  if (!yy__(G))  goto l1012;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l1012; }
+  goto l976;
+  l977:;	  G->pos= yypos977; G->thunkpos= yythunkpos977;
+  }  if (!yy_WS(G))  goto l975;
+  if (!yy__(G))  goto l975;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l975; }
   yyDo(G, yy_4_Stmt, G->begin, G->end, "yy_4_Stmt");
-  goto l1011;
-  l1012:;	  G->pos= yypos1011; G->thunkpos= yythunkpos1011;  if (!yy__(G))  goto l1010;
-  if (!yy_Stmt(G))  goto l1010;
+  goto l974;
+  l975:;	  G->pos= yypos974; G->thunkpos= yythunkpos974;  if (!yy__(G))  goto l973;
+  if (!yy_Stmt(G))  goto l973;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_5_Stmt, G->begin, G->end, "yy_5_Stmt");
 
   }
-  l1011:;	
-  l1015:;	
-  {  int yypos1016= G->pos, yythunkpos1016= G->thunkpos;  if (!yy_WS(G))  goto l1016;
-  if (!yymatchString(G, "else")) goto l1016;
-  if (!yy__(G))  goto l1016;
-  if (!yymatchString(G, "version")) goto l1016;
+  l974:;	
+  l978:;	
+  {  int yypos979= G->pos, yythunkpos979= G->thunkpos;  if (!yy_WS(G))  goto l979;
+  if (!yymatchString(G, "else")) goto l979;
+  if (!yy__(G))  goto l979;
+  if (!yymatchString(G, "version")) goto l979;
   yyDo(G, yy_6_Stmt, G->begin, G->end, "yy_6_Stmt");
-  if (!yy_WS(G))  goto l1016;
-  if (!yymatchChar(G, '(')) goto l1016;
-  if (!yy__(G))  goto l1016;
-  if (!yy_VersionSpec(G))  goto l1016;
+  if (!yy_WS(G))  goto l979;
+  if (!yymatchChar(G, '(')) goto l979;
+  if (!yy__(G))  goto l979;
+  if (!yy_VersionSpec(G))  goto l979;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l1016;
-  if (!yymatchChar(G, ')')) goto l1016;
+  if (!yy_WS(G))  goto l979;
+  if (!yymatchChar(G, ')')) goto l979;
 
-  {  int yypos1017= G->pos, yythunkpos1017= G->thunkpos;  if (!yy__(G))  goto l1018;
-  if (!yymatchChar(G, '{')) goto l1018;
+  {  int yypos980= G->pos, yythunkpos980= G->thunkpos;  if (!yy__(G))  goto l981;
+  if (!yymatchChar(G, '{')) goto l981;
   yyDo(G, yy_7_Stmt, G->begin, G->end, "yy_7_Stmt");
-  if (!yy_WS(G))  goto l1018;
+  if (!yy_WS(G))  goto l981;
 
-  l1019:;	
-  {  int yypos1020= G->pos, yythunkpos1020= G->thunkpos;  if (!yy_Stmt(G))  goto l1020;
+  l982:;	
+  {  int yypos983= G->pos, yythunkpos983= G->thunkpos;  if (!yy_Stmt(G))  goto l983;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_8_Stmt, G->begin, G->end, "yy_8_Stmt");
-  goto l1019;
-  l1020:;	  G->pos= yypos1020; G->thunkpos= yythunkpos1020;
-  }  if (!yy_WS(G))  goto l1018;
-  if (!yy__(G))  goto l1018;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l1018; }
+  goto l982;
+  l983:;	  G->pos= yypos983; G->thunkpos= yythunkpos983;
+  }  if (!yy_WS(G))  goto l981;
+  if (!yy__(G))  goto l981;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block.\n") ; } goto l981; }
   yyDo(G, yy_9_Stmt, G->begin, G->end, "yy_9_Stmt");
-  goto l1017;
-  l1018:;	  G->pos= yypos1017; G->thunkpos= yythunkpos1017;  if (!yy__(G))  goto l1016;
-  if (!yy_Stmt(G))  goto l1016;
+  goto l980;
+  l981:;	  G->pos= yypos980; G->thunkpos= yythunkpos980;  if (!yy__(G))  goto l979;
+  if (!yy_Stmt(G))  goto l979;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_10_Stmt, G->begin, G->end, "yy_10_Stmt");
 
   }
-  l1017:;	  goto l1015;
-  l1016:;	  G->pos= yypos1016; G->thunkpos= yythunkpos1016;
+  l980:;	  goto l978;
+  l979:;	  G->pos= yypos979; G->thunkpos= yythunkpos979;
   }
-  {  int yypos1021= G->pos, yythunkpos1021= G->thunkpos;  if (!yy_WS(G))  goto l1021;
-  if (!yymatchString(G, "else")) goto l1021;
+  {  int yypos984= G->pos, yythunkpos984= G->thunkpos;  if (!yy_WS(G))  goto l984;
+  if (!yymatchString(G, "else")) goto l984;
   yyDo(G, yy_11_Stmt, G->begin, G->end, "yy_11_Stmt");
 
-  {  int yypos1023= G->pos, yythunkpos1023= G->thunkpos;  if (!yy__(G))  goto l1024;
-  if (!yymatchChar(G, '{')) goto l1024;
+  {  int yypos986= G->pos, yythunkpos986= G->thunkpos;  if (!yy__(G))  goto l987;
+  if (!yymatchChar(G, '{')) goto l987;
   yyDo(G, yy_12_Stmt, G->begin, G->end, "yy_12_Stmt");
-  if (!yy_WS(G))  goto l1024;
+  if (!yy_WS(G))  goto l987;
 
-  l1025:;	
-  {  int yypos1026= G->pos, yythunkpos1026= G->thunkpos;  if (!yy_Stmt(G))  goto l1026;
+  l988:;	
+  {  int yypos989= G->pos, yythunkpos989= G->thunkpos;  if (!yy_Stmt(G))  goto l989;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_13_Stmt, G->begin, G->end, "yy_13_Stmt");
-  goto l1025;
-  l1026:;	  G->pos= yypos1026; G->thunkpos= yythunkpos1026;
-  }  if (!yy_WS(G))  goto l1024;
-  if (!yy__(G))  goto l1024;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block\n") ; } goto l1024; }
+  goto l988;
+  l989:;	  G->pos= yypos989; G->thunkpos= yythunkpos989;
+  }  if (!yy_WS(G))  goto l987;
+  if (!yy__(G))  goto l987;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_STATEMENT_OR_CLOSING_BRACKET, "Malformed statement or '"_CSBRACK"' missing to close version block\n") ; } goto l987; }
   yyDo(G, yy_14_Stmt, G->begin, G->end, "yy_14_Stmt");
-  goto l1023;
-  l1024:;	  G->pos= yypos1023; G->thunkpos= yythunkpos1023;  if (!yy__(G))  goto l1021;
-  if (!yy_Stmt(G))  goto l1021;
+  goto l986;
+  l987:;	  G->pos= yypos986; G->thunkpos= yythunkpos986;  if (!yy__(G))  goto l984;
+  if (!yy_Stmt(G))  goto l984;
   yyDo(G, yySet, -2, 0, "yySet");
   yyDo(G, yy_15_Stmt, G->begin, G->end, "yy_15_Stmt");
 
   }
-  l1023:;	  goto l1022;
-  l1021:;	  G->pos= yypos1021; G->thunkpos= yythunkpos1021;
+  l986:;	  goto l985;
+  l984:;	  G->pos= yypos984; G->thunkpos= yythunkpos984;
   }
-  l1022:;	  goto l1009;
-  l1010:;	  G->pos= yypos1009; G->thunkpos= yythunkpos1009;  if (!yy_StmtCore(G))  goto l1008;
+  l985:;	  goto l972;
+  l973:;	  G->pos= yypos972; G->thunkpos= yythunkpos972;  if (!yy_StmtCore(G))  goto l971;
 
   }
-  l1009:;	  yyprintf((stderr, "  ok   Stmt"));
+  l972:;	  yyprintf((stderr, "  ok   Stmt"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l1008:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Stmt"));
+  l971:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Stmt"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13529,13 +13210,13 @@ YY_RULE(int) yy_Stmt(GREG *G)
 }
 YY_RULE(int) yy_CLOS_BRACK(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLOS_BRACK"));
-  if (!yymatchChar(G, '}')) goto l1027;
+  if (!yymatchChar(G, '}')) goto l990;
   yyprintf((stderr, "  ok   CLOS_BRACK"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1027:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_BRACK"));
+  l990:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_BRACK"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13543,13 +13224,13 @@ YY_RULE(int) yy_CLOS_BRACK(GREG *G)
 }
 YY_RULE(int) yy_CLOS_PAREN(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "CLOS_PAREN"));
-  if (!yymatchChar(G, ')')) goto l1028;
+  if (!yymatchChar(G, ')')) goto l991;
   yyprintf((stderr, "  ok   CLOS_PAREN"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1028:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_PAREN"));
+  l991:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "CLOS_PAREN"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13559,46 +13240,46 @@ YY_RULE(int) yy_VersionSpec(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 2, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "VersionSpec"));
 
-  {  int yypos1030= G->pos, yythunkpos1030= G->thunkpos;  if (!yy__(G))  goto l1031;
-  if (!yymatchChar(G, '(')) goto l1031;
-  if (!yy__(G))  goto l1031;
-  if (!yy_VersionSpec(G))  goto l1031;
+  {  int yypos993= G->pos, yythunkpos993= G->thunkpos;  if (!yy__(G))  goto l994;
+  if (!yymatchChar(G, '(')) goto l994;
+  if (!yy__(G))  goto l994;
+  if (!yy_VersionSpec(G))  goto l994;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy__(G))  goto l1031;
-  if (!yymatchChar(G, ')')) goto l1031;
-  goto l1030;
-  l1031:;	  G->pos= yypos1030; G->thunkpos= yythunkpos1030;  if (!yy_VersionCore(G))  goto l1029;
+  if (!yy__(G))  goto l994;
+  if (!yymatchChar(G, ')')) goto l994;
+  goto l993;
+  l994:;	  G->pos= yypos993; G->thunkpos= yythunkpos993;  if (!yy_VersionCore(G))  goto l992;
   yyDo(G, yySet, -2, 0, "yySet");
 
   }
-  l1030:;	
-  l1032:;	
-  {  int yypos1033= G->pos, yythunkpos1033= G->thunkpos;
-  {  int yypos1034= G->pos, yythunkpos1034= G->thunkpos;  if (!yy__(G))  goto l1035;
-  if (!yymatchString(G, "&&")) goto l1035;
+  l993:;	
+  l995:;	
+  {  int yypos996= G->pos, yythunkpos996= G->thunkpos;
+  {  int yypos997= G->pos, yythunkpos997= G->thunkpos;  if (!yy__(G))  goto l998;
+  if (!yymatchString(G, "&&")) goto l998;
   yyDo(G, yy_1_VersionSpec, G->begin, G->end, "yy_1_VersionSpec");
-  if (!yy__(G))  goto l1035;
-  if (!yy_VersionSpec(G))  goto l1035;
+  if (!yy__(G))  goto l998;
+  if (!yy_VersionSpec(G))  goto l998;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_2_VersionSpec, G->begin, G->end, "yy_2_VersionSpec");
-  goto l1034;
-  l1035:;	  G->pos= yypos1034; G->thunkpos= yythunkpos1034;  if (!yy__(G))  goto l1033;
-  if (!yymatchString(G, "||")) goto l1033;
+  goto l997;
+  l998:;	  G->pos= yypos997; G->thunkpos= yythunkpos997;  if (!yy__(G))  goto l996;
+  if (!yymatchString(G, "||")) goto l996;
   yyDo(G, yy_3_VersionSpec, G->begin, G->end, "yy_3_VersionSpec");
-  if (!yy__(G))  goto l1033;
-  if (!yy_VersionSpec(G))  goto l1033;
+  if (!yy__(G))  goto l996;
+  if (!yy_VersionSpec(G))  goto l996;
   yyDo(G, yySet, -1, 0, "yySet");
   yyDo(G, yy_4_VersionSpec, G->begin, G->end, "yy_4_VersionSpec");
 
   }
-  l1034:;	  goto l1032;
-  l1033:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;
+  l997:;	  goto l995;
+  l996:;	  G->pos= yypos996; G->thunkpos= yythunkpos996;
   }  yyprintf((stderr, "  ok   VersionSpec"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 2, 0, "yyPop");
   return 1;
-  l1029:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionSpec"));
+  l992:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "VersionSpec"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13607,15 +13288,15 @@ YY_RULE(int) yy_VersionSpec(GREG *G)
 YY_RULE(int) yy__(GREG *G)
 {  yyprintfv((stderr, "%s\n", "_"));
 
-  l1037:;	
-  {  int yypos1038= G->pos, yythunkpos1038= G->thunkpos;
-  {  int yypos1039= G->pos, yythunkpos1039= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1040;
-  goto l1039;
-  l1040:;	  G->pos= yypos1039; G->thunkpos= yythunkpos1039;  if (!yy_CommentMultiLine(G))  goto l1038;
+  l1000:;	
+  {  int yypos1001= G->pos, yythunkpos1001= G->thunkpos;
+  {  int yypos1002= G->pos, yythunkpos1002= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1003;
+  goto l1002;
+  l1003:;	  G->pos= yypos1002; G->thunkpos= yythunkpos1002;  if (!yy_CommentMultiLine(G))  goto l1001;
 
   }
-  l1039:;	  goto l1037;
-  l1038:;	  G->pos= yypos1038; G->thunkpos= yythunkpos1038;
+  l1002:;	  goto l1000;
+  l1001:;	  G->pos= yypos1001; G->thunkpos= yythunkpos1001;
   }  yyprintf((stderr, "  ok   _"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -13625,20 +13306,20 @@ YY_RULE(int) yy__(GREG *G)
 YY_RULE(int) yy_EOL(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "EOL"));
 
-  {  int yypos1042= G->pos, yythunkpos1042= G->thunkpos;  if (!yymatchChar(G, '\n')) goto l1043;
-  goto l1042;
-  l1043:;	  G->pos= yypos1042; G->thunkpos= yythunkpos1042;  if (!yymatchString(G, "\r\n")) goto l1044;
-  goto l1042;
-  l1044:;	  G->pos= yypos1042; G->thunkpos= yythunkpos1042;  if (!yymatchChar(G, '\r')) goto l1041;
+  {  int yypos1005= G->pos, yythunkpos1005= G->thunkpos;  if (!yymatchChar(G, '\n')) goto l1006;
+  goto l1005;
+  l1006:;	  G->pos= yypos1005; G->thunkpos= yythunkpos1005;  if (!yymatchString(G, "\r\n")) goto l1007;
+  goto l1005;
+  l1007:;	  G->pos= yypos1005; G->thunkpos= yythunkpos1005;  if (!yymatchChar(G, '\r')) goto l1004;
 
   }
-  l1042:;	  yyDo(G, yy_1_EOL, G->begin, G->end, "yy_1_EOL");
+  l1005:;	  yyDo(G, yy_1_EOL, G->begin, G->end, "yy_1_EOL");
   yyprintf((stderr, "  ok   EOL"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1041:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EOL"));
+  l1004:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "EOL"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13647,21 +13328,17 @@ YY_RULE(int) yy_EOL(GREG *G)
 YY_RULE(int) yy_WS(GREG *G)
 {  yyprintfv((stderr, "%s\n", "WS"));
 
-  l1046:;	
-  {  int yypos1047= G->pos, yythunkpos1047= G->thunkpos;
-  {  int yypos1048= G->pos, yythunkpos1048= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1049;
-  goto l1048;
-  l1049:;	  G->pos= yypos1048; G->thunkpos= yythunkpos1048;  if (!yy_Comment(G))  goto l1050;
-  goto l1048;
-  l1050:;	  G->pos= yypos1048; G->thunkpos= yythunkpos1048;  if (!yy_PreprocessorBeginRegion(G))  goto l1051;
-  goto l1048;
-  l1051:;	  G->pos= yypos1048; G->thunkpos= yythunkpos1048;  if (!yy_PreprocessorEndRegion(G))  goto l1052;
-  goto l1048;
-  l1052:;	  G->pos= yypos1048; G->thunkpos= yythunkpos1048;  if (!yy_EOL(G))  goto l1047;
+  l1009:;	
+  {  int yypos1010= G->pos, yythunkpos1010= G->thunkpos;
+  {  int yypos1011= G->pos, yythunkpos1011= G->thunkpos;  if (!yymatchClass(G, (const unsigned char *)"\000\002\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000", " \\t")) goto l1012;
+  goto l1011;
+  l1012:;	  G->pos= yypos1011; G->thunkpos= yythunkpos1011;  if (!yy_Comment(G))  goto l1013;
+  goto l1011;
+  l1013:;	  G->pos= yypos1011; G->thunkpos= yythunkpos1011;  if (!yy_EOL(G))  goto l1010;
 
   }
-  l1048:;	  goto l1046;
-  l1047:;	  G->pos= yypos1047; G->thunkpos= yythunkpos1047;
+  l1011:;	  goto l1009;
+  l1010:;	  G->pos= yypos1010; G->thunkpos= yythunkpos1010;
   }  yyprintf((stderr, "  ok   WS"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
@@ -13672,140 +13349,140 @@ YY_RULE(int) yy_ModuleCore(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyDo(G, yyPush, 4, 0, "yyPush");
   yyprintfv((stderr, "%s\n", "ModuleCore"));
 
-  {  int yypos1054= G->pos, yythunkpos1054= G->thunkpos;  if (!yy_WS(G))  goto l1055;
-  if (!yymatchString(G, "version")) goto l1055;
+  {  int yypos1015= G->pos, yythunkpos1015= G->thunkpos;  if (!yy_WS(G))  goto l1016;
+  if (!yymatchString(G, "version")) goto l1016;
   yyDo(G, yy_1_ModuleCore, G->begin, G->end, "yy_1_ModuleCore");
-  if (!yy_WS(G))  goto l1055;
-  if (!yymatchChar(G, '(')) goto l1055;
-  if (!yy__(G))  goto l1055;
-  if (!yy_VersionSpec(G))  goto l1055;
+  if (!yy_WS(G))  goto l1016;
+  if (!yymatchChar(G, '(')) goto l1016;
+  if (!yy__(G))  goto l1016;
+  if (!yy_VersionSpec(G))  goto l1016;
   yyDo(G, yySet, -4, 0, "yySet");
-  if (!yy_WS(G))  goto l1055;
-  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed version spec!\n") ; } goto l1055; }
+  if (!yy_WS(G))  goto l1016;
+  if (!yy_CLOS_PAREN(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_CLOSING_PAREN, "Malformed version spec!\n") ; } goto l1016; }
 
-  {  int yypos1056= G->pos, yythunkpos1056= G->thunkpos;  if (!yy__(G))  goto l1057;
-  if (!yymatchChar(G, '{')) goto l1057;
+  {  int yypos1017= G->pos, yythunkpos1017= G->thunkpos;  if (!yy__(G))  goto l1018;
+  if (!yymatchChar(G, '{')) goto l1018;
   yyDo(G, yy_2_ModuleCore, G->begin, G->end, "yy_2_ModuleCore");
-  if (!yy_WS(G))  goto l1057;
+  if (!yy_WS(G))  goto l1018;
 
-  l1058:;	
-  {  int yypos1059= G->pos, yythunkpos1059= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1059;
-  goto l1058;
-  l1059:;	  G->pos= yypos1059; G->thunkpos= yythunkpos1059;
-  }  if (!yy_WS(G))  goto l1057;
-  if (!yy__(G))  goto l1057;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1057; }
+  l1019:;	
+  {  int yypos1020= G->pos, yythunkpos1020= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1020;
+  goto l1019;
+  l1020:;	  G->pos= yypos1020; G->thunkpos= yythunkpos1020;
+  }  if (!yy_WS(G))  goto l1018;
+  if (!yy__(G))  goto l1018;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1018; }
   yyDo(G, yy_3_ModuleCore, G->begin, G->end, "yy_3_ModuleCore");
-  goto l1056;
-  l1057:;	  G->pos= yypos1056; G->thunkpos= yythunkpos1056;  if (!yy__(G))  goto l1055;
-  if (!yy_Stmt(G))  goto l1055;
+  goto l1017;
+  l1018:;	  G->pos= yypos1017; G->thunkpos= yythunkpos1017;  if (!yy__(G))  goto l1016;
+  if (!yy_Stmt(G))  goto l1016;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_4_ModuleCore, G->begin, G->end, "yy_4_ModuleCore");
 
   }
-  l1056:;	
-  l1060:;	
-  {  int yypos1061= G->pos, yythunkpos1061= G->thunkpos;  if (!yy_WS(G))  goto l1061;
-  if (!yymatchString(G, "else")) goto l1061;
-  if (!yy__(G))  goto l1061;
-  if (!yymatchString(G, "version")) goto l1061;
+  l1017:;	
+  l1021:;	
+  {  int yypos1022= G->pos, yythunkpos1022= G->thunkpos;  if (!yy_WS(G))  goto l1022;
+  if (!yymatchString(G, "else")) goto l1022;
+  if (!yy__(G))  goto l1022;
+  if (!yymatchString(G, "version")) goto l1022;
   yyDo(G, yy_5_ModuleCore, G->begin, G->end, "yy_5_ModuleCore");
-  if (!yy_WS(G))  goto l1061;
-  if (!yymatchChar(G, '(')) goto l1061;
-  if (!yy__(G))  goto l1061;
-  if (!yy_VersionSpec(G))  goto l1061;
+  if (!yy_WS(G))  goto l1022;
+  if (!yymatchChar(G, '(')) goto l1022;
+  if (!yy__(G))  goto l1022;
+  if (!yy_VersionSpec(G))  goto l1022;
   yyDo(G, yySet, -2, 0, "yySet");
-  if (!yy_WS(G))  goto l1061;
-  if (!yymatchChar(G, ')')) goto l1061;
+  if (!yy_WS(G))  goto l1022;
+  if (!yymatchChar(G, ')')) goto l1022;
 
-  {  int yypos1062= G->pos, yythunkpos1062= G->thunkpos;  if (!yy__(G))  goto l1063;
-  if (!yymatchChar(G, '{')) goto l1063;
+  {  int yypos1023= G->pos, yythunkpos1023= G->thunkpos;  if (!yy__(G))  goto l1024;
+  if (!yymatchChar(G, '{')) goto l1024;
   yyDo(G, yy_6_ModuleCore, G->begin, G->end, "yy_6_ModuleCore");
-  if (!yy_WS(G))  goto l1063;
+  if (!yy_WS(G))  goto l1024;
 
-  l1064:;	
-  {  int yypos1065= G->pos, yythunkpos1065= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1065;
-  goto l1064;
-  l1065:;	  G->pos= yypos1065; G->thunkpos= yythunkpos1065;
-  }  if (!yy_WS(G))  goto l1063;
-  if (!yy__(G))  goto l1063;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1063; }
+  l1025:;	
+  {  int yypos1026= G->pos, yythunkpos1026= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1026;
+  goto l1025;
+  l1026:;	  G->pos= yypos1026; G->thunkpos= yythunkpos1026;
+  }  if (!yy_WS(G))  goto l1024;
+  if (!yy__(G))  goto l1024;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1024; }
   yyDo(G, yy_7_ModuleCore, G->begin, G->end, "yy_7_ModuleCore");
-  goto l1062;
-  l1063:;	  G->pos= yypos1062; G->thunkpos= yythunkpos1062;  if (!yy__(G))  goto l1061;
-  if (!yy_Stmt(G))  goto l1061;
+  goto l1023;
+  l1024:;	  G->pos= yypos1023; G->thunkpos= yythunkpos1023;  if (!yy__(G))  goto l1022;
+  if (!yy_Stmt(G))  goto l1022;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_8_ModuleCore, G->begin, G->end, "yy_8_ModuleCore");
 
   }
-  l1062:;	  goto l1060;
-  l1061:;	  G->pos= yypos1061; G->thunkpos= yythunkpos1061;
+  l1023:;	  goto l1021;
+  l1022:;	  G->pos= yypos1022; G->thunkpos= yythunkpos1022;
   }
-  {  int yypos1066= G->pos, yythunkpos1066= G->thunkpos;  if (!yy_WS(G))  goto l1066;
-  if (!yymatchString(G, "else")) goto l1066;
+  {  int yypos1027= G->pos, yythunkpos1027= G->thunkpos;  if (!yy_WS(G))  goto l1027;
+  if (!yymatchString(G, "else")) goto l1027;
   yyDo(G, yy_9_ModuleCore, G->begin, G->end, "yy_9_ModuleCore");
 
-  {  int yypos1068= G->pos, yythunkpos1068= G->thunkpos;  if (!yy__(G))  goto l1069;
-  if (!yymatchChar(G, '{')) goto l1069;
+  {  int yypos1029= G->pos, yythunkpos1029= G->thunkpos;  if (!yy__(G))  goto l1030;
+  if (!yymatchChar(G, '{')) goto l1030;
   yyDo(G, yy_10_ModuleCore, G->begin, G->end, "yy_10_ModuleCore");
-  if (!yy_WS(G))  goto l1069;
+  if (!yy_WS(G))  goto l1030;
 
-  l1070:;	
-  {  int yypos1071= G->pos, yythunkpos1071= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1071;
-  goto l1070;
-  l1071:;	  G->pos= yypos1071; G->thunkpos= yythunkpos1071;
-  }  if (!yy_WS(G))  goto l1069;
-  if (!yy__(G))  goto l1069;
-  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1069; }
+  l1031:;	
+  {  int yypos1032= G->pos, yythunkpos1032= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1032;
+  goto l1031;
+  l1032:;	  G->pos= yypos1032; G->thunkpos= yythunkpos1032;
+  }  if (!yy_WS(G))  goto l1030;
+  if (!yy__(G))  goto l1030;
+  if (!yy_CLOS_BRACK(G)) {  { YY_XTYPE YY_XVAR = (YY_XTYPE) G->data; int yyindex = G->offset + G->pos;  rewindWhiteSpace; throwError(NQE_EXP_INC_IMP_STMT_OR_DECL, "Expected include, import, statement or declaration\n") ; } goto l1030; }
   yyDo(G, yy_11_ModuleCore, G->begin, G->end, "yy_11_ModuleCore");
-  goto l1068;
-  l1069:;	  G->pos= yypos1068; G->thunkpos= yythunkpos1068;  if (!yy__(G))  goto l1066;
-  if (!yy_Stmt(G))  goto l1066;
+  goto l1029;
+  l1030:;	  G->pos= yypos1029; G->thunkpos= yythunkpos1029;  if (!yy__(G))  goto l1027;
+  if (!yy_Stmt(G))  goto l1027;
   yyDo(G, yySet, -3, 0, "yySet");
   yyDo(G, yy_12_ModuleCore, G->begin, G->end, "yy_12_ModuleCore");
 
   }
-  l1068:;	  goto l1067;
-  l1066:;	  G->pos= yypos1066; G->thunkpos= yythunkpos1066;
+  l1029:;	  goto l1028;
+  l1027:;	  G->pos= yypos1027; G->thunkpos= yythunkpos1027;
   }
-  l1067:;	  goto l1054;
-  l1055:;	  G->pos= yypos1054; G->thunkpos= yythunkpos1054;
-  {  int yypos1072= G->pos, yythunkpos1072= G->thunkpos;  if (!yy_WS(G))  goto l1073;
-  if (!yy_Include(G))  goto l1073;
-  if (!yy_WS(G))  goto l1073;
-  goto l1072;
-  l1073:;	  G->pos= yypos1072; G->thunkpos= yythunkpos1072;  if (!yy_WS(G))  goto l1074;
-  if (!yy_Import(G))  goto l1074;
-  if (!yy_WS(G))  goto l1074;
-  goto l1072;
-  l1074:;	  G->pos= yypos1072; G->thunkpos= yythunkpos1072;  if (!yy_WS(G))  goto l1075;
-  if (!yy_Use(G))  goto l1075;
-  if (!yy_WS(G))  goto l1075;
-  goto l1072;
-  l1075:;	  G->pos= yypos1072; G->thunkpos= yythunkpos1072;  if (!yy_WS(G))  goto l1076;
-  if (!yy_Decl(G))  goto l1076;
-  if (!yy_WS(G))  goto l1076;
-  goto l1072;
-  l1076:;	  G->pos= yypos1072; G->thunkpos= yythunkpos1072;  if (!yy_WS(G))  goto l1077;
-  if (!yy_Stmt(G))  goto l1077;
+  l1028:;	  goto l1015;
+  l1016:;	  G->pos= yypos1015; G->thunkpos= yythunkpos1015;
+  {  int yypos1033= G->pos, yythunkpos1033= G->thunkpos;  if (!yy_WS(G))  goto l1034;
+  if (!yy_Include(G))  goto l1034;
+  if (!yy_WS(G))  goto l1034;
+  goto l1033;
+  l1034:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1035;
+  if (!yy_Import(G))  goto l1035;
+  if (!yy_WS(G))  goto l1035;
+  goto l1033;
+  l1035:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1036;
+  if (!yy_Use(G))  goto l1036;
+  if (!yy_WS(G))  goto l1036;
+  goto l1033;
+  l1036:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1037;
+  if (!yy_Decl(G))  goto l1037;
+  if (!yy_WS(G))  goto l1037;
+  goto l1033;
+  l1037:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1038;
+  if (!yy_Stmt(G))  goto l1038;
   yyDo(G, yySet, -1, 0, "yySet");
-  if (!yy_WS(G))  goto l1077;
+  if (!yy_WS(G))  goto l1038;
   yyDo(G, yy_13_ModuleCore, G->begin, G->end, "yy_13_ModuleCore");
-  goto l1072;
-  l1077:;	  G->pos= yypos1072; G->thunkpos= yythunkpos1072;  if (!yy_WS(G))  goto l1053;
+  goto l1033;
+  l1038:;	  G->pos= yypos1033; G->thunkpos= yythunkpos1033;  if (!yy_WS(G))  goto l1014;
   yyDo(G, yy_14_ModuleCore, G->begin, G->end, "yy_14_ModuleCore");
-  if (!yy_OocDocCore(G))  goto l1053;
+  if (!yy_OocDocCore(G))  goto l1014;
   yyDo(G, yy_15_ModuleCore, G->begin, G->end, "yy_15_ModuleCore");
 
   }
-  l1072:;	
+  l1033:;	
   }
-  l1054:;	  yyprintf((stderr, "  ok   ModuleCore"));
+  l1015:;	  yyprintf((stderr, "  ok   ModuleCore"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
   yyDo(G, yyPop, 4, 0, "yyPop");
   return 1;
-  l1053:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ModuleCore"));
+  l1014:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "ModuleCore"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 
@@ -13814,27 +13491,27 @@ YY_RULE(int) yy_ModuleCore(GREG *G)
 YY_RULE(int) yy_Module(GREG *G)
 {  int yypos0= G->pos, yythunkpos0= G->thunkpos;  yyprintfv((stderr, "%s\n", "Module"));
 
-  {  int yypos1079= G->pos, yythunkpos1079= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1080;
-  goto l1079;
-  l1080:;	  G->pos= yypos1079; G->thunkpos= yythunkpos1079;  if (!yy_WS(G))  goto l1078;
+  {  int yypos1040= G->pos, yythunkpos1040= G->thunkpos;  if (!yy_ModuleCore(G))  goto l1041;
+  goto l1040;
+  l1041:;	  G->pos= yypos1040; G->thunkpos= yythunkpos1040;  if (!yy_WS(G))  goto l1039;
 
-  l1081:;	
-  {  int yypos1082= G->pos, yythunkpos1082= G->thunkpos;
-  {  int yypos1083= G->pos, yythunkpos1083= G->thunkpos;  if (!yy_EOL(G))  goto l1083;
-  goto l1082;
-  l1083:;	  G->pos= yypos1083; G->thunkpos= yythunkpos1083;
-  }  if (!yymatchDot(G)) goto l1082;  goto l1081;
-  l1082:;	  G->pos= yypos1082; G->thunkpos= yythunkpos1082;
-  }  if (!yy_EOL(G))  goto l1078;
+  l1042:;	
+  {  int yypos1043= G->pos, yythunkpos1043= G->thunkpos;
+  {  int yypos1044= G->pos, yythunkpos1044= G->thunkpos;  if (!yy_EOL(G))  goto l1044;
+  goto l1043;
+  l1044:;	  G->pos= yypos1044; G->thunkpos= yythunkpos1044;
+  }  if (!yymatchDot(G)) goto l1043;  goto l1042;
+  l1043:;	  G->pos= yypos1043; G->thunkpos= yythunkpos1043;
+  }  if (!yy_EOL(G))  goto l1039;
   yyDo(G, yy_1_Module, G->begin, G->end, "yy_1_Module");
 
   }
-  l1079:;	  yyprintf((stderr, "  ok   Module"));
+  l1040:;	  yyprintf((stderr, "  ok   Module"));
   yyprintfGcontext;
   yyprintf((stderr, "\n"));
 
   return 1;
-  l1078:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Module"));
+  l1039:;	  G->pos= yypos0; G->thunkpos= yythunkpos0;  yyprintfv((stderr, "  fail %s", "Module"));
   yyprintfvGcontext;
   yyprintfv((stderr, "\n"));
 

--- a/source/rock/middle/ClassDecl.ooc
+++ b/source/rock/middle/ClassDecl.ooc
@@ -97,9 +97,11 @@ ClassDecl: class extends TypeDecl {
                     }
 
                     // So, we need to call the user defined destroy function, memfree all generic members that belong to us (not our superclasses) then add a super() call
-                    hasDestroy? := functions contains?(This DESTROY_FUNC_NAME)
-                    if (hasDestroy?) {
-                        fDecl body add(FunctionCall new(This DESTROY_FUNC_NAME, token))
+                    if (lookupFunction(This DESTROY_FUNC_NAME, "")) {
+                        fCall := FunctionCall new(This DESTROY_FUNC_NAME, token)
+                        fCall virtual = false
+
+                        fDecl body add(fCall)
                     }
 
                     mustReturn? := false

--- a/source/rock/middle/VariableDecl.ooc
+++ b/source/rock/middle/VariableDecl.ooc
@@ -25,7 +25,6 @@ VariableDecl: class extends Declaration {
     isProto := false
     externName: String = null
     unmangledName: String = null
-    isForcedMalloc := false
 
     /** if this VariableDecl is a Func, it can be called! */
     fDecl : FunctionDecl = null
@@ -60,7 +59,6 @@ VariableDecl: class extends Declaration {
         copy externName    = externName
         copy unmangledName = unmangledName
         copy fDecl         = fDecl
-        copy isForcedMalloc = isForcedMalloc
         copy
     }
 
@@ -105,9 +103,6 @@ VariableDecl: class extends Declaration {
 
     isGlobal: func -> Bool { isGlobal }
     setGlobal: func (=isGlobal) {}
-
-    isForcedMalloc: func -> Bool { isForcedMalloc}
-    setForcedMalloc: func (=isForcedMalloc) {}
 
     isArg: func -> Bool { isArg }
 
@@ -390,14 +385,8 @@ VariableDecl: class extends Declaration {
         typeAcc := VariableAccess new(type, token)
         sizeAcc := VariableAccess new(typeAcc, "size", token)
 
-        fCall: FunctionCall
-            if(isForcedMalloc) {
-              fCall = FunctionCall new("calloc", token)
-              fCall args add(IntLiteral new(1, (0, 0, null, 0) as Token))
-            }
-            else {
-              fCall = FunctionCall new("alloca", token)
-            }
+        fCall := FunctionCall new("calloc", token)
+        fCall args add(IntLiteral new(1, (0, 0, null, 0) as Token))
         fCall args add(sizeAcc)
 
         expr = fCall


### PR DESCRIPTION
This remains backwards compatible as `free` is not generated if it already exists.
To start using this feature, simply declare `__destroy__` instead of `free` methods.  
The only required change in the SDK (ooc-kean) is removing the (virtual) `__destroy__` call from `Object free` as well as any `__onheap__` keyword usage.  

Here is a trivial example:  

```ooc
MyCell: class <T> {
    val: T

    init: func (=val)

    __destroy__: func {
        "Destroy" println()
    }


}

MySubCell: class <T> extends MyCell <T> {
    init: super func

    __destroy__: func {
        "Subdestroy" println()
    }


}

cell := MySubCell new(42)
cell val toString() println()
cell free()
```

Output:
```
42
Subdestroy
Destroy

(Additional 'Subdestroy' if __destroy__() is present in Object free)
```