### PR TITLE
Fixed source path issue when compiling obfucated code

### DIFF
--- a/source/rock/frontend/obfuscator/Obfuscator.ooc
+++ b/source/rock/frontend/obfuscator/Obfuscator.ooc
@@ -26,9 +26,7 @@ Obfuscator: class {
         for (node in This declarationNodes) {
             match (node getAstNode()) {
                 case module: Module =>
-                    newName := node getAuxiliaryData() as String
-                    module simpleName = newName
-                    module underName = "#{newName}_"
+                    module resetNames(node getAuxiliaryData() as String)
                     module isObfuscated = true
                 case classDeclaration: ClassDecl =>
                     This obfuscateTypeDeclaration(classDeclaration, node)

--- a/source/rock/middle/Module.ooc
+++ b/source/rock/middle/Module.ooc
@@ -74,6 +74,19 @@ Module: class extends Node {
         dead = false
     }
 
+    // NOTE: This does not recompute the paths!
+    resetNames: func (newName: String) {
+        //newFullName: String
+        idx := fullName lastIndexOf('/')
+        simpleName = newName clone()
+        if (idx > -1) {
+            fullName = fullName substring(0, idx + 1) append(newName)
+        } else {
+            fullName = newName clone()
+        }
+        underName = sanitize(fullName)
+    }
+
     clone: func -> This {
         raise(This, "Can't clone Module")
         null
@@ -99,11 +112,10 @@ Module: class extends Node {
     }
 
     getPath: func (suffix := "") -> String {
-        // TODO: This is highly ineffecient
-        if (isObfuscated)
-            path = path contains?(File separator) ? path substring(0, path lastIndexOf(File separator) + 1) + simpleName : simpleName
+        // TODO: This is hack to fix an issue with source paths when using the obfuscator
+        modPath := isObfuscated ? (path contains?(File separator) ? path substring(0, path lastIndexOf(File separator) + 1) + simpleName : simpleName) : path
         base := getSourceFolderName()
-        File new(base, path) path + suffix
+        File new(base, modPath) path + suffix
     }
 
     getLocalPath: func (suffix := "") -> String {


### PR DESCRIPTION
Fixed source path issue when compiling obfuscated code using certain drivers. The fix in this PR correctly recomputes the module name while retaining the internal path structure. @fredrikbryntesson ready for merge